### PR TITLE
Event 67 · Doc classification policy in AGENTS.md (Event 66 follow-up — inline-amend was blocked by PR #25 merge timing)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,42 @@ git push origin --delete event-NN-shortname
 
 ---
 
+## Doc classification policy (public vs. private)
+
+Before creating or moving any doc under `docs/`, classify it. The repo splits `docs/` across two visibility tiers; getting the classification right is load-bearing for both competitive position and ecosystem credibility.
+
+**PUBLIC tier (commit to repo):**
+
+- Architecture / spec / contract docs — `DESIGN_V*`, `ARCHITECTURE.md`, `LAYER_MODEL.md`, `EVOLUTION_CONTRACT.md`, `MEMORY_CONTRACT.md`, `SUBSTRATE_BRIDGE.md`. These are the credibility surface; AGPL-3.0 § 13 protects against closed-source extraction.
+- Kernel docs (`kernel/*`) — canonical philosophy, reasoning protocol, failure-mode taxonomy, references.
+- User references — `HOOKS.md`, `COMMANDS.md`, `SETUP.md`, `CUSTOMIZATION.md`, `DEMOS.md`, `HARNESSES.md`, `SYNC_AND_MEMORY.md`, `SKILLS_AND_PERSONAS.md`, `ANTHROPIC_MANAGED_AGENTS_BRIDGE.md`.
+- GTM surface — `README.md` (and translations), `INSTALL.md`, `llms.txt`, `.claude-plugin/README.md`, `OPEN_SOURCE_YOUR_PROFILE.md`.
+
+**PRIVATE tier (symlink to `~/episteme-private/docs/<name>`, gitignore the symlink):**
+
+- Operational state — *"where I am, what I'm doing, what I'm fighting"*: `PLAN.md`, `PROGRESS.md`, `NEXT_STEPS.md`, `*_TRIAGE.md`, `*_CALIBRATION.md`, `PREPARED_PATCHES.md`.
+- Positioning narrative — *"how I market"*: `POSTURE.md`, `NARRATIVE.md`, `COGNITIVE_SYSTEM_PLAYBOOK.md`.
+- Historical decision logs (`DECISION_STORY.md`-class once filled with content).
+- Anything that documents the operator's *how I work* or *how I market*.
+
+**Default when uncertain: privatize.** Reverting privatization is cheap (republish from private staging); reverting a leak requires `git filter-repo` + force-push + public explanation, with strictly worse optics.
+
+**Classification test.** Could a competitor read this doc and (a) replicate my workflow, (b) anticipate my next move, (c) copy my positioning playbook, (d) find an unfixed weakness to exploit? Any "yes" → PRIVATE.
+
+**Privatize mechanism (4 steps):**
+
+1. `cp docs/<name>.md ~/episteme-private/docs/<name>.md`
+2. `diff -q docs/<name>.md ~/episteme-private/docs/<name>.md` (verify byte-identical)
+3. `git rm docs/<name>.md`
+4. `ln -s ../../episteme-private/docs/<name>.md docs/<name>.md`
+5. Append `docs/<name>.md` to `.gitignore` under a dated Event section.
+
+**Cross-ref repair discipline (when privatizing).** Run `git grep -nE '<filename>'` across all tracked files. Repair links in PUBLIC-tier docs (visitor-facing 404s); leave operational/descriptive references that function correctly in user projects (harnesses, skills, agent definitions); never edit `kernel/CHANGELOG.md` historical entries (revisionism).
+
+**For new docs (creation, not move).** Same classification gate before the first write. If the doc would describe operational state, positioning, or strategic decision rationale, create it directly in `~/episteme-private/docs/` and symlink in; do not commit a public version first.
+
+---
+
 ## Scaling by delegation
 
 Subagents live in `core/agents/` and install into `~/.claude/agents/`.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Short version:
 
 1. Read `AGENTS.md` (the operational contract) and `kernel/SUMMARY.md` (30-line kernel distillation).
 2. Work in a branch — `feat/<name>`, `fix/<name>`, `docs/<name>`.
-3. For substantive changes, include narrative context (what changed, why, expected impact) in the PR description. The maintainer integrates this into the project's private operational state — external contributors do not need to update operational docs themselves.
+3. For substantive changes, include narrative context (what changed, why, expected impact) in the PR description. The maintainer integrates this into the project's private operational state — external contributors do not need to update operational docs themselves. The same applies to proposing new `docs/*.md` files: include the proposed content (or a draft) in the PR description; the maintainer classifies it (public vs. private staging per `AGENTS.md` § Doc classification policy) and integrates on merge.
 4. `PYTHONPATH=. pytest -q` must pass before you ask for review.
 5. Kernel changes follow `docs/EVOLUTION_CONTRACT.md` — major shifts go through propose → critique → gate → promote.
 


### PR DESCRIPTION
## Summary

Codifies the public-vs-private classification rule that Event 66 EXECUTED but did not document — closes the gap surfaced by the operator immediately after the privatize commit landed.

**Why a separate PR (operator originally requested inline-amend):** PR #25 was merged while this commit was being prepared, so amending Event 66's commit was no longer possible. This PR is the smallest viable substitute — additive, soak-safe, and self-contained.

## What this adds

`AGENTS.md` — new top-level section between **Commit and handoff conventions** and **Scaling by delegation**:

- **PUBLIC tier criteria** — architecture/spec/contract docs, kernel docs, user references, GTM surface
- **PRIVATE tier criteria** — operational state ("where I am, what I'm doing, what I'm fighting"), positioning narrative ("how I market"), historical decision logs
- **Default-when-uncertain rule:** PRIVATIZE (cheap to revert; leak requires `git filter-repo` + force-push + announce, with strictly worse optics)
- **Classification test:** "Could a competitor read this and (a) replicate workflow, (b) anticipate next move, (c) copy positioning playbook, (d) find unfixed weakness? Any 'yes' → PRIVATE"
- **5-step privatize mechanism** (cp + diff verify + git rm + symlink + .gitignore append)
- **Cross-ref repair discipline** (`git grep`, repair public-tier 404s, leave descriptive references, never edit `kernel/CHANGELOG.md` historical entries)
- **For new docs:** classify before first write; create directly in private staging if operational/positioning content

`docs/CONTRIBUTING.md` step 3 — parallel addition: external contributors don't classify either; include proposed doc content in PR description; maintainer classifies on integration.

## Why this matters

Without this protocol on disk, future agents (or me, in fresh sessions) repeat the question-substitution failure that surfaced during Event 66 — defaulting to "public" without checking whether new docs actually belong there. The kernel itself doesn't enforce classification today (no `PreToolUse` hook catches `Write docs/NEW.md` and prompts), so documenting the rule in AGENTS.md is the load-bearing intervention.

## Optional future work (not in this PR — post-soak)

A `PreToolUse Write|Edit` hook in `core/hooks/` that detects new `docs/*.md` paths and prompts the agent to declare classification in the Reasoning Surface before write. Closes the loop machine-checkably. Touches `core/hooks/` (soak-protected); deferred to v1.0.1+.

## Soak invariants

ZERO `kernel/*` / `core/hooks/*` / `core/blueprints/*` / `src/episteme/*` / `tests/*` / `templates/*` / `labs/*` touches. Only `AGENTS.md` + `docs/CONTRIBUTING.md` modified.

## Test plan

- [x] `git diff master..HEAD --name-only` shows exactly 2 files: `AGENTS.md`, `docs/CONTRIBUTING.md`
- [x] AGENTS.md renders the new section between "Commit and handoff conventions" and "Scaling by delegation"
- [x] CONTRIBUTING.md step 3 includes the new docs-classification follow-on
- [x] No regression: hook code paths (`session_context.py`, `workflow_guard.py`) untouched; cli.py untouched; pytest still passes