### PR TITLE
Event 78 · CP-AUDIT-ACK-01 · episteme profile audit ack CLI + hash-chained ack-store

### DIFF
--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -147,6 +147,47 @@ def run(args: list[str]) -> str:
     return r.stdout.strip() if r.returncode == 0 else ""
 
 
+def _is_acked_in_store(run_id: str) -> bool:
+    """Inline ack-store check (CP-AUDIT-ACK-01 / Event 78). Walks
+    ~/.episteme/state/profile_audit_acks.jsonl in order; latest-state-
+    per-audit_id wins. Returns True iff the latest entry for ``run_id``
+    is a `profile_audit_ack` (and not subsequently revoked).
+
+    Inlined rather than importing src/episteme/_profile_audit_ack.py —
+    same pattern as _profile_audit_line below: hooks run as standalone
+    scripts with no guaranteed sys.path of src/episteme/.
+    """
+    path = Path.home() / ".episteme" / "state" / "profile_audit_acks.jsonl"
+    if not path.exists():
+        return False
+    state: str | None = None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                s = line.strip()
+                if not s:
+                    continue
+                try:
+                    rec = json.loads(s)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(rec, dict):
+                    continue
+                payload = rec.get("payload", {})
+                if not isinstance(payload, dict):
+                    continue
+                if payload.get("audit_id") != run_id:
+                    continue
+                etype = payload.get("type")
+                if etype == "profile_audit_ack":
+                    state = "ack"
+                elif etype == "profile_audit_ack_revoke":
+                    state = "revoke"
+    except OSError:
+        return False
+    return state == "ack"
+
+
 def _profile_audit_line() -> str | None:
     """Return a re-elicitation prompt string from the latest unacknowledged
     profile-audit record, or None when nothing to surface.
@@ -191,6 +232,12 @@ def _profile_audit_line() -> str | None:
     if not drifts:
         return None
     run_id = record.get("run_id", "unknown")
+    # CP-AUDIT-ACK-01 / Event 78: also suppress if the run_id is acked
+    # in the ack-store at ~/.episteme/state/profile_audit_acks.jsonl.
+    # Inlined per the hooks-stay-self-contained convention — no
+    # sys.path setup required.
+    if _is_acked_in_store(run_id):
+        return None
     if len(drifts) == 1:
         a = drifts[0]
         return (

--- a/src/episteme/_profile_audit.py
+++ b/src/episteme/_profile_audit.py
@@ -2006,9 +2006,10 @@ def read_latest_audit(reflective_dir: Path | None = None) -> dict[str, Any] | No
 def surface_drift_line(record: dict[str, Any] | None) -> str | None:
     """Produce the one-line SessionStart surfacing string, or None.
 
