### PR TITLE
Event 79 · v1.0.1 polish cleanup · audit_id auto-prefix + regex validation

### DIFF
--- a/src/episteme/_profile_audit_ack.py
+++ b/src/episteme/_profile_audit_ack.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -133,18 +134,46 @@ def validate_rationale(text) -> None:
         )
 
 
-def _validate_audit_id(audit_id) -> None:
-    """Reject empty / non-string audit_ids. Format check is loose — the
-    audit-id format `audit-YYYYMMDD-HHMMSS-NNNN` is convention from
-    ``_profile_audit.run_audit`` but not strictly enforced here so the
-    ack-store tolerates schema evolution.
+# Audit-id format from `_profile_audit.run_audit`:
+#   audit-YYYYMMDD-HHMMSS-NNNN
+# where NNNN is ``uuid.uuid4().hex[:4]`` — exactly 4 lowercase hex chars.
+_AUDIT_ID_PATTERN = re.compile(r"^audit-\d{8}-\d{6}-[0-9a-f]{4}$")
+
+
+def normalize_audit_id(audit_id) -> str:
+    """Validate + normalize an audit_id. Returns the well-formed id.
+
+    Lenient on missing prefix: if ``audit_id`` is the bare stem
+    ``YYYYMMDD-HHMMSS-NNNN``, ``audit-`` is auto-prepended. This was
+    added (Event 79) after a dogfood firing of CP-AUDIT-ACK-01 (Event 78)
+    where the operator copy-pasted the stem without the prefix and the
+    permissive CLI silently wrote a malformed entry to the ack-store —
+    the suppression check then failed because the run_id in
+    ``profile_audit.jsonl`` carries the prefix.
+
+    Strict on format: the resulting string must match
+    ``^audit-\\d{8}-\\d{6}-[0-9a-f]{4}$`` exactly. Anything else raises
+    ValueError with a diagnostic message.
 
     Untyped param is intentional: this is a runtime defensive check at
     the public-API boundary; CLI passes strings but the validator must
     handle any input shape without trusting type annotations.
     """
-    if not isinstance(audit_id, str) or not audit_id.strip():
+    if not isinstance(audit_id, str):
+        raise ValueError("audit_id must be a string")
+    stripped = audit_id.strip()
+    if not stripped:
         raise ValueError("audit_id must be a non-empty string")
+
+    candidate = stripped if stripped.startswith("audit-") else f"audit-{stripped}"
+
+    if not _AUDIT_ID_PATTERN.match(candidate):
+        raise ValueError(
+            f"audit_id {audit_id!r} does not match the expected format "
+            f"`audit-YYYYMMDD-HHMMSS-NNNN` (NNNN = 4 lowercase hex chars). "
+            f"Use `episteme profile audit ack --list` to see valid ids."
+        )
+    return candidate
 
 
 # ---------------------------------------------------------------------------
@@ -212,13 +241,13 @@ def write_ack(
     Raises ``ValueError`` on invalid ``audit_id`` or invalid
     ``rationale`` (lazy-token, too-short).
     """
