### PR TITLE
Event 76 · CP-SYMLINK-RESTORE-01 Part A · scripts/restore-private-symlinks.sh

### DIFF
--- a/scripts/restore-private-symlinks.sh
+++ b/scripts/restore-private-symlinks.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# scripts/restore-private-symlinks.sh
+#
+# Restore the gitignored canonical-path symlinks that point to
+# ~/episteme-private/. After a branch switch or fresh clone, these
+# symlinks get wiped because they live at gitignored paths and aren't
+# part of git history. Run this script to recreate them from the
+# privatize-list embedded below.
+#
+# Idempotent: skips symlinks that already point at the correct target.
+# Reports: restored / already-correct / missing-private counts.
+# Exit codes:
+#   0 - all 18 symlinks restored or already correct
+#   1 - $HOME/episteme-private/ does not exist (cannot restore anything)
+#   2 - some private targets are missing (partial success)
+#
+# CP-SYMLINK-RESTORE-01 Part A (Event 76, v1.0.1 polish).
+# Part B — SessionStart hook integration in core/hooks/session_context.py
+# that auto-detects + auto-runs this script — is deferred to a later Event.
+#
+# Sources of truth for the path list:
+#   .gitignore § "Privatized strategic forward-vision docs (Event 65)"
+#   .gitignore § "Privatized Tier 1 + Tier 2 docs (Event 66)"
+#   .gitignore § "Privatized operator-profile canonicals (Event 71)"
+# If any future Event privatizes more files, append them below in the
+# matching section.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PRIVATE_ROOT="$HOME/episteme-private"
+cd "$REPO_ROOT"
+
+if [[ ! -d "$PRIVATE_ROOT" ]]; then
+  echo "Error: $PRIVATE_ROOT does not exist." >&2
+  echo "       Symlinks cannot be restored without the private staging directory." >&2
+  echo "       This script is intended for the maintainer's machine; fork users" >&2
+  echo "       seed clean templates from core/memory/global/examples/ via 'episteme init'." >&2
+  exit 1
+fi
+
+# Canonical paths from .gitignore privatize sections. Mirror the privatize
+# list — keep in sync if a future Event privatizes more files.
+PATHS=(
+  # Event 65 — forward-vision strategic docs (4)
+  docs/DESIGN_V1_1_REASONING_ENGINE.md
+  docs/ROADMAP_POST_V1.md
+  docs/POST_SOAK_MIGRATION_PLAN.md
+  docs/POST_SOAK_TRIAGE.md
+  # Event 66 — Tier 1 + Tier 2 docs (10)
+  docs/NEXT_STEPS.md
+  docs/PLAN.md
+  docs/PROGRESS.md
+  docs/DEFERRED_DISCOVERIES_TRIAGE.md
+  docs/DISCRIMINATOR_CALIBRATION.md
+  docs/PREPARED_PATCHES.md
+  docs/POSTURE.md
+  docs/NARRATIVE.md
+  docs/COGNITIVE_SYSTEM_PLAYBOOK.md
+  docs/DECISION_STORY.md
+  # Event 71 — operator-profile canonicals (4)
+  core/memory/global/operator_profile.md
+  core/memory/global/cognitive_profile.md
+  core/memory/global/workflow_policy.md
+  core/memory/global/agent_feedback.md
+)
+
+restored=0
+already=0
+missing=0
+
+for canonical in "${PATHS[@]}"; do
+  private_path="$PRIVATE_ROOT/$canonical"
+
+  # Verify private target exists; skip cleanly if missing
+  if [[ ! -f "$private_path" ]]; then
+    echo "[MISS] private target absent: $private_path" >&2
+    missing=$((missing + 1))
+    continue
+  fi
+
+  # Compute the relative-target prefix based on canonical's depth from
+  # $HOME. We need to step out of the canonical's parent directory all
+  # the way up to $HOME, then descend into ~/episteme-private/. Pattern:
+  #   docs/<file>               (depth 2 from $HOME) -> ../../episteme-private/docs/<file>
+  #   core/memory/global/<file> (depth 4 from $HOME) -> ../../../../episteme-private/core/memory/global/<file>
+  case "$canonical" in
+    docs/*)               prefix="../.." ;;
+    core/memory/global/*) prefix="../../../.." ;;
+    *)
+      echo "[SKIP] unknown canonical path prefix: $canonical (script needs an update)" >&2
+      continue
+      ;;
+  esac
+  relative_target="$prefix/episteme-private/$canonical"
+
+  # If symlink already points at the correct target, skip
+  if [[ -L "$canonical" ]]; then
+    current="$(readlink "$canonical")"
+    if [[ "$current" == "$relative_target" ]]; then
+      already=$((already + 1))
+      continue
+    fi
+  fi
+
+  # Defensive: ensure parent dir exists (should always be true post-clone)
+  mkdir -p "$(dirname "$canonical")"
+
+  # Create or refresh the symlink
+  ln -sf "$relative_target" "$canonical"
+  echo "[OK]   $canonical -> $relative_target"
+  restored=$((restored + 1))
+done
+
+total=${#PATHS[@]}
+echo ""
+echo "Summary: restored=$restored, already-correct=$already, missing-private=$missing (of $total)"
+
+if [[ $missing -gt 0 ]]; then
+  exit 2
+fi
+exit 0


### PR DESCRIPTION
## Summary

Second v1.0.1 polish mini-batch CP shipped. Adds `scripts/restore-private-symlinks.sh` — a small bash utility that recreates the 18 gitignored canonical-path symlinks pointing into `~/episteme-private/`.

**Trigger.** After Events 65/66/71 privatized 18 docs with relative symlinks at gitignored canonical paths, any branch switch or fresh clone wipes the local symlinks because they're not in git history. The friction surfaced **mid-Event-74** when `git filter-repo` recovery left the working tree without symlinks at canonical paths — operator had to manually `ln -sf` each one. This script closes that loop.

## What this ships

`scripts/restore-private-symlinks.sh` (NEW, executable, 122 lines).

Walks the embedded privatize list:

| Event | Section | Files |
|---|---|---:|
| 65 | Forward-vision strategic docs | 4 |
| 66 | Tier 1 (operational) + Tier 2 (positioning) docs | 10 |
| 71 | Operator-profile canonicals | 4 |
| | **Total** | **18** |

For each path, verifies the private target exists in `$HOME/episteme-private/`, computes the correct relative-path prefix (2 levels for `docs/`, 4 levels for `core/memory/global/`), and runs `ln -sf` to create or refresh the symlink.

**Properties:**
- **Idempotent** — skips symlinks that already point at the correct target.
- **Reports** — restored / already-correct / missing-private counts.
- **Exit codes** — `0` clean, `1` no private dir (fork users), `2` some private targets missing.
- **Dogfooded locally** — 18/18 resolve correctly; idempotency verified by re-run; content reads through symlinks confirmed.

## What's deferred

**Part B** of the CP — `SessionStart` hook integration in `core/hooks/session_context.py` that auto-detects missing symlinks (where private targets exist) and prompts to run this script. Estimated ~1 hour. Touches `core/hooks/*` (post-soak; allowed). Deferred to a later Event for tight scope per the operator's preference for cognitively-bounded sessions.

## Verification

- [x] Script executes cleanly: 18 restored on first run from no-symlinks state
- [x] Idempotent: re-run shows 18 already-correct, 0 restored
- [x] All 18 symlinks resolve to real files (verified via `ls -la` + `head` content read)
- [x] Path math correct for both depths (`docs/` = `../..`; `core/memory/global/` = `../../../..`)
- [x] Missing-private path handled cleanly (caught a relative-path bug in v1 of the script during dogfood — fixed before commit)

## Soak-invariant

ZERO touches to `kernel/*` / `core/hooks/*` / `core/blueprints/*` / `src/episteme/*` / `tests/*` / `templates/*` / `labs/*`. Single new file under `scripts/` (operator-tooling tier).

## v1.0.1 polish queue post-Event-76

- ✅ CP-RELEASE-PLEASE-CHKPT-FILTER-01 (Event 75)
- ✅ CP-SYMLINK-RESTORE-01 Part A (this PR)
- ⏳ CP-SYMLINK-RESTORE-01 Part B (SessionStart hook integration; deferred)
- ⏳ CP-AUDIT-ACK-01 (~1-2 days)
- ⏳ CP-EXAMPLES-SCHEMA-PARITY-01 (~1-2 days)

## Cross-references

- Spec source: `~/episteme-private/docs/cp-v1.0.1-polish.md` § CP-SYMLINK-RESTORE-01
- Friction surfaced: Event 74 (`~/episteme-private/docs/PROGRESS.md` Event 74 entry — filter-repo recovery left missing symlinks)
- Privatize list authoritative: `.gitignore` Event 65 / Event 66 / Event 71 sections
- Audit trail: `~/episteme-private/docs/PROGRESS.md` Event 76 entry (private)