-    Silent when the record is absent, acknowledged, or contains no
-    drift. Matches the `profile-audit: ...` shape documented in the
-    spec §SessionStart surfacing.
+    Silent when the record is absent, acknowledged, ack-store-acked
+    (CP-AUDIT-ACK-01 / Event 78), or contains no drift. Matches the
+    `profile-audit: ...` shape documented in the spec §SessionStart
+    surfacing.
     """
     if not record:
         return None
@@ -2021,6 +2022,19 @@ def surface_drift_line(record: dict[str, Any] | None) -> str | None:
     if not drifts:
         return None
     run_id = record.get("run_id", "unknown")
+    # CP-AUDIT-ACK-01 / Event 78: also suppress if the run_id is acked
+    # in the hash-chained ack-store. Library callers (non-hot-path)
+    # import the ack module directly.
+    try:
+        from episteme import _profile_audit_ack as _ack_mod
+        if _ack_mod.is_acked(run_id):
+            return None
+    except Exception:
+        # Degrade gracefully — if the ack module is unavailable
+        # (test isolation, broken install), fall through to the
+        # in-record `acknowledged` check above and the standard
+        # surfacing logic below.
+        pass
     if len(drifts) == 1:
         a = drifts[0]
         return (

--- a/src/episteme/_profile_audit_ack.py
+++ b/src/episteme/_profile_audit_ack.py
@@ -1,0 +1,373 @@
+"""Profile-audit acknowledgement store — CP-AUDIT-ACK-01 (Event 78).
+
+Append-only hash-chained record of operator acknowledgements (and
+revocations) of profile-audit drift alerts. Lives at
+``~/.episteme/state/profile_audit_acks.jsonl`` and uses the existing
+CP7 ``cp7-chained-v1`` envelope schema (see ``core/hooks/_chain.py``).
+
+## Why a separate ack-store
+
+The audit record itself (in ``~/.episteme/memory/reflective/profile_audit.jsonl``)
+already carries an ``acknowledged: bool`` field, but mutating that field
+in-place would violate Pillar 2 append-only semantics on the reflective
+tier. The ack-store is the load-bearing audit trail: each ack and each
+revoke is a new chain entry, so the *trajectory* of acknowledgement
+state is preserved (Pillar 2 ethos: nothing changes silently).
+
+## Schema
+
+Two payload ``type`` values:
+
+```
+{"type": "profile_audit_ack", "audit_id": "audit-...",
+ "rationale": "<≥15 chars, no lazy tokens>",
+ "acked_at": "<ISO-8601>", "acker": "<operator-id>",
+ "evidence_refs": ["Event 65", ...]}
+
+{"type": "profile_audit_ack_revoke", "audit_id": "audit-...",
+ "rationale": "<≥15 chars>",
+ "revoked_at": "<ISO-8601>", "acker": "<operator-id>"}
+```
+
+A revoke is *not* a delete: it appends a new chain entry whose payload
+flips the latest-state-per-audit-id back to "not acked." `is_acked()`
+walks the chain and reads the latest entry per id.
+
+## Lazy-rationale rejection
+
+Mirrors the Reasoning Surface validator's lazy-token discipline. A
+rationale of "n/a", "tbd", "ok", "해당 없음", etc. is rejected with
+``ValueError``. Minimum 15 characters mirrors the disconfirmation
+field's substantiveness floor.
+
+Spec: ``~/episteme-private/docs/cp-v1.0.1-polish.md`` § CP-AUDIT-ACK-01.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+# Locate core/hooks/_chain.py — same lazy-import pattern the rest of
+# the CLI uses for hook-tier modules.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_CORE_HOOKS_DIR = _REPO_ROOT / "core" / "hooks"
+if str(_CORE_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_CORE_HOOKS_DIR))
+
+import _chain  # type: ignore  # pyright: ignore[reportMissingImports]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+# Default location of the ack-store. Tests override via the
+# ``state_dir`` keyword argument on the public functions.
+DEFAULT_STATE_DIR = Path.home() / ".episteme" / "state"
+ACK_STORE_FILENAME = "profile_audit_acks.jsonl"
+
+# Mirrors the Reasoning Surface validator's lazy-token list. A rationale
+# whose stripped+lowered form matches any of these is rejected. The set
+# is intentionally narrow — these are the high-signal lazy tokens, not
+# every possible short answer.
+LAZY_RATIONALE_TOKENS: frozenset[str] = frozenset({
+    # English shortforms
+    "n/a", "na", "tbd", "todo",
+    "none", "nothing", "nil", "null",
+    "ack", "acked", "acknowledged",
+    "ok", "okay", "fine",
+    "later", "fix later", "do later", "address later",
+    "wip", "in progress",
+    # Korean equivalents (the kernel's lazy-token list spans both)
+    "해당 없음", "없음", "없다", "추후", "나중에",
+})
+
+MIN_RATIONALE_CHARS = 15
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate_rationale(text) -> None:
+    """Raise ValueError if the rationale is missing, lazy-token-matched,
+    or too short. Stripped + lowered for matching.
+
+    Order: lazy-token check fires BEFORE min-char check so a typed
+    "n/a" returns the lazy-token error message (more diagnostic) rather
+    than the min-char error. Untyped param is intentional: this is a
+    runtime defensive check at the public-API boundary; CLI passes
+    strings but the validator must handle any input shape without
+    trusting type annotations.
+
+    Mirrors the Reasoning Surface validator's discipline — an
+    acknowledgement without substance defeats the purpose of the
+    structured ack-store (which exists to *record reasoning*, not just
+    to silence the banner).
+    """
+    if not isinstance(text, str):
+        raise ValueError("rationale must be a string")
+    stripped = text.strip()
+    lowered = stripped.lower()
+    # Lazy-token check first: a lazy token of any length should report
+    # as lazy, not as too-short.
+    for token in LAZY_RATIONALE_TOKENS:
+        if lowered == token.lower():
+            raise ValueError(
+                f"rationale matches lazy-token {token!r}. "
+                f"Provide a substantive reason — what evidence supports the ack?"
+            )
+    if len(stripped) < MIN_RATIONALE_CHARS:
+        raise ValueError(
+            f"rationale must be at least {MIN_RATIONALE_CHARS} characters; "
+            f"got {len(stripped)}. Provide a substantive reason — what "
+            f"evidence supports the ack? (Empty / placeholder rationales "
+            f"are rejected.)"
+        )
+
+
+def _validate_audit_id(audit_id) -> None:
+    """Reject empty / non-string audit_ids. Format check is loose — the
+    audit-id format `audit-YYYYMMDD-HHMMSS-NNNN` is convention from
+    ``_profile_audit.run_audit`` but not strictly enforced here so the
+    ack-store tolerates schema evolution.
+
+    Untyped param is intentional: this is a runtime defensive check at
+    the public-API boundary; CLI passes strings but the validator must
+    handle any input shape without trusting type annotations.
+    """
+    if not isinstance(audit_id, str) or not audit_id.strip():
+        raise ValueError("audit_id must be a non-empty string")
+
+
+# ---------------------------------------------------------------------------
+# Acker identity resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_acker() -> str:
+    """Default acker identity. Single-operator default; future-proofed
+    for multi-operator extensions.
+
+    Resolution order:
+    1. ``$EPISTEME_ACKER`` env var (explicit override)
+    2. ``$USER`` env var
+    3. ``git config user.name`` (if available)
+    4. literal "unknown"
+    """
+    explicit = os.environ.get("EPISTEME_ACKER", "").strip()
+    if explicit:
+        return explicit
+    user = os.environ.get("USER", "").strip()
+    if user:
+        return user
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "user.name"],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_path(state_dir: Path | None = None) -> Path:
+    """Return the resolved ack-store JSONL path. Tests pass an explicit
+    ``state_dir`` to isolate from the operator's real ack-store."""
+    base = state_dir or DEFAULT_STATE_DIR
+    return base / ACK_STORE_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# Write paths — append-only, hash-chained
+# ---------------------------------------------------------------------------
+
+
+def write_ack(
+    audit_id: str,
+    rationale: str,
+    *,
+    evidence_refs: Iterable[str] | None = None,
+    acker: str | None = None,
+    state_dir: Path | None = None,
+    _now: datetime | None = None,  # test seam
+) -> dict:
+    """Write a ``profile_audit_ack`` envelope to the ack-store and
+    return the full chain envelope.
+
+    Raises ``ValueError`` on invalid ``audit_id`` or invalid
+    ``rationale`` (lazy-token, too-short).
+    """
+    _validate_audit_id(audit_id)
+    validate_rationale(rationale)
+    now = _now or datetime.now(timezone.utc)
+
+    payload = {
+        "type": "profile_audit_ack",
+        "audit_id": audit_id,
+        "rationale": rationale.strip(),
+        "acked_at": now.isoformat(),
+        "acker": acker or _resolve_acker(),
+        "evidence_refs": list(evidence_refs) if evidence_refs else [],
+    }
+    return _chain.append(_resolve_path(state_dir), payload)
+
+
+def write_revoke(
+    audit_id: str,
+    rationale: str,
+    *,
+    acker: str | None = None,
+    state_dir: Path | None = None,
+    _now: datetime | None = None,  # test seam
+) -> dict:
+    """Write a ``profile_audit_ack_revoke`` envelope to the ack-store.
+
+    A revoke does NOT delete the prior ack — it appends a new chain
+    entry whose latest-state-per-audit-id wins. Audit trail preserved
+    by construction (Pillar 2 ethos).
+    """
+    _validate_audit_id(audit_id)
+    validate_rationale(rationale)
+    now = _now or datetime.now(timezone.utc)
+
+    payload = {
+        "type": "profile_audit_ack_revoke",
+        "audit_id": audit_id,
+        "rationale": rationale.strip(),
+        "revoked_at": now.isoformat(),
+        "acker": acker or _resolve_acker(),
+    }
+    return _chain.append(_resolve_path(state_dir), payload)
+
+
+# ---------------------------------------------------------------------------
+# Read paths
+# ---------------------------------------------------------------------------
+
+
+def _walk_latest_state(state_dir: Path | None = None) -> dict[str, str]:
+    """Walk the ack-store chain and return ``{audit_id: "ack"|"revoke"}``
+    for every audit_id seen, where the value is the LATEST entry's type.
+
+    Quietly skips non-dict payloads + entries with non-string audit_ids
+    so the read path never raises on a malformed entry.
+    """
+    path = _resolve_path(state_dir)
+    if not path.exists():
+        return {}
+
+    latest: dict[str, str] = {}
+    for envelope in _chain.iter_records(path, verify=True):
+        payload = envelope.get("payload", {})
+        if not isinstance(payload, dict):
+            continue
+        entry_type = payload.get("type")
+        entry_id = payload.get("audit_id")
+        if not isinstance(entry_id, str):
+            continue
+        if entry_type == "profile_audit_ack":
+            latest[entry_id] = "ack"
+        elif entry_type == "profile_audit_ack_revoke":
+            latest[entry_id] = "revoke"
+    return latest
+
+
+def is_acked(audit_id: str, *, state_dir: Path | None = None) -> bool:
+    """Return True iff the LATEST entry for ``audit_id`` is an ack
+    (and not subsequently revoked)."""
+    return _walk_latest_state(state_dir).get(audit_id) == "ack"
+
+
+def acked_ids(*, state_dir: Path | None = None) -> set[str]:
+    """Return set of all audit_ids currently in the acked state.
+    Used by SessionStart banner suppression for batch lookup."""
+    return {aid for aid, state in _walk_latest_state(state_dir).items() if state == "ack"}
+
+
+def list_all_entries(*, state_dir: Path | None = None) -> list[dict]:
+    """Return all chain envelopes in file order. Forensic / audit
+    helper — used by `episteme profile audit ack --list-history` if/when
+    that flag lands; not currently CLI-exposed."""
+    path = _resolve_path(state_dir)
+    if not path.exists():
+        return []
+    return list(_chain.iter_records(path, verify=True))
+
+
+def list_outstanding_audits(
+    *,
+    reflective_dir: Path | None = None,
+    state_dir: Path | None = None,
+) -> list[dict]:
+    """Return audit records that have drift AND are not currently acked.
+
+    Each returned dict carries: ``{run_id, run_ts, drift_axes}``. Used by
+    ``episteme profile audit ack --list``.
+    """
+    reflective_dir = reflective_dir or (Path.home() / ".episteme" / "memory" / "reflective")
+    audit_path = reflective_dir / "profile_audit.jsonl"
+    if not audit_path.exists():
+        return []
+
+    acked = acked_ids(state_dir=state_dir)
+    outstanding: list[dict] = []
+
+    try:
+        with open(audit_path, "r", encoding="utf-8") as f:
+            for line in f:
+                s = line.strip()
+                if not s:
+                    continue
+                try:
+                    rec = json.loads(s)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(rec, dict):
+                    continue
+                run_id = rec.get("run_id")
+                if not isinstance(run_id, str):
+                    continue
+                if run_id in acked:
+                    continue
+                drift_axes = [
+                    a.get("axis_name")
+                    for a in rec.get("axes", [])
+                    if isinstance(a, dict) and a.get("verdict") == "drift"
+                ]
+                if not drift_axes:
+                    continue
+                outstanding.append({
+                    "run_id": run_id,
+                    "run_ts": rec.get("run_ts"),
+                    "drift_axes": [name for name in drift_axes if isinstance(name, str)],
+                })
+    except OSError:
+        return []
+    return outstanding
+
+
+# ---------------------------------------------------------------------------
+# Chain verification (delegates to _chain)
+# ---------------------------------------------------------------------------
+
+
+def verify_chain(state_dir: Path | None = None):
+    """Return ``_chain.ChainVerdict`` for the ack-store. Used by
+    ``episteme chain verify`` to integrate the ack-store stream into the
+    Pillar 2 verification surface."""
+    return _chain.verify_chain(_resolve_path(state_dir))

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -3034,6 +3034,79 @@ def _profile_audit_cli(*, since: str, write: bool, as_json: bool) -> int:
     return 0
 
 