-    _validate_audit_id(audit_id)
+    normalized_id = normalize_audit_id(audit_id)
     validate_rationale(rationale)
     now = _now or datetime.now(timezone.utc)
 
     payload = {
         "type": "profile_audit_ack",
-        "audit_id": audit_id,
+        "audit_id": normalized_id,
         "rationale": rationale.strip(),
         "acked_at": now.isoformat(),
         "acker": acker or _resolve_acker(),
@@ -241,13 +270,13 @@ def write_revoke(
     entry whose latest-state-per-audit-id wins. Audit trail preserved
     by construction (Pillar 2 ethos).
     """
-    _validate_audit_id(audit_id)
+    normalized_id = normalize_audit_id(audit_id)
     validate_rationale(rationale)
     now = _now or datetime.now(timezone.utc)
 
     payload = {
         "type": "profile_audit_ack_revoke",
-        "audit_id": audit_id,
+        "audit_id": normalized_id,
         "rationale": rationale.strip(),
         "revoked_at": now.isoformat(),
         "acker": acker or _resolve_acker(),

--- a/tests/test_profile_audit_ack.py
+++ b/tests/test_profile_audit_ack.py
@@ -89,19 +89,19 @@ class AckStoreWriteTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             state_dir = Path(td)
             ack.write_ack(
-                "audit-x",
+                "audit-20260427-070000-aaaa",
                 "Substantive ack rationale here.",
                 state_dir=state_dir,
                 acker="testuser",
             )
             revoke = ack.write_revoke(
-                "audit-x",
+                "audit-20260427-070000-aaaa",
                 "Reverting because new evidence shows drift continues.",
                 state_dir=state_dir,
                 acker="testuser",
             )
             self.assertEqual(revoke["payload"]["type"], "profile_audit_ack_revoke")
-            self.assertEqual(revoke["payload"]["audit_id"], "audit-x")
+            self.assertEqual(revoke["payload"]["audit_id"], "audit-20260427-070000-aaaa")
 
     def test_write_ack_invalid_audit_id_rejected(self):
         with tempfile.TemporaryDirectory() as td:
@@ -112,72 +112,138 @@ class AckStoreWriteTests(unittest.TestCase):
                 ack.write_ack(None, "Substantive rationale here.", state_dir=state_dir)  # type: ignore[arg-type]
 
 
+class NormalizeAuditIdTests(unittest.TestCase):
+    """Event 79 — auto-prefix + regex validation on audit_id."""
+
+    def test_already_prefixed_audit_id_returned_unchanged(self):
+        result = ack.normalize_audit_id("audit-20260427-063251-9131")
+        self.assertEqual(result, "audit-20260427-063251-9131")
+
+    def test_bare_stem_gets_audit_prefix_auto_prepended(self):
+        result = ack.normalize_audit_id("20260427-063251-9131")
+        self.assertEqual(result, "audit-20260427-063251-9131")
+
+    def test_malformed_format_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            ack.normalize_audit_id("blarg")
+        self.assertIn("expected format", str(ctx.exception))
+
+    def test_uppercase_hex_in_suffix_rejected(self):
+        # NNNN must be lowercase hex per uuid4().hex[:4] convention
+        with self.assertRaises(ValueError):
+            ack.normalize_audit_id("audit-20260427-063251-91FF")
+
+    def test_wrong_date_length_rejected(self):
+        with self.assertRaises(ValueError):
+            ack.normalize_audit_id("audit-2026-04-27-063251-9131")
+
+    def test_empty_audit_id_rejected(self):
+        with self.assertRaises(ValueError):
+            ack.normalize_audit_id("")
+        with self.assertRaises(ValueError):
+            ack.normalize_audit_id("   ")
+
+    def test_non_string_rejected(self):
+        with self.assertRaises(ValueError):
+            ack.normalize_audit_id(None)  # type: ignore[arg-type]
+        with self.assertRaises(ValueError):
+            ack.normalize_audit_id(123)  # type: ignore[arg-type]
+
+    def test_write_ack_with_bare_stem_normalizes_in_chain(self):
+        """Functional test: write_ack with bare stem ends up storing the full id."""
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td)
+            envelope = ack.write_ack(
+                "20260427-063251-9131",  # NO prefix
+                "Substantive rationale of sufficient length here.",
+                state_dir=state_dir,
+            )
+            # The chain entry carries the normalized (prefixed) id
+            self.assertEqual(envelope["payload"]["audit_id"], "audit-20260427-063251-9131")
+            # And is_acked of the FULL id returns True
+            self.assertTrue(ack.is_acked("audit-20260427-063251-9131", state_dir=state_dir))
+
+    def test_write_ack_with_malformed_id_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            state_dir = Path(td)
+            with self.assertRaises(ValueError):
+                ack.write_ack(
+                    "abracadabra",
+                    "Substantive rationale of sufficient length here.",
+                    state_dir=state_dir,
+                )
+
+
 class IsAckedReadPathTests(unittest.TestCase):
     """is_acked + acked_ids reflect the latest-state-per-id walk."""
 
     def test_is_acked_returns_false_when_no_store(self):
         with tempfile.TemporaryDirectory() as td:
             state_dir = Path(td)
-            self.assertFalse(ack.is_acked("audit-anything", state_dir=state_dir))
+            self.assertFalse(ack.is_acked("audit-20260427-060001-0000", state_dir=state_dir))
 
     def test_is_acked_returns_true_after_ack(self):
         with tempfile.TemporaryDirectory() as td:
             state_dir = Path(td)
             ack.write_ack(
-                "audit-y",
+                "audit-20260427-070001-aaaa",
                 "Rationale that is sufficiently long.",
                 state_dir=state_dir,
             )
-            self.assertTrue(ack.is_acked("audit-y", state_dir=state_dir))
-            self.assertFalse(ack.is_acked("audit-other", state_dir=state_dir))
+            self.assertTrue(ack.is_acked("audit-20260427-070001-aaaa", state_dir=state_dir))
+            self.assertFalse(ack.is_acked("audit-20260427-070002-bbbb", state_dir=state_dir))
 
     def test_revoke_after_ack_returns_false(self):
         with tempfile.TemporaryDirectory() as td:
             state_dir = Path(td)
             ack.write_ack(
-                "audit-z",
+                "audit-20260427-080001-aaaa",
                 "First ack rationale that is substantive.",
                 state_dir=state_dir,
             )
-            self.assertTrue(ack.is_acked("audit-z", state_dir=state_dir))
+            self.assertTrue(ack.is_acked("audit-20260427-080001-aaaa", state_dir=state_dir))
             ack.write_revoke(
-                "audit-z",
+                "audit-20260427-080001-aaaa",
                 "Reverting on new evidence of continued drift.",
                 state_dir=state_dir,
             )
-            self.assertFalse(ack.is_acked("audit-z", state_dir=state_dir))
+            self.assertFalse(ack.is_acked("audit-20260427-080001-aaaa", state_dir=state_dir))
 
     def test_re_ack_after_revoke_returns_true(self):
         with tempfile.TemporaryDirectory() as td:
             state_dir = Path(td)
+            aid = "audit-20260427-090001-aaaa"
             ack.write_ack(
-                "audit-q",
+                aid,
                 "First ack with substantive rationale text.",
                 state_dir=state_dir,
             )
             ack.write_revoke(
-                "audit-q",
+                aid,
                 "Initial revoke with substantive reason text.",
                 state_dir=state_dir,
             )
             ack.write_ack(
-                "audit-q",
+                aid,
                 "Second ack with substantive rationale text.",
                 state_dir=state_dir,
             )
             # Latest is ack again
-            self.assertTrue(ack.is_acked("audit-q", state_dir=state_dir))
+            self.assertTrue(ack.is_acked(aid, state_dir=state_dir))
 
     def test_acked_ids_returns_set_of_currently_acked(self):
         with tempfile.TemporaryDirectory() as td:
             state_dir = Path(td)
-            ack.write_ack("audit-a", "Substantive ack rationale here.", state_dir=state_dir)
-            ack.write_ack("audit-b", "Substantive ack rationale here.", state_dir=state_dir)
-            ack.write_ack("audit-c", "Substantive ack rationale here.", state_dir=state_dir)
-            ack.write_revoke("audit-b", "Substantive revoke rationale here.", state_dir=state_dir)
+            aid_a = "audit-20260427-100001-aaaa"
+            aid_b = "audit-20260427-100002-bbbb"
+            aid_c = "audit-20260427-100003-cccc"
+            ack.write_ack(aid_a, "Substantive ack rationale here.", state_dir=state_dir)
+            ack.write_ack(aid_b, "Substantive ack rationale here.", state_dir=state_dir)
+            ack.write_ack(aid_c, "Substantive ack rationale here.", state_dir=state_dir)
+            ack.write_revoke(aid_b, "Substantive revoke rationale here.", state_dir=state_dir)
             self.assertEqual(
                 ack.acked_ids(state_dir=state_dir),
-                {"audit-a", "audit-c"},  # b revoked
+                {aid_a, aid_c},  # b revoked
             )
 
 
@@ -187,10 +253,12 @@ class ChainIntegrityTests(unittest.TestCase):
     def test_chain_intact_after_multiple_writes(self):
         with tempfile.TemporaryDirectory() as td:
             state_dir = Path(td)
-            ack.write_ack("audit-1", "First substantive ack rationale.", state_dir=state_dir)
-            ack.write_ack("audit-2", "Second substantive ack rationale.", state_dir=state_dir)
-            ack.write_revoke("audit-1", "Revoke rationale that is substantive.", state_dir=state_dir)
-            ack.write_ack("audit-1", "Re-ack rationale that is substantive.", state_dir=state_dir)
+            aid_1 = "audit-20260427-110001-1111"
+            aid_2 = "audit-20260427-110002-2222"
+            ack.write_ack(aid_1, "First substantive ack rationale.", state_dir=state_dir)
+            ack.write_ack(aid_2, "Second substantive ack rationale.", state_dir=state_dir)
+            ack.write_revoke(aid_1, "Revoke rationale that is substantive.", state_dir=state_dir)
+            ack.write_ack(aid_1, "Re-ack rationale that is substantive.", state_dir=state_dir)
 
             verdict = ack.verify_chain(state_dir=state_dir)
             self.assertTrue(verdict.intact)
@@ -219,10 +287,12 @@ class ListOutstandingAuditsTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             state_dir = Path(td) / "state"
             reflective_dir = Path(td) / "reflective"
-            self._write_audit_record(reflective_dir, "audit-old", ["asymmetry_posture"])
-            self._write_audit_record(reflective_dir, "audit-new", ["fence_discipline"])
+            aid_old = "audit-20260427-120001-aaaa"
+            aid_new = "audit-20260427-120002-bbbb"
+            self._write_audit_record(reflective_dir, aid_old, ["asymmetry_posture"])
+            self._write_audit_record(reflective_dir, aid_new, ["fence_discipline"])
             ack.write_ack(
-                "audit-old",
+                aid_old,
                 "Acked because re-elicited in Event 68.",
                 state_dir=state_dir,
             )
@@ -232,7 +302,7 @@ class ListOutstandingAuditsTests(unittest.TestCase):
                 state_dir=state_dir,
             )
             self.assertEqual(len(outstanding), 1)
-            self.assertEqual(outstanding[0]["run_id"], "audit-new")
+            self.assertEqual(outstanding[0]["run_id"], aid_new)
             self.assertEqual(outstanding[0]["drift_axes"], ["fence_discipline"])
 
     def test_outstanding_excludes_no_drift_records(self):
@@ -240,7 +310,7 @@ class ListOutstandingAuditsTests(unittest.TestCase):
             state_dir = Path(td) / "state"
             reflective_dir = Path(td) / "reflective"
             # Record with NO drift axes
-            self._write_audit_record(reflective_dir, "audit-no-drift", [])
+            self._write_audit_record(reflective_dir, "audit-20260427-130001-cccc", [])
 
             outstanding = ack.list_outstanding_audits(
                 reflective_dir=reflective_dir,


### PR DESCRIPTION
## Summary

v1.0.1 polish cleanup — closes the UX gap surfaced on first dogfood of CP-AUDIT-ACK-01 (Event 78 / PR #35).

**Bug story.** Operator copy-pasted the audit-id stem `20260424-155444-14e5` without the `audit-` prefix; the permissive CLI accepted it and silently wrote a malformed entry to the ack-store. Suppression then failed because the `run_id` in `profile_audit.jsonl` carries the prefix — the IDs didn't match and the SessionStart banner kept firing.

Local state was fixed by revoke + re-ack with the correct full id. This PR ships the code-level fix so it can't happen again.

## What this changes

`src/episteme/_profile_audit_ack.py` gets a new `normalize_audit_id()` helper that:

1. **Auto-prepends `audit-`** if the input is the bare stem (`YYYYMMDD-HHMMSS-NNNN`).
2. **Regex-validates** the result against `^audit-\d{8}-\d{6}-[0-9a-f]{4}$` — strict on lowercase hex per `uuid4().hex[:4]` generation convention.
3. Returns the normalized id, OR raises `ValueError` with a diagnostic message pointing the operator at `episteme profile audit ack --list` for valid IDs.

Integrated into `write_ack` + `write_revoke` so the chain only ever stores well-formed IDs going forward.

**Behavior matrix:**

| Input | Behavior |
|---|---|
| `audit-20260427-063251-9131` | unchanged |
| `20260427-063251-9131` (bare stem) | auto-prefixed → `audit-20260427-063251-9131` |
| `audit-20260427-063251-91FF` (uppercase hex) | rejected (must be lowercase) |
| `audit-2026-04-27-063251-9131` (wrong date format) | rejected |
| `abracadabra` | rejected |
| `""` / `"   "` / `None` | rejected |

The legacy malformed entry from the dogfood discovery (already revoked + re-acked correctly via the local-state fix) remains in the chain per Pillar 2 append-only ethos — historical record preserved, but no longer findable via well-formed lookup.

## Tests

`tests/test_profile_audit_ack.py` — **29/29 pass** (20 from Event 78 + 9 new).

New `NormalizeAuditIdTests` class:

- `test_already_prefixed_audit_id_returned_unchanged`
- `test_bare_stem_gets_audit_prefix_auto_prepended`
- `test_malformed_format_rejected`
- `test_uppercase_hex_in_suffix_rejected`
- `test_wrong_date_length_rejected`
- `test_empty_audit_id_rejected`
- `test_non_string_rejected`
- `test_write_ack_with_bare_stem_normalizes_in_chain` (functional)
- `test_write_ack_with_malformed_id_rejected`

Existing tests updated to use well-formed test ids (`audit-20260427-NNNNNN-XXXX`) so they pass the new regex.

## CLI behavior unchanged

The CLI handler in `cli.py` doesn't need direct changes — `write_ack` / `write_revoke` handle normalization internally. The success message echoes the normalized id from the envelope, so an operator who types the bare stem sees the prefixed id in the confirmation output.

## Soak-invariant

ZERO touches to `kernel/*` / `core/hooks/*` / `core/blueprints/*` / `cli.py` / `templates/*` / `labs/*`. Module-internal validator update + test extension only.

## v1.0.1 polish queue post-Event-79

- ✅ CP-RELEASE-PLEASE-CHKPT-FILTER-01 (Event 75)
- ✅ CP-SYMLINK-RESTORE-01 Part A (Event 76)
- ✅ CP-EXAMPLES-SCHEMA-PARITY-01 Components 1-4 (Event 77)
- ✅ CP-AUDIT-ACK-01 (Event 78)
- ✅ **CP-AUDIT-ACK-01 cleanup** (this PR — UX gap closed)
- ⏳ CP-SYMLINK-RESTORE-01 Part B (deferred-by-design)
- ⏳ CP-EXAMPLES-SCHEMA-PARITY-01 Component 5 (deferred-by-design)

**v1.0.1 polish track effectively complete after this merges.** Next major: v1.1 cycle with CP-CHAIN-RECOVERY-PROTOCOL-01.

## Cross-references

- Bug surface: Event 78 dogfood (immediately post-merge)
- Local state fix: revoke `20260424-155444-14e5` + re-ack `audit-20260424-155444-14e5` with substantive rationale + evidence_refs `["Event 65", "Event 66", "Event 67"]`
- Audit-id format source of truth: `src/episteme/_profile_audit.py:run_audit` line 157 — `f"audit-{now.strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:4]}"`
- Audit trail: `~/episteme-private/docs/PROGRESS.md` Event 79 entry (private)