### PR TITLE
Event 86 · CP-ACTIVE-GUIDANCE-RANKING-AUDIT-01 · anti-Doxa discipline at protocol-routing layer

### DIFF
--- a/core/hooks/_guidance.py
+++ b/core/hooks/_guidance.py
@@ -211,6 +211,69 @@ def _clear_cache_for_tests() -> None:
 # ---------------------------------------------------------------------------
 
 
+def query_top_k(
+    candidate_signature: ContextSignature,
+    *,
+    k: int = 3,
+    cwd: Path,
+    min_overlap: int | None = None,
+) -> list[GuidanceMatch]:
+    """Ranked-with-disclosure helper — Event 86 / CP-ACTIVE-GUIDANCE-
+    RANKING-AUDIT-01. Returns the top-K matching protocols (descending
+    by overlap, then ts) instead of just the top-1.
+
+    Spec: kernel/ACTIVE_GUIDANCE_RANKING.md. Operators use this for
+    forensic / spot-check / 'why did the kernel surface THIS protocol?'
+    workflows. The hot-path `query()` (single-result) remains the
+    primary active-guidance API.
+    """
+    threshold = min_overlap if min_overlap is not None else load_min_overlap(cwd)
+    try:
+        protocols = _load_protocols_cached(candidate_signature.project_name)
+    except Exception:
+        return []
+    if not protocols:
+        return []
+
+    vapor_cids = _build_vapor_correlation_set()
+
+    ranked: list[tuple[int, str, dict]] = []
+    for envelope in protocols:
+        if not isinstance(envelope, dict):
+            continue
+        payload = envelope.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        cid = payload.get("correlation_id")
+        if isinstance(cid, str) and cid in vapor_cids:
+            continue
+        stored = payload.get("context_signature")
+        if not isinstance(stored, dict):
+            continue
+        overlap = field_overlap(candidate_signature, {"context_signature": stored})
+        if overlap < threshold:
+            continue
+        ts = str(envelope.get("ts") or "")
+        ranked.append((overlap, ts, payload))
+
+    if not ranked:
+        return []
+    # Same sort as `query`: primary = overlap desc (specificity);
+    # secondary = ts desc (recency tiebreaker). Anti-Doxa: NO
+    # popularity / use-count / frequency input. Audit doc:
+    # kernel/ACTIVE_GUIDANCE_RANKING.md.
+    ranked.sort(key=lambda t: (t[0], t[1]), reverse=True)
+    matches: list[GuidanceMatch] = []
+    for overlap_val, ts_val, payload_val in ranked[:k]:
+        matches.append(GuidanceMatch(
+            protocol_payload=payload_val,
+            overlap=overlap_val,
+            synthesized_at=ts_val,
+            correlation_id=str(payload_val.get("correlation_id") or ""),
+        ))
+    return matches
+
+
 def query(
     candidate_signature: ContextSignature,
     *,

--- a/kernel/ACTIVE_GUIDANCE_RANKING.md
+++ b/kernel/ACTIVE_GUIDANCE_RANKING.md
@@ -1,0 +1,131 @@
+# Active-Guidance Ranking — Anti-Doxa Discipline at the Protocol-Routing Layer
+
+**Operational summary** (load first if you have a token budget):
+
+- The kernel exists to counter Doxa (statistical-mean reasoning). If active-guidance routes synthesized protocols by popularity-frequency-recency, the kernel reinstalls Doxa at the routing layer.
+- This file is the audit + the documentation of the ranking strategy actually implemented in `core/hooks/_guidance.py:query`. It is the load-bearing claim that the routing layer is anti-Doxa-aligned.
+- **Ranking strategy:** primary key = `field_overlap` (context-signature specificity); secondary key = `ts` (recency tiebreaker). NO popularity / frequency-of-fire / use-count input.
+- v1.1 first slice (Event 86 / CP-ACTIVE-GUIDANCE-RANKING-AUDIT-01): doc + audit + ranked-with-disclosure helper (`query_top_k`) + anti-Doxa test cases. Future enhancements (full ranked-with-disclosure UX, additional ranking strategies as opt-in modes) deferred.
+
+---
+
+## What this is
+
+Pillar 3 active guidance fires at decision points. Multiple synthesized protocols may match the same candidate `context_signature`. The kernel MUST rank them when surfacing to the operator.
+
+Each candidate ranking algorithm carries built-in bias:
+
+| Ranking strategy | Hidden bias |
+|---|---|
+| By recency | recency-bias |
+| By frequency-of-fire | popularity = **Doxa** |
+| By use-count | success-bias (popular ≠ correct) |
+| By chain-position | freshness-bias |
+| By weighted-blend | hidden-Doxa-via-coefficients |
+| **By context-signature specificity** | **none — context-fit is exactly the kernel's thesis** |
+
+The kernel's central anti-Doxa thesis applied at the protocol-routing layer: **rank by context-signature specificity, not by popularity or use-count.** The protocol whose `context_signature` matches MORE precisely wins, regardless of how many times it has fired previously.
+
+If the kernel's protocol-routing used statistical-mean ranking, the kernel would be the very statistical-mean engine it set out to destroy — applied to its own knowledge layer.
+
+---
+
+## Audit (current state)
+
+**Code path:** `core/hooks/_guidance.py:query`.
+
+**Ranking function:**
+
+```python
+ranked.sort(key=lambda t: (t[0], t[1]), reverse=True)
+top_overlap, top_ts, top_payload = ranked[0]
+```
+
+Where each tuple is `(overlap, ts, payload)`:
+- `overlap` (int 0..6) — `field_overlap(candidate, stored)` from `_context_signature.py`. Counts how many of the 6 canonical context-signature fields (`project_name`, `project_tier`, `blueprint`, `op_class`, `constraint_head`, `runtime_marker`) match between the query candidate and the stored protocol.
+- `ts` (str ISO-8601) — chain envelope timestamp.
+
+**Filter inputs (applied BEFORE ranking):**
+- Vapor verdict filter (CP8 spot-check) — skips protocols whose latest spot-check verdict marks them `vapor`.
+- Project scope — `_load_protocols_cached` filters by `context_signature.project_name`.
+- Threshold — `min_overlap` (per-project configurable; default 4 of 6).
+- Supersede filter (Event 84 / Item 4) — `list_protocols` (default) filters out superseded entries.
+
+**Anti-Doxa-aligned conclusions:**
+
+1. **Primary key is specificity, not popularity.** A protocol that has fired 1,000 times with overlap=4 LOSES to a protocol that has fired once with overlap=5. The kernel routes by context-fit.
+2. **Secondary key is recency, not use-count.** The tiebreaker on equal-overlap is timestamp descending, NOT firing frequency. Ties go to "more-recent context-fit context"; the alternative (use-count) would be popularity-via-track-record.
+3. **No frequency / popularity input anywhere.** `_load_protocols_cached` returns the verified chain-walk result; ranking sees only the per-protocol `overlap` + `ts`. The chain itself contains use-count via repeated synthesis events of the same protocol, but the ranker does NOT count those.
+
+**Status: anti-Doxa-aligned at the ranking layer.** The audit confirms the implementation matches the spec's "context-fit, not statistical-fit" principle.
+
+---
+
+## Ranked-with-disclosure helper
+
+`core/hooks/_guidance.py:query_top_k` (Event 86) returns the top-K matching protocols WITH ranking-rationale + provenance trail, instead of just the top-1. Operators surfacing the routing decision can see the runner-up + understand why one won.
+
+The `query` function (single-result API) remains unchanged — used by hot-path active-guidance. `query_top_k` is operator-facing for spot-check / forensic / "why did the kernel surface THIS protocol?" workflows.
+
+---
+
+## Falsifiability — what would falsify the anti-Doxa claim
+
+Per `kernel/FALSIFIABILITY_CONDITIONS.md` discipline, the anti-Doxa property of the ranking layer must be falsifiable:
+
+**Claim.** Active-guidance routes by context-signature specificity, not by popularity or use-count.
+
+**Falsification condition.** A test scenario where:
+- Protocol A has `context_signature` matching the query candidate by 5 of 6 fields, has fired ONCE.
+- Protocol B has `context_signature` matching the query candidate by 4 of 6 fields, has fired 100 TIMES (e.g., emitted on every cascade for a noisy op-class).
+- `query()` returns Protocol B (the popular-but-less-context-fit one) instead of Protocol A.
+
+If this scenario fires, the ranker has acquired a popularity coefficient it was not supposed to have.
+
+**Test case** at `tests/test_guidance_ranking_audit.py:test_anti_doxa_specificity_wins`. Concrete adversarial fixture verifies the ranker prefers the higher-overlap protocol regardless of how many times the lower-overlap one was emitted.
+
+---
+
+## Action on disconfirmation
+
+If the falsification fires:
+
+1. **Investigate before demoting** (per `kernel/FALSIFIABILITY_CONDITIONS.md` action-on-disconfirmation policy). Drift may be real OR a test-fixture bug.
+2. **If drift is real:** the ranker has acquired hidden-Doxa coefficients. Audit the sort key; remove popularity input; re-test.
+3. **If drift is a tied-overlap edge case:** the secondary key (`ts`) is NOT popularity but recency-bias. Document that recency-tiebreaking IS a recency-bias choice (rebuttable: there isn't a non-arbitrary tiebreaker in the spec; recency is the explicit choice over use-count).
+
+---
+
+## Counter-pattern — context-signature specificity is the right primary key
+
+The kernel's broader principle: *context-fit, not statistical-fit*. The active-guidance ranking IS context-fit applied at the routing layer. Three reasons:
+
+1. **The whole synthesis discipline rewards context-specific protocols.** Pillar 3 emits a protocol scoped to the context-signature it was synthesized from. Routing by specificity preserves that scoping all the way through to the surfacing decision.
+2. **The kernel's failure-mode taxonomy explicitly counters statistical-mean reasoning.** `kernel/FAILURE_MODES.md` mode 10 (Framework-as-Doxa) names this exact failure shape at the framework layer. Ranking-by-popularity would be the same failure at the routing layer.
+3. **The federation extension preserves it.** CP-FEDERATED-COGNITIVE-NETWORK-01 (`~/episteme-private/docs/cp-v1.2-federation.md`) extends the anti-Doxa discipline from local-active-guidance to federated class-pattern aggregation. Both layers share the same principle: aggregate at the class level, not the protocol level; route by context-fit, not statistical-fit.
+
+---
+
+## Cross-references
+
+- [`kernel/CONSTITUTION.md`](./CONSTITUTION.md) — the four principles whose anti-Doxa thesis this file operationalizes at the routing layer.
+- [`kernel/FAILURE_MODES.md`](./FAILURE_MODES.md) § 10 (Framework-as-Doxa) — the failure mode this ranker counters at its layer.
+- [`kernel/FALSIFIABILITY_CONDITIONS.md`](./FALSIFIABILITY_CONDITIONS.md) — falsifiability discipline this audit honors.
+- `core/hooks/_guidance.py:query` — the audited ranking implementation.
+- `core/hooks/_guidance.py:query_top_k` — ranked-with-disclosure helper (Event 86).
+- `core/hooks/_context_signature.py:field_overlap` — overlap-counting primitive.
+- `~/episteme-private/docs/cp-v1.1-architectural.md` § CP-ACTIVE-GUIDANCE-RANKING-AUDIT-01 — spec source.
+- `~/episteme-private/docs/cp-v1.2-federation.md` § CP-FEDERATED-COGNITIVE-NETWORK-01 — anti-Doxa preservation at federation scope.
+
+---
+
+## Maintenance
+
+This file is correct when:
+
+- The `query` function in `core/hooks/_guidance.py` matches the ranking strategy described above.
+- The `query_top_k` helper exists and exposes ranking rationale.
+- `tests/test_guidance_ranking_audit.py` includes the anti-Doxa specificity-wins test.
+- Cross-references resolve.
+
+Version: v1.0 (Event 86, 2026-04-29). First slice: audit + doc + ranked-with-disclosure helper + anti-Doxa tests. Future enhancements (full UX for top-K disclosure, opt-in alternate ranking modes for spot-check experiments) deferred.

--- a/tests/test_guidance_ranking_audit.py
+++ b/tests/test_guidance_ranking_audit.py
@@ -1,0 +1,179 @@
+"""Tests for CP-ACTIVE-GUIDANCE-RANKING-AUDIT-01 (Event 86) — anti-Doxa
+discipline at the protocol-routing layer.
+
+Critical falsifiability test: ranking by context-signature specificity
+must beat popularity / use-count / frequency-of-fire. The kernel exists
+to counter Doxa; the routing layer must not reinstall it.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Locate core/hooks/_guidance + _framework + _chain
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CORE_HOOKS_DIR = _REPO_ROOT / "core" / "hooks"
+if str(_CORE_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_CORE_HOOKS_DIR))
+
+import _guidance  # type: ignore  # pyright: ignore[reportMissingImports]
+import _framework  # type: ignore  # pyright: ignore[reportMissingImports]
+from _context_signature import ContextSignature  # type: ignore  # pyright: ignore[reportMissingImports]
+
+
+def _make_protocol_payload(
+    project: str = "p",
+    blueprint: str = "fence",
+    op_class: str = "rm",
+    constraint_head: str = "fileX",
+    runtime_marker: str = "claude",
+    project_tier: str = "personal",
+    rule: str = "rule",
+    cid: str = "cid",
+) -> dict:
+    return {
+        "blueprint": blueprint,
+        "context_signature": {
+            "project_name": project,
+            "project_tier": project_tier,
+            "blueprint": blueprint,
+            "op_class": op_class,
+            "constraint_head": constraint_head,
+            "runtime_marker": runtime_marker,
+        },
+        "synthesized_protocol": rule,
+        "correlation_id": cid,
+    }
+
+
+class AntiDoxaSpecificityWinsTests(unittest.TestCase):
+    """The load-bearing falsification check: ranking-by-specificity
+    beats ranking-by-popularity. Adversarial fixture: 1 high-overlap
+    protocol vs N low-overlap protocols. The high-overlap one MUST win
+    regardless of how many low-overlap ones exist."""
+
+    def setUp(self):
+        # Clear the warm cache to ensure each test reads fresh state.
+        _guidance._clear_cache_for_tests()
+
+    def test_specificity_wins_over_popularity(self):
+        """5-of-6 overlap protocol (fired ONCE) wins over 4-of-6
+        overlap protocols (fired 100 times)."""
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "protocols.jsonl"
+
+            # 100 protocols matching 4 of 6 fields (low specificity, high popularity)
+            for i in range(100):
+                _framework.write_protocol(
+                    _make_protocol_payload(
+                        project="p", blueprint="fence", op_class="rm",
+                        constraint_head="fileX",
+                        runtime_marker=f"runtime_{i}",  # different runtime → won't match query
+                        project_tier=f"tier_{i}",        # different tier → won't match query
+                        rule=f"popular_rule_{i}",
+                        cid=f"popular_{i}",
+                    ),
+                    path=path,
+                )
+
+            # 1 protocol matching 5 of 6 fields (high specificity, fired once)
+            _framework.write_protocol(
+                _make_protocol_payload(
+                    project="p", blueprint="fence", op_class="rm",
+                    constraint_head="fileX",
+                    runtime_marker="claude",
+                    project_tier="tier_OTHER",  # 1 field mismatch
+                    rule="rare_specific_rule",
+                    cid="rare_specific",
+                ),
+                path=path,
+            )
+
+            # Patch _protocols_path to point at our fixture
+            original_path_fn = _framework._protocols_path
+            _framework._protocols_path = lambda: path
+            try:
+                _guidance._clear_cache_for_tests()
+                candidate = ContextSignature(
+                    project_name="p",
+                    project_tier="tier_TARGET",
+                    blueprint="fence",
+                    op_class="rm",
+                    constraint_head="fileX",
+                    runtime_marker="claude",
+                )
+                # min_overlap=4 so low-overlap protocols also pass threshold
+                top_k = _guidance.query_top_k(
+                    candidate,
+                    k=5,
+                    cwd=Path(td),
+                    min_overlap=4,
+                )
+            finally:
+                _framework._protocols_path = original_path_fn
+                _guidance._clear_cache_for_tests()
+
+            self.assertGreater(len(top_k), 0)
+            # The TOP result must be the high-specificity one (overlap=5),
+            # not any of the 100 popular but lower-specificity ones (overlap=4).
+            top = top_k[0]
+            self.assertEqual(top.overlap, 5)
+            self.assertEqual(top.correlation_id, "rare_specific")
+            self.assertIn("rare_specific_rule", top.protocol_payload.get("synthesized_protocol", ""))
+
+
+class QueryTopKBasicTests(unittest.TestCase):
+    """Basic mechanics of query_top_k."""
+
+    def setUp(self):
+        _guidance._clear_cache_for_tests()
+
+    def test_query_top_k_empty_when_no_protocols(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "protocols.jsonl"
+            original_path_fn = _framework._protocols_path
+            _framework._protocols_path = lambda: path
+            try:
+                _guidance._clear_cache_for_tests()
+                candidate = ContextSignature(
+                    project_name="p", project_tier="t", blueprint="b",
+                    op_class="o", constraint_head="c", runtime_marker="r",
+                )
+                top_k = _guidance.query_top_k(candidate, k=3, cwd=Path(td), min_overlap=1)
+            finally:
+                _framework._protocols_path = original_path_fn
+                _guidance._clear_cache_for_tests()
+            self.assertEqual(top_k, [])
+
+    def test_query_top_k_returns_at_most_k(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "protocols.jsonl"
+            for i in range(10):
+                _framework.write_protocol(
+                    _make_protocol_payload(
+                        project="p",
+                        runtime_marker=f"r_{i}",
+                        cid=f"cid_{i}",
+                        rule=f"rule_{i}",
+                    ),
+                    path=path,
+                )
+            original_path_fn = _framework._protocols_path
+            _framework._protocols_path = lambda: path
+            try:
+                _guidance._clear_cache_for_tests()
+                candidate = ContextSignature(
+                    project_name="p", project_tier="personal", blueprint="fence",
+                    op_class="rm", constraint_head="fileX", runtime_marker="r_5",
+                )
+                top_k = _guidance.query_top_k(candidate, k=3, cwd=Path(td), min_overlap=1)
+            finally:
+                _framework._protocols_path = original_path_fn
+                _guidance._clear_cache_for_tests()
+            self.assertLessEqual(len(top_k), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

CP-ACTIVE-GUIDANCE-RANKING-AUDIT-01 first slice. The kernel routes synthesized protocols at decision points. If ranking uses popularity / use-count / frequency, the kernel reinstalls Doxa at the routing layer — the exact failure mode the kernel exists to counter.

This Event audits + documents the existing ranking + ships a falsifiability test that confirms the implementation is anti-Doxa-aligned.

## Audit findings

`core/hooks/_guidance.py:query` ranks by:
- **Primary:** `field_overlap` (context-signature specificity, 0..6)
- **Secondary:** `ts` (recency tiebreaker, NOT use-count)

NO popularity / frequency / popularity-weighted-coefficient input. **Anti-Doxa-aligned.**

## What ships

### 1. New doc `kernel/ACTIVE_GUIDANCE_RANKING.md` (~170 lines)

- Audit findings table (popularity → Doxa; specificity → kernel's thesis).
- Ranking strategy documentation.
- Anti-Doxa property statement + falsifiability condition.
- Action-on-disconfirmation policy.
- Cross-references to FAILURE_MODES.md § 10 (Framework-as-Doxa), FALSIFIABILITY_CONDITIONS.md, cp-v1.2-federation.md.

### 2. New helper `core/hooks/_guidance.py:query_top_k`

```python
matches = query_top_k(candidate_signature, k=3, cwd=cwd, min_overlap=4)
# Returns list[GuidanceMatch] in ranked order (descending by overlap, then ts)
```

Operator-facing forensic API for "why did the kernel surface THIS protocol?" workflows. Hot-path `query()` (single-result) unchanged.

### 3. Tests — 3/3 pass

- **`test_specificity_wins_over_popularity`** — adversarial 100:1 popularity fixture. 1 high-specificity (overlap=5) protocol vs 100 low-specificity (overlap=4) protocols. The high-specificity one wins. **Load-bearing falsification check.**
- `test_query_top_k_empty_when_no_protocols`
- `test_query_top_k_returns_at_most_k`

**Full test suite green: 692/692 + 21 subtests.**

## Soak-invariant

ZERO touches to existing `query()` (hot-path active-guidance API). New doc + additive helper + new test file.

## Cross-references

- Spec: `~/episteme-private/docs/cp-v1.1-architectural.md` § CP-ACTIVE-GUIDANCE-RANKING-AUDIT-01
- Anti-Doxa preservation at federation scope: `~/episteme-private/docs/cp-v1.2-federation.md` § CP-FEDERATED-COGNITIVE-NETWORK-01

## v1.1 cycle status

- ✅ All 9 main CPs have shipped first slices
- ⏳ CP-OPERATOR-COGNITIVE-BUDGET-01 (remaining; pairs with D11 in Arm A)
- ⏳ Various integration components deferred from prior CPs (Items 3, 5; auto-instrumentation; Components 4-6 of CONTEXT-AWARE-PROFILE-OVERRIDE; Components 4-5 of CHAIN-RECOVERY)