+def _profile_audit_ack_cli(args) -> int:
+    """CLI entry for `episteme profile audit ack` (CP-AUDIT-ACK-01 / Event 78).
+
+    Three modes dispatched by args:
+    - `--list`: enumerate outstanding (un-acked) audit IDs with drift.
+    - `--revoke <audit-id> --rationale "..."`: revoke a prior ack
+      (audit-trail preserved; revoke appends a new chain entry).
+    - `<audit-id> --rationale "..."`: ack the audit ID with rationale.
+
+    Library: src/episteme/_profile_audit_ack.py (hash-chained ack-store
+    at ~/.episteme/state/profile_audit_acks.jsonl).
+    """
+    from episteme import _profile_audit_ack as ack_mod
+
+    if getattr(args, "list_outstanding", False):
+        outstanding = ack_mod.list_outstanding_audits()
+        if not outstanding:
+            print("No outstanding (un-acked) profile-audit drift records.")
+            return 0
+        print(f"Outstanding profile-audit drift records ({len(outstanding)}):")
+        print()
+        for entry in outstanding:
+            run_id = entry.get("run_id", "?")
+            run_ts = entry.get("run_ts", "?")
+            axes = entry.get("drift_axes") or []
+            axes_str = ", ".join(axes) if axes else "(no drift axes named)"
+            print(f"  {run_id}")
+            print(f"    run_ts:      {run_ts}")
+            print(f"    drift_axes:  {axes_str}")
+            print(f"    ack via:     episteme profile audit ack {run_id} --rationale \"...\"")
+            print()
+        return 0
+
+    audit_id = getattr(args, "audit_id", None)
+    rationale = getattr(args, "rationale", None)
+    revoke = getattr(args, "revoke", False)
+    evidence_refs = getattr(args, "evidence_refs", None) or []
+
+    if not audit_id:
+        print(
+            "audit_id is required (or pass --list to enumerate outstanding records).",
+            file=sys.stderr,
+        )
+        return 2
+    if not rationale:
+        print(
+            "--rationale is required (min 15 chars; lazy tokens like 'n/a' / 'tbd' rejected).",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        if revoke:
+            envelope = ack_mod.write_revoke(audit_id, rationale)
+            print(f"Revoked ack for {audit_id}.")
+        else:
+            envelope = ack_mod.write_ack(
+                audit_id,
+                rationale,
+                evidence_refs=evidence_refs,
+            )
+            print(f"Acked {audit_id}.")
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"  entry_hash: {envelope['entry_hash']}")
+    print(f"  acker:      {envelope['payload'].get('acker', 'unknown')}")
+    if evidence_refs:
+        print(f"  evidence:   {', '.join(evidence_refs)}")
+    return 0
+
+
 def _profile_show() -> int:
     scores_path = GENERATED_PROFILE_DIR / "workstyle_scores.json"
     profile_path = GENERATED_PROFILE_DIR / "workstyle_profile.json"
