### PR TITLE
Event 75 · CP-RELEASE-PLEASE-CHKPT-FILTER-01 · ignore chkpt: in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,7 +27,22 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "docs", "section": "Documentation", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "chkpt", "section": "Checkpoints", "hidden": true }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

First v1.0.1 polish mini-batch CP shipped — fixes the recurring `release-please` workflow failure on `chkpt:` commits.

**Trigger.** Two `release-please` workflow runs failed 2026-04-27 (request `7411:35550C:15F898F:55C5B22:69EF9AA0` + retry `E451:4925:9B0436:26E3C3A:69EF9DA8`) with the same GraphQL 500-class error wrapping a parser issue on commit `0f66bd0` (title `chkpt: 2026-04-27T02:10:02`, auto-generated by `core/hooks/checkpoint.py`). The `chkpt:` prefix is not a Conventional Commits type, so release-please's parser choked when walking merge-commit history.

## What this changes

`release-please-config.json`: adds `changelog-sections` array to the package config, declaring all standard Conventional Commits types explicitly + adding `chkpt` as a hidden type so the parser recognizes and skips it cleanly without emitting a changelog entry.

| Type | Visibility | Default? |
|---|---|---|
| feat | visible (Features) | yes |
| fix | visible (Bug Fixes) | yes |
| perf | visible (Performance Improvements) | yes |
| deps | visible (Dependencies) | yes |
| revert | visible (Reverts) | yes |
| docs / style / chore / refactor / test / build / ci | hidden | yes |
| **chkpt** | **hidden (NEW)** | **no — added in this PR** |

Behavior matches release-please default for the standard 12 types; `chkpt` is the only addition.

## What this is not

This is **Path 1 (config-only)** from the CP description. It does NOT fix the `chkpt:` hook footgun at the source. The recurring chkpt-hook race-with-operator-commit footgun (Events 57, 61, 70) remains; this just stops downstream CI breakage.

If after merge release-please STILL fails on the next master push, escalate to **Path 2**: modify `core/hooks/checkpoint.py` to emit a Conventional Commits-compatible prefix (e.g., `chore(chkpt):`). That's larger scope (touches `core/hooks/`) and would land as a separate v1.0.1 polish CP.

## Verification

- [x] `python3 -m json.tool release-please-config.json` passes (JSON valid)
- [x] `changelog-sections` schema matches release-please-action@v4 documented format (`type` + `section` + optional `hidden`)
- [x] Operator merges this PR → next master push triggers release-please → workflow run succeeds (the disconfirmation gate per `kernel/FALSIFIABILITY_CONDITIONS.md` action-on-disconfirmation policy). If it fails, fall back to Path 2.

## Soak-invariant

Zero `kernel/*` / `core/hooks/*` / `core/blueprints/*` / `src/episteme/*` / `tests/*` / `templates/*` / `labs/*` touches. Single-file CI config edit. (Soak window already closed via Event 72; called out for completeness.)

## v1.0.1 polish queue status

CP-RELEASE-PLEASE-CHKPT-FILTER-01 (this PR — Event 75) is **CP #1 of 4** in `~/episteme-private/docs/cp-v1.0.1-polish.md`. Remaining:

- CP-AUDIT-ACK-01 (~1-2 days, `episteme profile audit ack` CLI)
- CP-SYMLINK-RESTORE-01 (~30 min script + 1h hook; the canonical-symlink restore that bit us mid-Event-74)
- CP-EXAMPLES-SCHEMA-PARITY-01 (~1-2 days, fork-onboarding example template upgrade)

## Cross-references

- Spec source: `~/episteme-private/docs/cp-v1.0.1-polish.md` § CP-RELEASE-PLEASE-CHKPT-FILTER-01
- Audit trail: `~/episteme-private/docs/PROGRESS.md` Event 75 entry (private)
- Original failure context: chkpt-hook footgun history in Events 57, 61, 70 (PROGRESS narrative entries)
- Decision rationale: Path 1 chosen over Path 2 per operator's "quickest closing-of-loops" authorization 2026-04-29