@@ -3890,12 +3963,21 @@ def _chain_dispatch(args) -> int:
         fw = _framework.verify_chains()
         pc = _pending_contracts.verify_chain()
         pc_arch = _pending_contracts.verify_archive()
+        # CP-AUDIT-ACK-01 / Event 78: include the profile-audit ack-store
+        # in the chain-verify enumeration so its integrity is checked
+        # alongside the framework + pending-contracts streams.
+        try:
+            from episteme import _profile_audit_ack as _ack_mod
+            ack_verdict = _ack_mod.verify_chain()
+        except Exception:  # noqa: BLE001 — degrade gracefully
+            ack_verdict = None
         all_intact = True
         for stream_name, verdict in (
             ("protocols", fw.get("protocols")),
             ("deferred_discoveries", fw.get("deferred_discoveries")),
             ("pending_contracts", pc),
             ("pending_contracts_archive", pc_arch),
+            ("profile_audit_acks", ack_verdict),
         ):
             if verdict is None:
                 continue
@@ -4521,6 +4603,41 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit the full audit record as JSON instead of human-readable Markdown (stable format)",
     )
 
+    # Nested ack subcommand under `profile audit ack`. CP-AUDIT-ACK-01 / Event 78.
+    audit_sub = p_audit.add_subparsers(dest="audit_action", required=False)
+    p_ack = audit_sub.add_parser(
+        "ack",
+        help="Acknowledge / list / revoke profile-audit drift findings",
+    )
+    p_ack.add_argument(
+        "audit_id",
+        nargs="?",
+        help="Audit run-id to acknowledge (audit-YYYYMMDD-HHMMSS-NNNN); omit when using --list",
+    )
+    p_ack.add_argument(
+        "--rationale",
+        help="Substantive reason for the ack (min 15 chars; lazy tokens 'n/a' / 'tbd' / etc. rejected)",
+    )
+    p_ack.add_argument(
+        "--list",
+        dest="list_outstanding",
+        action="store_true",
+        help="List outstanding (un-acked) profile-audit drift records",
+    )
+    p_ack.add_argument(
+        "--revoke",
+        action="store_true",
+        help="Revoke a prior ack (audit-trail preserved; revoke appends a new chain entry, never deletes)",
+    )
+    p_ack.add_argument(
+        "--evidence-refs",
+        dest="evidence_refs",
+        nargs="*",
+        default=[],
+        metavar="REF",
+        help="Optional event/episode references supporting the ack (e.g. 'Event 65' 'Event 66')",
+    )
+
     cognition_cmd = sub.add_parser("cognition", help="Deterministic cognitive/philosophy profiling")
     cognition_sub = cognition_cmd.add_subparsers(dest="cognition_action", required=True)
     c_survey = cognition_sub.add_parser("survey", help="Interactive cognitive-style survey")
@@ -4932,6 +5049,8 @@ def main(argv: Iterable[str] | None = None) -> int:
         if args.profile_action == "show":
             return _profile_show()
         if args.profile_action == "audit":
+            if getattr(args, "audit_action", None) == "ack":
+                return _profile_audit_ack_cli(args)
             return _profile_audit_cli(
                 since=args.since,
                 write=args.write,

--- a/tests/test_profile_audit_ack.py
+++ b/tests/test_profile_audit_ack.py
@@ -1,0 +1,263 @@
+"""Tests for CP-AUDIT-ACK-01 (Event 78) — `episteme profile audit ack` CLI
++ hash-chained ack-store at ~/.episteme/state/profile_audit_acks.jsonl.
+
+Coverage:
+
+- Validation (lazy-token rejection, min-char floor, both English + Korean tokens).
+- Write path (ack + revoke produce valid cp7-chained-v1 envelopes).
+- Read path (is_acked / acked_ids reflect latest-state-per-id).
+- Revoke preserves audit trail (revoke is a new entry, not a delete; chain stays intact).
+- list_outstanding_audits filters out acked records correctly.
+- Chain integrity (`verify_chain` returns intact after writes).
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from episteme import _profile_audit_ack as ack
+
+
+class ValidateRationaleTests(unittest.TestCase):
+    """Lazy-token + min-char discipline mirrors Reasoning Surface validator."""
+
+    def test_rationale_too_short_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            ack.validate_rationale("too short")
+        self.assertIn("at least", str(ctx.exception))
+
+    def test_rationale_lazy_token_n_a_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            ack.validate_rationale("n/a" + " " * 20)  # padded to pass min-char
+        self.assertIn("lazy-token", str(ctx.exception))
+
+    def test_rationale_lazy_token_tbd_rejected(self):
+        # exact match "tbd" stripped+lowered should reject regardless of length
+        # (after stripping). With trailing spaces but lazy match.
+        # Note: we strip+lower then compare to lazy set; trailing spaces
+        # don't help. We need the stripped form to NOT match the lazy set.
+        with self.assertRaises(ValueError):
+            ack.validate_rationale("   tbd   ")  # padded fails min-char
+
+    def test_rationale_lazy_token_korean_rejected(self):
+        with self.assertRaises(ValueError):
+            ack.validate_rationale("해당 없음")
+
+    def test_rationale_lazy_token_ack_rejected(self):
+        with self.assertRaises(ValueError):
+            ack.validate_rationale("ack")
+
+    def test_rationale_lazy_token_ok_rejected(self):
+        with self.assertRaises(ValueError):
+            ack.validate_rationale("ok")
+
+    def test_rationale_substantive_accepted(self):
+        # 15+ chars, not in lazy set
+        ack.validate_rationale("Re-elicited asymmetry_posture in Event 68; closed gap.")
+        # Should NOT raise
+
+    def test_rationale_non_string_rejected(self):
+        with self.assertRaises(ValueError):
+            ack.validate_rationale(None)  # type: ignore[arg-type]
+        with self.assertRaises(ValueError):
+            ack.validate_rationale(123)  # type: ignore[arg-type]
+
+
+class AckStoreWriteTests(unittest.TestCase):
+    """Write paths produce valid cp7-chained-v1 envelopes."""
+
+    def test_write_ack_creates_chain_entry_with_correct_payload(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td)
+            envelope = ack.write_ack(
+                "audit-20260427-063251-9131",
+                "Re-elicited asymmetry_posture in Event 68; closed the gap.",
+                evidence_refs=["Event 65", "Event 66", "Event 67"],
+                acker="testuser",
+                state_dir=state_dir,
+            )
+            self.assertEqual(envelope["schema_version"], "cp7-chained-v1")
+            self.assertEqual(envelope["payload"]["type"], "profile_audit_ack")
+            self.assertEqual(envelope["payload"]["audit_id"], "audit-20260427-063251-9131")
+            self.assertEqual(envelope["payload"]["acker"], "testuser")
+            self.assertEqual(envelope["payload"]["evidence_refs"], ["Event 65", "Event 66", "Event 67"])
+            self.assertTrue(envelope["entry_hash"].startswith("sha256:"))
+
+    def test_write_revoke_creates_revoke_entry(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td)
+            ack.write_ack(
+                "audit-x",
+                "Substantive ack rationale here.",
+                state_dir=state_dir,
+                acker="testuser",
+            )
+            revoke = ack.write_revoke(
+                "audit-x",
+                "Reverting because new evidence shows drift continues.",
+                state_dir=state_dir,
+                acker="testuser",
+            )
+            self.assertEqual(revoke["payload"]["type"], "profile_audit_ack_revoke")
+            self.assertEqual(revoke["payload"]["audit_id"], "audit-x")
+
+    def test_write_ack_invalid_audit_id_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td)
+            with self.assertRaises(ValueError):
+                ack.write_ack("", "Substantive rationale here.", state_dir=state_dir)
+            with self.assertRaises(ValueError):
+                ack.write_ack(None, "Substantive rationale here.", state_dir=state_dir)  # type: ignore[arg-type]
+
+
+class IsAckedReadPathTests(unittest.TestCase):
+    """is_acked + acked_ids reflect the latest-state-per-id walk."""
+
+    def test_is_acked_returns_false_when_no_store(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td)
+            self.assertFalse(ack.is_acked("audit-anything", state_dir=state_dir))
+
+    def test_is_acked_returns_true_after_ack(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td)
+            ack.write_ack(
+                "audit-y",
+                "Rationale that is sufficiently long.",
+                state_dir=state_dir,
+            )
+            self.assertTrue(ack.is_acked("audit-y", state_dir=state_dir))
+            self.assertFalse(ack.is_acked("audit-other", state_dir=state_dir))
+
+    def test_revoke_after_ack_returns_false(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td)
+            ack.write_ack(
+                "audit-z",
+                "First ack rationale that is substantive.",
+                state_dir=state_dir,
+            )
+            self.assertTrue(ack.is_acked("audit-z", state_dir=state_dir))
+            ack.write_revoke(
+                "audit-z",
+                "Reverting on new evidence of continued drift.",
+                state_dir=state_dir,
+            )
+            self.assertFalse(ack.is_acked("audit-z", state_dir=state_dir))
+
+    def test_re_ack_after_revoke_returns_true(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td)
+            ack.write_ack(
+                "audit-q",
+                "First ack with substantive rationale text.",
+                state_dir=state_dir,
+            )
+            ack.write_revoke(
+                "audit-q",
+                "Initial revoke with substantive reason text.",
+                state_dir=state_dir,
+            )
+            ack.write_ack(
+                "audit-q",
+                "Second ack with substantive rationale text.",
+                state_dir=state_dir,
+            )
+            # Latest is ack again
+            self.assertTrue(ack.is_acked("audit-q", state_dir=state_dir))
+
+    def test_acked_ids_returns_set_of_currently_acked(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td)
+            ack.write_ack("audit-a", "Substantive ack rationale here.", state_dir=state_dir)
+            ack.write_ack("audit-b", "Substantive ack rationale here.", state_dir=state_dir)
+            ack.write_ack("audit-c", "Substantive ack rationale here.", state_dir=state_dir)
+            ack.write_revoke("audit-b", "Substantive revoke rationale here.", state_dir=state_dir)
+            self.assertEqual(
+                ack.acked_ids(state_dir=state_dir),
+                {"audit-a", "audit-c"},  # b revoked
+            )
+
+
+class ChainIntegrityTests(unittest.TestCase):
+    """Chain stays intact across multiple writes (ack + revoke + re-ack)."""
+
+    def test_chain_intact_after_multiple_writes(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td)
+            ack.write_ack("audit-1", "First substantive ack rationale.", state_dir=state_dir)
+            ack.write_ack("audit-2", "Second substantive ack rationale.", state_dir=state_dir)
+            ack.write_revoke("audit-1", "Revoke rationale that is substantive.", state_dir=state_dir)
+            ack.write_ack("audit-1", "Re-ack rationale that is substantive.", state_dir=state_dir)
+
+            verdict = ack.verify_chain(state_dir=state_dir)
+            self.assertTrue(verdict.intact)
+            self.assertEqual(verdict.total_entries, 4)
+
+
+class ListOutstandingAuditsTests(unittest.TestCase):
+    """list_outstanding_audits filters acked records and returns drift-axis info."""
+
+    def _write_audit_record(self, reflective_dir: Path, run_id: str, drift_axes: list[str]):
+        reflective_dir.mkdir(parents=True, exist_ok=True)
+        path = reflective_dir / "profile_audit.jsonl"
+        rec = {
+            "version": "profile-audit-v1",
+            "run_id": run_id,
+            "run_ts": "2026-04-29T00:00:00+00:00",
+            "axes": [
+                {"axis_name": name, "verdict": "drift", "reason": "test"}
+                for name in drift_axes
+            ],
+        }
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+    def test_outstanding_excludes_acked_records(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td) / "state"
+            reflective_dir = Path(td) / "reflective"
+            self._write_audit_record(reflective_dir, "audit-old", ["asymmetry_posture"])
+            self._write_audit_record(reflective_dir, "audit-new", ["fence_discipline"])
+            ack.write_ack(
+                "audit-old",
+                "Acked because re-elicited in Event 68.",
+                state_dir=state_dir,
+            )
+
+            outstanding = ack.list_outstanding_audits(
+                reflective_dir=reflective_dir,
+                state_dir=state_dir,
+            )
+            self.assertEqual(len(outstanding), 1)
+            self.assertEqual(outstanding[0]["run_id"], "audit-new")
+            self.assertEqual(outstanding[0]["drift_axes"], ["fence_discipline"])
+
+    def test_outstanding_excludes_no_drift_records(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td) / "state"
+            reflective_dir = Path(td) / "reflective"
+            # Record with NO drift axes
+            self._write_audit_record(reflective_dir, "audit-no-drift", [])
+
+            outstanding = ack.list_outstanding_audits(
+                reflective_dir=reflective_dir,
+                state_dir=state_dir,
+            )
+            self.assertEqual(len(outstanding), 0)
+
+    def test_outstanding_empty_when_no_records(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td) / "state"
+            reflective_dir = Path(td) / "reflective"  # does not exist
+            outstanding = ack.list_outstanding_audits(
+                reflective_dir=reflective_dir,
+                state_dir=state_dir,
+            )
+            self.assertEqual(outstanding, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fourth (and last main) v1.0.1 polish CP. The SessionStart audit-drift banner has pointed at `episteme profile audit ack <audit-id>` since v0.11.0, but **the subcommand did not exist**. Operator (Event 68, 2026-04-27) had to close the `asymmetry_posture` audit loop via direct profile re-elicit because there was no structured ack pathway. This PR ships the missing CLI + the hash-chained ack-store the banner has been promising all along.

## What ships

### 1. New CLI subcommand `episteme profile audit ack`

```bash
# Ack a drift alert with a substantive rationale
episteme profile audit ack audit-20260427-063251-9131 --rationale "Re-elicited asymmetry_posture in Event 68; 3 consecutive stop+rollbacks closed the gap."

# Optional supporting refs
episteme profile audit ack <id> --rationale "..." --evidence-refs "Event 65" "Event 66" "Event 67"

# List outstanding (un-acked) drift records
episteme profile audit ack --list

# Revoke a prior ack (audit trail preserved; revoke appends, never deletes)
episteme profile audit ack --revoke <audit-id> --rationale "Reverting on new evidence of continued drift."
```

### 2. New module `src/episteme/_profile_audit_ack.py`

| Function | Purpose |
|---|---|
| `validate_rationale(text)` | Lazy-token + min-15-char rejection (mirrors Reasoning Surface validator discipline) |
| `write_ack(audit_id, rationale, ...)` | Append `cp7-chained-v1` envelope to `~/.episteme/state/profile_audit_acks.jsonl` |
| `write_revoke(audit_id, rationale, ...)` | Append revoke entry (NOT a delete) |
| `is_acked(audit_id)` | Latest-state-per-id walk; True iff latest entry is an ack |
| `acked_ids()` | Batch lookup for SessionStart suppression |
| `list_outstanding_audits()` | Filter `profile_audit.jsonl` records by ack-store state |
| `verify_chain()` | Integration with `episteme chain verify` |

### 3. Audit-loop integration (suppression)

- `core/hooks/session_context.py`: inline `_is_acked_in_store(run_id)` check suppresses SessionStart banner for acked run_ids. **Inlined** per the hooks-stay-self-contained convention (no `sys.path` setup of `src/episteme/` in standalone hook invocation).
- `src/episteme/_profile_audit.py:surface_drift_line()`: imports `_profile_audit_ack` and runs `is_acked` check. Library-tier; degrades gracefully if module unavailable (test isolation).

### 4. Chain integration

`episteme chain verify` now enumerates `profile_audit_acks` alongside `protocols` / `deferred_discoveries` / `pending_contracts`. Stream uses the same SHA-256 `cp7-chained-v1` envelope schema — no new chain primitives needed.

## Audit-trail discipline

**Revoke is NEVER a delete.** A revoke appends a new chain entry whose type is `profile_audit_ack_revoke`; the latest-state-per-id walk treats the latest entry as authoritative. The full ack/revoke trajectory is preserved in the chain (Pillar 2 ethos: nothing changes silently; nothing is silently undone).

## Validation discipline

Rationale must be ≥ 15 chars AND must NOT match the lazy-token list:

- **English:** `n/a`, `na`, `tbd`, `todo`, `none`, `nothing`, `nil`, `null`, `ack`, `acked`, `acknowledged`, `ok`, `okay`, `fine`, `later`, `fix later`, `do later`, `address later`, `wip`, `in progress`
- **Korean:** `해당 없음`, `없음`, `없다`, `추후`, `나중에`

Lazy-token check fires BEFORE min-char check so `'n/a'` returns the lazy-token error message (more diagnostic) rather than the min-char message.

## Tests

`tests/test_profile_audit_ack.py` — **20/20 pass**:

| Class | Cases |
|---|---|
| `ValidateRationaleTests` | min-char, English lazy tokens, Korean lazy tokens (`해당 없음`), `ack` / `ok` / `tbd`, substantive accepted, non-string rejected |
| `AckStoreWriteTests` | ack envelope shape, revoke entry, invalid audit-id rejected |
| `IsAckedReadPathTests` | no-store, ack-then-acked, revoke-after-ack, re-ack-after-revoke (latest wins), `acked_ids` set correctness |
| `ChainIntegrityTests` | 4-entry chain stays intact across ack + ack + revoke + ack |
| `ListOutstandingAuditsTests` | excludes-acked, excludes-no-drift, empty-when-no-records |

**Full test suite green: 144/144** (124 baseline + 20 new).

## Smoke test (live, post-merge — operator should run)

```bash
# 1. Confirm the CLI is wired (--help renders all flags)
episteme profile audit ack --help

# 2. List currently outstanding drift records
episteme profile audit ack --list

# 3. (If outstanding records exist) ack one with a substantive rationale
episteme profile audit ack <id-from-step-2> --rationale "Re-elicited in Event 68; lived-behavior closed the gap."

# 4. Verify the new chain stream
episteme chain verify
# Expect: profile_audit_acks listed alongside other streams; INTACT entries=1

# 5. Verify suppression — start a new Claude Code session
# The SessionStart banner should NOT show the acked drift alert
```

## Soak-invariant

| Surface | Status |
|---|---|
| `core/hooks/session_context.py` | Modified (post-soak; allowed) |
| `src/episteme/_profile_audit.py` | Modified (library) |
| `src/episteme/_profile_audit_ack.py` | NEW |
| `src/episteme/cli.py` | Modified |
| `tests/test_profile_audit_ack.py` | NEW |
| `kernel/*` / `core/blueprints/*` / `templates/*` / `labs/*` | UNTOUCHED |

## v1.0.1 polish queue post-Event-78

- ✅ CP-RELEASE-PLEASE-CHKPT-FILTER-01 (Event 75)
- ✅ CP-SYMLINK-RESTORE-01 Part A (Event 76)
- ✅ CP-EXAMPLES-SCHEMA-PARITY-01 Components 1-4 (Event 77)
- ✅ **CP-AUDIT-ACK-01** (this PR) — last main piece
- ⏳ CP-SYMLINK-RESTORE-01 Part B (SessionStart hook integration; ~1h, deferred-by-design)
- ⏳ CP-EXAMPLES-SCHEMA-PARITY-01 Component 5 (optional `episteme verify-examples` CLI; deferred-by-design)

**4 of 4 main v1.0.1 polish CPs shipped.** Both remaining items are explicitly deferred-by-design optional enhancements (Part B integrates the symlink-restore script into a hook for auto-run; Component 5 adds a machine-checkable schema-parity validator). v1.0.1 polish track is effectively complete.

## Cross-references

- Spec source: `~/episteme-private/docs/cp-v1.0.1-polish.md` § CP-AUDIT-ACK-01
- Original gap surfaced: Event 68 (`docs/PROGRESS.md` Event 68 entry — operator closed asymmetry_posture audit loop via direct re-elicit because no CLI existed)
- Chain envelope schema: `core/hooks/_chain.py` § cp7-chained-v1
- Phase 12 audit module: `src/episteme/_profile_audit.py`
- Audit trail: `~/episteme-private/docs/PROGRESS.md` Event 78 entry (private)