### PR TITLE
Event 88 · CP-OPERATOR-COGNITIVE-BUDGET-01 first slice · D11 fatigue substrate (last main v1.1 CP)

### DIFF
--- a/src/episteme/_cognitive_budget.py
+++ b/src/episteme/_cognitive_budget.py
@@ -1,0 +1,573 @@
+"""Operator cognitive-budget approval-time history — Cognitive Arm A
+companion stream (CP-OPERATOR-COGNITIVE-BUDGET-01 first slice; Event 88).
+
+Append-only hash-chained record of operator approval-time observations.
+Lives at ``~/.episteme/memory/reflective/approval_times.jsonl`` and uses
+the existing CP7 ``cp7-chained-v1`` envelope schema (see
+``core/hooks/_chain.py``).
+
+## Why this exists
+
+The kernel imposes cognitive load on its operator: every Reasoning
+Surface declaration takes time, every cascade-class op requires
+attention, every audit alert requires a decision. D11 (Operator Fatigue
+Guardrails) was named in the v1.1 spec but had no executable carrier
+until this Event. CP-OPERATOR-COGNITIVE-BUDGET-01 §4 calls out
+distinguishing **cost-exceeded-benefit** from **discipline-failure**;
+they look identical to the audit today (both register as drift). This
+module ships the substrate that lets a future audit tell them apart.
+
+The mechanism: every recorded approval entry pairs a
+``correlation_id`` with the ``elapsed_seconds`` between blueprint
+advisory and op completion plus a ``blueprint`` tag and a ``reason``
+note. ``detect_fatigue`` walks the rolling window and flags
+``attention_bottleneck`` when sub-second-approval rate exceeds the
+configured threshold — the structured signal that means *operator
+fatigue suspected, this isn't necessarily discipline-failure*.
+
+## Schema
+
+Single payload type:
+
+```
+{"type": "approval_record",
+ "correlation_id": "<hook-correlation-id or operator-supplied tag>",
+ "blueprint": "<one of A/B/C/D/fallback or 'unknown'>",
+ "op_class": "<bash|edit|cascade|other>",
+ "elapsed_seconds": <float ≥ 0>,
+ "reason": "<≥15 chars, no lazy tokens>",
+ "recorded_at": "<ISO-8601 UTC>",
+ "recorder": "<operator-id>"}
+```
+
+## Validation discipline
+
+- ``blueprint`` must be one of the declared blueprint slugs (or
+  ``unknown`` / ``fallback``).
+- ``op_class`` must be one of {bash, edit, cascade, other}.
+- ``elapsed_seconds`` must be a non-negative number.
+- ``reason`` must be ≥ 15 chars + must NOT match the lazy-token list
+  (mirrors Reasoning Surface validator + ``_profile_history`` discipline).
+
+## Auto-instrumentation status
+
+This module ships the API + CLI for **manual** approval-time recording.
+**Auto-instrumentation** of approval-time capture (PreToolUse marker +
+PostToolUse computation + register-with-Claude-Code per Event 38) is
+deferred to a follow-up Event. Operators use the
+``episteme cognitive-budget --record`` CLI to log observations until then.
+
+Spec: ``~/episteme-private/docs/cp-v1.1-architectural.md``
+§ CP-OPERATOR-COGNITIVE-BUDGET-01.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Locate core/hooks/_chain.py — same lazy-import pattern other src/episteme/
+# library modules use for hook-tier modules.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_CORE_HOOKS_DIR = _REPO_ROOT / "core" / "hooks"
+if str(_CORE_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_CORE_HOOKS_DIR))
+
+import _chain  # type: ignore  # pyright: ignore[reportMissingImports]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_REFLECTIVE_DIR = Path.home() / ".episteme" / "memory" / "reflective"
+HISTORY_FILENAME = "approval_times.jsonl"
+
+
+# Fixed enum for the blueprint slug carried in each record. Mirrors the
+# Pillar 1 named-blueprints set with `unknown` (no blueprint matched) and
+# `fallback` (Goodhart-closer max-rigor fallback fired). Strings, not
+# objects — operator may record manually without importing anything.
+VALID_BLUEPRINTS: frozenset[str] = frozenset({
+    "axiomatic_judgment",      # Blueprint A
+    "fence_reconstruction",    # Blueprint B
+    "consequence_chain",       # Blueprint C
+    "cascade_escalation",      # Blueprint D
+    "fallback",                # Goodhart-closer max-rigor fallback
+    "unknown",
+})
+
+
+VALID_OP_CLASSES: frozenset[str] = frozenset({
+    "bash",
+    "edit",
+    "cascade",
+    "other",
+})
+
+
+# Mirrors `_profile_history.py:LAZY_REASON_TOKENS`. Reasoning Surface
+# validator's lazy-token discipline applied to the reason field.
+LAZY_REASON_TOKENS: frozenset[str] = frozenset({
+    # English shortforms
+    "n/a", "na", "tbd", "todo",
+    "none", "nothing", "nil", "null",
+    "ack", "acked", "acknowledged",
+    "ok", "okay", "fine",
+    "later", "fix later", "do later", "address later",
+    "wip", "in progress",
+    # Korean equivalents
+    "해당 없음", "없음", "없다", "추후", "나중에",
+})
+
+MIN_REASON_CHARS = 15
+
+
+# Defaults for fatigue detection. The threshold values are conservative
+# and tunable per-project via `<cwd>/.episteme/cognitive_budget_thresholds`
+# (single line `p50=<float>,sub_second_rate=<float>,window=<int>`).
+# Going with p50 < 1.5s and sub-second-rate > 0.5 across last 20 records
+# as the qualitative anchor from v1.1 Event 56 ("sub-second approval
+# times flag as attention_bottleneck drift signal").
+DEFAULT_WINDOW = 20
+DEFAULT_P50_THRESHOLD_SECONDS = 1.5
+DEFAULT_SUB_SECOND_RATE_THRESHOLD = 0.5
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate_blueprint(blueprint) -> None:
+    if not isinstance(blueprint, str):
+        raise ValueError("blueprint must be a string")
+    stripped = blueprint.strip()
+    if not stripped:
+        raise ValueError("blueprint must be a non-empty string")
+    if stripped not in VALID_BLUEPRINTS:
+        raise ValueError(
+            f"unknown blueprint {blueprint!r}. Must be one of "
+            f"{sorted(VALID_BLUEPRINTS)}."
+        )
+
+
+def validate_op_class(op_class) -> None:
+    if not isinstance(op_class, str):
+        raise ValueError("op_class must be a string")
+    stripped = op_class.strip()
+    if not stripped:
+        raise ValueError("op_class must be a non-empty string")
+    if stripped not in VALID_OP_CLASSES:
+        raise ValueError(
+            f"unknown op_class {op_class!r}. Must be one of "
+            f"{sorted(VALID_OP_CLASSES)}."
+        )
+
+
+def validate_elapsed_seconds(value) -> None:
+    if isinstance(value, bool):
+        raise ValueError("elapsed_seconds must be a number, not bool")
+    if not isinstance(value, (int, float)):
+        raise ValueError("elapsed_seconds must be a number")
+    if value < 0:
+        raise ValueError("elapsed_seconds must be non-negative")
+
+
+def validate_correlation_id(value) -> None:
+    if not isinstance(value, str):
+        raise ValueError("correlation_id must be a string")
+    if not value.strip():
+        raise ValueError("correlation_id must be a non-empty string")
+
+
+def validate_reason(text) -> None:
+    """Lazy-token + min-char rejection. Mirrors `_profile_history.py:
+    validate_reason` — a reason without substance defeats the
+    purpose of the trajectory record."""
+    if not isinstance(text, str):
+        raise ValueError("reason must be a string")
+    stripped = text.strip()
+    lowered = stripped.lower()
+    for token in LAZY_REASON_TOKENS:
+        if lowered == token.lower():
+            raise ValueError(
+                f"reason matches lazy-token {token!r}. "
+                f"Provide a substantive reason — what made this approval "
+                f"observation worth recording?"
+            )
+    if len(stripped) < MIN_REASON_CHARS:
+        raise ValueError(
+            f"reason must be at least {MIN_REASON_CHARS} characters; "
+            f"got {len(stripped)}. Empty / placeholder reasons rejected."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Recorder identity resolution (same pattern as _profile_history.py)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_recorder() -> str:
+    explicit = os.environ.get("EPISTEME_RECORDER", "").strip()
+    if explicit:
+        return explicit
+    user = os.environ.get("USER", "").strip()
+    if user:
+        return user
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "user.name"],
+            capture_output=True, text=True, timeout=2,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_path(reflective_dir: Path | None = None) -> Path:
+    base = reflective_dir or DEFAULT_REFLECTIVE_DIR
+    return base / HISTORY_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# Threshold override (per-project)
+# ---------------------------------------------------------------------------
+
+
+def load_thresholds(cwd: Path) -> tuple[int, float, float]:
+    """Read ``<cwd>/.episteme/cognitive_budget_thresholds`` for per-project
+    overrides. Format: ``key=value`` lines, keys
+    ``window`` / ``p50`` / ``sub_second_rate``. Falls back silently to
+    defaults on missing / malformed file. Mirrors the override pattern
+    used by ``_guidance.py:load_min_overlap``.
+    """
+    window = DEFAULT_WINDOW
+    p50 = DEFAULT_P50_THRESHOLD_SECONDS
+    rate = DEFAULT_SUB_SECOND_RATE_THRESHOLD
+    path = cwd / ".episteme" / "cognitive_budget_thresholds"
+    if not path.is_file():
+        return (window, p50, rate)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return (window, p50, rate)
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        k = k.strip().lower()
+        v = v.strip()
+        try:
+            if k == "window":
+                window = max(1, int(v))
+            elif k == "p50":
+                p50 = max(0.0, float(v))
+            elif k in ("sub_second_rate", "rate"):
+                rate = max(0.0, min(1.0, float(v)))
+        except (ValueError, TypeError):
+            continue
+    return (window, p50, rate)
+
+
+# ---------------------------------------------------------------------------
+# Write path
+# ---------------------------------------------------------------------------
+
+
+def record_approval(
+    correlation_id: str,
+    blueprint: str,
+    op_class: str,
+    elapsed_seconds: float,
+    reason: str,
+    *,
+    recorder: str | None = None,
+    reflective_dir: Path | None = None,
+    _now: datetime | None = None,  # test seam
+) -> dict:
+    """Append an ``approval_record`` envelope to the history stream
+    and return the full chain envelope.
+
+    Raises ValueError on invalid blueprint (must be in VALID_BLUEPRINTS),
+    invalid op_class (must be in VALID_OP_CLASSES), invalid
+    elapsed_seconds (must be ≥ 0), or invalid reason (lazy-token /
+    too-short).
+    """
+    validate_correlation_id(correlation_id)
+    validate_blueprint(blueprint)
+    validate_op_class(op_class)
+    validate_elapsed_seconds(elapsed_seconds)
+    validate_reason(reason)
+    now = _now or datetime.now(timezone.utc)
+
+    payload = {
+        "type": "approval_record",
+        "correlation_id": correlation_id.strip(),
+        "blueprint": blueprint.strip(),
+        "op_class": op_class.strip(),
+        "elapsed_seconds": float(elapsed_seconds),
+        "reason": reason.strip(),
+        "recorded_at": now.isoformat(),
+        "recorder": recorder or _resolve_recorder(),
+    }
+    return _chain.append(_resolve_path(reflective_dir), payload)
+
+
+# ---------------------------------------------------------------------------
+# Read paths
+# ---------------------------------------------------------------------------
+
+
+def walk_approvals(
+    *,
+    blueprint: str | None = None,
+    op_class: str | None = None,
+    limit: int | None = None,
+    reflective_dir: Path | None = None,
+) -> list[dict]:
+    """Return approval envelopes in chronological (chain) order. Filters
+    by ``blueprint`` / ``op_class`` if supplied. ``limit`` returns the
+    last N (most recent) entries after filtering; pass None for all.
+
+    Filters out non-`approval_record` payloads (defensive — the stream
+    is single-payload-type by design, but the filter ensures forward-
+    compat with future payload types).
+    """
+    if blueprint is not None:
+        validate_blueprint(blueprint)
+    if op_class is not None:
+        validate_op_class(op_class)
+    path = _resolve_path(reflective_dir)
+    if not path.exists():
+        return []
+
+    entries: list[dict] = []
+    for envelope in _chain.iter_records(path, verify=True):
+        payload = envelope.get("payload", {})
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("type") != "approval_record":
+            continue
+        if blueprint is not None and payload.get("blueprint") != blueprint:
+            continue
+        if op_class is not None and payload.get("op_class") != op_class:
+            continue
+        entries.append(envelope)
+    if limit is not None and limit > 0:
+        return entries[-limit:]
+    return entries
+
+
+def list_blueprints_with_history(*, reflective_dir: Path | None = None) -> set[str]:
+    """Return set of blueprint slugs that have at least one recorded
+    approval observation."""
+    path = _resolve_path(reflective_dir)
+    if not path.exists():
+        return set()
+    blueprints: set[str] = set()
+    for envelope in _chain.iter_records(path, verify=True):
+        payload = envelope.get("payload", {})
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("type") != "approval_record":
+            continue
+        bp = payload.get("blueprint")
+        if isinstance(bp, str):
+            blueprints.add(bp)
+    return blueprints
+
+
+# ---------------------------------------------------------------------------
+# Fatigue detection (D11 attention_bottleneck signal)
+# ---------------------------------------------------------------------------
+
+
+def detect_fatigue(
+    *,
+    window: int = DEFAULT_WINDOW,
+    p50_threshold_seconds: float = DEFAULT_P50_THRESHOLD_SECONDS,
+    sub_second_rate_threshold: float = DEFAULT_SUB_SECOND_RATE_THRESHOLD,
+    reflective_dir: Path | None = None,
+) -> dict | None:
+    """Inspect the most recent ``window`` approval observations and
+    return a fatigue signal if either:
+
+    - rolling p50 elapsed_seconds is BELOW ``p50_threshold_seconds``, OR
+    - rate of sub-second-elapsed approvals exceeds
+      ``sub_second_rate_threshold``.
+
+    Returns None when not enough observations OR neither threshold is
+    crossed. Returns a dict ``{signal: "attention_bottleneck", window,
+    p50, sub_second_rate, observed_at, sample_size}`` when fired.
+
+    Both thresholds are evaluated independently — either alone fires
+    the signal. p50 measures central tendency; sub-second-rate measures
+    auto-approval shape. Together they cover both 'consistently fast'
+    and 'occasional bursts of fast approvals'.
+
+    The function is purely observational. Operator action on the signal
+    (slow down, take a break, raise discipline ceiling, etc.) lives in
+    the audit / advisory layer — explicitly NOT here. Per the v1.1
+    bounded-autonomy posture: budget detection should never block.
+    """
+    if window < 1:
+        raise ValueError("window must be ≥ 1")
+    if p50_threshold_seconds < 0:
+        raise ValueError("p50_threshold_seconds must be ≥ 0")
+    if not 0.0 <= sub_second_rate_threshold <= 1.0:
+        raise ValueError("sub_second_rate_threshold must be in [0, 1]")
+
+    entries = walk_approvals(limit=window, reflective_dir=reflective_dir)
+    if not entries:
+        return None
+
+    elapsed = [
+        float(env["payload"]["elapsed_seconds"])
+        for env in entries
+        if isinstance(env.get("payload"), dict)
+        and isinstance(env["payload"].get("elapsed_seconds"), (int, float))
+    ]
+    if not elapsed:
+        return None
+
+    sample_size = len(elapsed)
+    sorted_e = sorted(elapsed)
+    # Median (p50) — for even sample sizes, average the two middle values.
+    mid = sample_size // 2
+    if sample_size % 2 == 1:
+        p50 = sorted_e[mid]
+    else:
+        p50 = (sorted_e[mid - 1] + sorted_e[mid]) / 2.0
+    sub_second_count = sum(1 for v in elapsed if v < 1.0)
+    sub_second_rate = sub_second_count / sample_size
+
+    p50_fires = p50 < p50_threshold_seconds
+    rate_fires = sub_second_rate > sub_second_rate_threshold
+    if not (p50_fires or rate_fires):
+        return None
+
+    triggers = []
+    if p50_fires:
+        triggers.append("p50_below_threshold")
+    if rate_fires:
+        triggers.append("sub_second_rate_above_threshold")
+
+    return {
+        "signal": "attention_bottleneck",
+        "window": window,
+        "sample_size": sample_size,
+        "p50": p50,
+        "sub_second_rate": sub_second_rate,
+        "p50_threshold_seconds": p50_threshold_seconds,
+        "sub_second_rate_threshold": sub_second_rate_threshold,
+        "triggers": triggers,
+        "observed_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Summary stats (CLI helper)
+# ---------------------------------------------------------------------------
+
+
+def summarize(
+    *,
+    window: int | None = None,
+    blueprint: str | None = None,
+    reflective_dir: Path | None = None,
+) -> dict:
+    """Return a summary dict over the most-recent ``window`` observations
+    (or all if window=None). Useful as a CLI surface — operator runs
+    `episteme cognitive-budget --summary` and gets a concise readout.
+
+    Shape: ``{count, p50, p95, mean, sub_second_rate, by_blueprint:
+    {<bp>: count}, fatigue: <detect_fatigue result or None>}``.
+    """
+    entries = walk_approvals(
+        blueprint=blueprint,
+        limit=window,
+        reflective_dir=reflective_dir,
+    )
+    if not entries:
+        return {
+            "count": 0,
+            "p50": None,
+            "p95": None,
+            "mean": None,
+            "sub_second_rate": None,
+            "by_blueprint": {},
+            "fatigue": None,
+        }
+    elapsed: list[float] = []
+    by_bp: dict[str, int] = {}
+    for env in entries:
+        payload = env.get("payload", {})
+        if not isinstance(payload, dict):
+            continue
+        e = payload.get("elapsed_seconds")
+        if isinstance(e, (int, float)):
+            elapsed.append(float(e))
+        bp = payload.get("blueprint")
+        if isinstance(bp, str):
+            by_bp[bp] = by_bp.get(bp, 0) + 1
+    if not elapsed:
+        return {
+            "count": len(entries),
+            "p50": None,
+            "p95": None,
+            "mean": None,
+            "sub_second_rate": None,
+            "by_blueprint": by_bp,
+            "fatigue": None,
+        }
+    sorted_e = sorted(elapsed)
+    n = len(sorted_e)
+    mid = n // 2
+    if n % 2 == 1:
+        p50 = sorted_e[mid]
+    else:
+        p50 = (sorted_e[mid - 1] + sorted_e[mid]) / 2.0
+    p95_idx = max(0, min(n - 1, int(round(0.95 * (n - 1)))))
+    p95 = sorted_e[p95_idx]
+    mean = sum(sorted_e) / n
+    sub_second_rate = sum(1 for v in sorted_e if v < 1.0) / n
+
+    fatigue = detect_fatigue(
+        window=window or DEFAULT_WINDOW,
+        reflective_dir=reflective_dir,
+    )
+    return {
+        "count": n,
+        "p50": p50,
+        "p95": p95,
+        "mean": mean,
+        "sub_second_rate": sub_second_rate,
+        "by_blueprint": by_bp,
+        "fatigue": fatigue,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Chain verification (delegates to _chain)
+# ---------------------------------------------------------------------------
+
+
+def verify_chain(reflective_dir: Path | None = None):
+    """Return ``_chain.ChainVerdict`` for the approval_times stream.
+    Used by ``episteme chain verify`` to integrate the budget stream
+    into the Pillar 2 verification surface."""
+    return _chain.verify_chain(_resolve_path(reflective_dir))

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -3352,6 +3352,139 @@ def _policy_history_cli(args) -> int:
     return 0
 
 
+def _cognitive_budget_cli(args) -> int:
+    """CLI entry for `episteme cognitive-budget` (Event 88 — D11 substrate).
+
+    Modes dispatched by args:
+    - `--list`: enumerate blueprints with at least one recorded approval.
+    - `--summary [--window N] [--blueprint <slug>]`: rolling stats + fatigue check.
+    - `--check`: print only the fatigue verdict (machine-friendly: exit 1 if fired).
+    - `--record <correlation_id> --blueprint X --op-class Y --elapsed-seconds Z --reason "..."`:
+      append a manual approval observation.
+    - default (no flag): print recent approvals (most recent first) up to --tail.
+    """
+    from episteme import _cognitive_budget as cb_mod
+
+    if getattr(args, "list_blueprints", False):
+        bps = cb_mod.list_blueprints_with_history()
+        if not bps:
+            print("No approval observations recorded yet.")
+            return 0
+        print(f"Blueprints with recorded approvals ({len(bps)}):")
+        for bp in sorted(bps):
+            entries = cb_mod.walk_approvals(blueprint=bp)
+            print(f"  {bp:25s}  {len(entries)} entr{'y' if len(entries) == 1 else 'ies'}")
+        return 0
+
+    record = getattr(args, "record", False)
+    if record:
+        correlation_id = getattr(args, "correlation_id", None)
+        blueprint = getattr(args, "blueprint", None)
+        op_class = getattr(args, "op_class", None)
+        elapsed_seconds = getattr(args, "elapsed_seconds", None)
+        reason = getattr(args, "reason", None)
+        if (
+            not correlation_id
+            or not blueprint
+            or not op_class
+            or elapsed_seconds is None
+            or not reason
+        ):
+            print(
+                "--record requires <correlation_id> --blueprint --op-class "
+                "--elapsed-seconds --reason (min 15 chars; lazy tokens rejected).",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            envelope = cb_mod.record_approval(
+                correlation_id,
+                blueprint,
+                op_class,
+                elapsed_seconds,
+                reason,
+            )
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+        payload = envelope.get("payload", {})
+        print(f"Recorded approval observation for {correlation_id}.")
+        print(f"  entry_hash:  {envelope.get('entry_hash', '?')}")
+        print(f"  blueprint:   {payload.get('blueprint', '?')}")
+        print(f"  op_class:    {payload.get('op_class', '?')}")
+        print(f"  elapsed:     {payload.get('elapsed_seconds', '?')}s")
+        return 0
+
+    if getattr(args, "summary", False):
+        window = getattr(args, "window", None)
+        blueprint = getattr(args, "blueprint", None)
+        summ = cb_mod.summarize(window=window, blueprint=blueprint)
+        if summ["count"] == 0:
+            print("No approval observations recorded yet.")
+            return 0
+        scope = f"window={window}" if window else "all entries"
+        if blueprint:
+            scope += f", blueprint={blueprint}"
+        print(f"Approval-time summary ({scope}):")
+        print(f"  count:           {summ['count']}")
+        if summ["p50"] is not None:
+            print(f"  p50:             {summ['p50']:.3f}s")
+            print(f"  p95:             {summ['p95']:.3f}s")
+            print(f"  mean:            {summ['mean']:.3f}s")
+            print(f"  sub_second_rate: {summ['sub_second_rate']:.2%}")
+        if summ["by_blueprint"]:
+            print("  by_blueprint:")
+            for bp, n in sorted(summ["by_blueprint"].items()):
+                print(f"    {bp:25s}  {n}")
+        fatigue = summ.get("fatigue")
+        if fatigue:
+            print()
+            print(f"  ⚠ FATIGUE SIGNAL: {fatigue['signal']}")
+            print(f"    triggers:        {', '.join(fatigue['triggers'])}")
+            print(f"    p50:             {fatigue['p50']:.3f}s "
+                  f"(threshold {fatigue['p50_threshold_seconds']}s)")
+            print(f"    sub_second_rate: {fatigue['sub_second_rate']:.2%} "
+                  f"(threshold {fatigue['sub_second_rate_threshold']:.2%})")
+        return 0
+
+    if getattr(args, "check", False):
+        sig = cb_mod.detect_fatigue()
+        if sig is None:
+            print("No fatigue signal — approval-time pattern within thresholds.")
+            return 0
+        print(f"FATIGUE SIGNAL: {sig['signal']}")
+        print(f"  triggers:        {', '.join(sig['triggers'])}")
+        print(f"  p50:             {sig['p50']:.3f}s "
+              f"(threshold {sig['p50_threshold_seconds']}s)")
+        print(f"  sub_second_rate: {sig['sub_second_rate']:.2%} "
+              f"(threshold {sig['sub_second_rate_threshold']:.2%})")
+        return 1
+
+    # Default: tail recent observations
+    tail = getattr(args, "tail", None) or 10
+    blueprint = getattr(args, "blueprint", None)
+    entries = cb_mod.walk_approvals(blueprint=blueprint, limit=tail)
+    if not entries:
+        print("No approval observations recorded yet.")
+        return 0
+    scope = f"tail={tail}"
+    if blueprint:
+        scope += f", blueprint={blueprint}"
+    print(f"Recent approval observations ({scope}):")
+    print()
+    for envelope in entries:
+        payload = envelope.get("payload", {})
+        print(f"  recorded_at:    {payload.get('recorded_at', '?')}")
+        print(f"  correlation_id: {payload.get('correlation_id', '?')}")
+        print(f"  blueprint:      {payload.get('blueprint', '?')}")
+        print(f"  op_class:       {payload.get('op_class', '?')}")
+        print(f"  elapsed:        {payload.get('elapsed_seconds', '?')}s")
+        print(f"  reason:         {payload.get('reason', '?')}")
+        print(f"  entry_hash:     {envelope.get('entry_hash', '?')}")
+        print()
+    return 0
+
+
 def _profile_audit_ack_cli(args) -> int:
     """CLI entry for `episteme profile audit ack` (CP-AUDIT-ACK-01 / Event 78).
 
@@ -4302,6 +4435,12 @@ def _chain_dispatch(args) -> int:
             policy_history_verdict = _polh_mod.verify_chain()
         except Exception:  # noqa: BLE001 — degrade gracefully
             policy_history_verdict = None
+        # CP-OPERATOR-COGNITIVE-BUDGET-01 / Event 88 — approval_times
+        try:
+            from episteme import _cognitive_budget as _cb_mod
+            cognitive_budget_verdict = _cb_mod.verify_chain()
+        except Exception:  # noqa: BLE001 — degrade gracefully
+            cognitive_budget_verdict = None
         all_intact = True
         for stream_name, verdict in (
             ("protocols", fw.get("protocols")),
@@ -4311,6 +4450,7 @@ def _chain_dispatch(args) -> int:
             ("profile_audit_acks", ack_verdict),
             ("profile_history", history_verdict),
             ("policy_history", policy_history_verdict),
+            ("approval_times", cognitive_budget_verdict),
         ):
             if verdict is None:
                 continue
@@ -5333,6 +5473,75 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional description of data that won't be carried forward (recommended for mode=reset)",
     )
 
+    # CP-OPERATOR-COGNITIVE-BUDGET-01 / Event 88 — Cognitive Arm A D11
+    # substrate. Operator approval-time observations + fatigue detection.
+    cb_cmd = sub.add_parser(
+        "cognitive-budget",
+        help="Inspect operator approval-time observations + D11 fatigue signal (Cognitive Arm A)",
+    )
+    cb_cmd.add_argument(
+        "--list",
+        dest="list_blueprints",
+        action="store_true",
+        help="List blueprints with at least one recorded approval observation",
+    )
+    cb_cmd.add_argument(
+        "--summary",
+        action="store_true",
+        help="Render rolling stats (count / p50 / p95 / mean / sub_second_rate) + fatigue check",
+    )
+    cb_cmd.add_argument(
+        "--check",
+        action="store_true",
+        help="Print only the fatigue verdict (exit 1 when attention_bottleneck fires)",
+    )
+    cb_cmd.add_argument(
+        "--record",
+        action="store_true",
+        help="Record a new approval observation (requires correlation_id, --blueprint, --op-class, --elapsed-seconds, --reason)",
+    )
+    cb_cmd.add_argument(
+        "correlation_id",
+        nargs="?",
+        help="Correlation id for the observation (omit unless using --record)",
+    )
+    cb_cmd.add_argument(
+        "--blueprint",
+        choices=[
+            "axiomatic_judgment", "fence_reconstruction", "consequence_chain",
+            "cascade_escalation", "fallback", "unknown",
+        ],
+        help="Blueprint slug for the observation (axiomatic_judgment / fence_reconstruction / consequence_chain / cascade_escalation / fallback / unknown)",
+    )
+    cb_cmd.add_argument(
+        "--op-class",
+        dest="op_class",
+        choices=["bash", "edit", "cascade", "other"],
+        help="Op class for the observation",
+    )
+    cb_cmd.add_argument(
+        "--elapsed-seconds",
+        dest="elapsed_seconds",
+        type=float,
+        help="Approval elapsed seconds (≥ 0)",
+    )
+    cb_cmd.add_argument(
+        "--reason",
+        help="Substantive reason for the observation (min 15 chars; lazy tokens rejected)",
+    )
+    cb_cmd.add_argument(
+        "--window",
+        type=int,
+        default=None,
+        help="Most-recent N observations to consider for --summary (default: all)",
+    )
+    cb_cmd.add_argument(
+        "--tail",
+        type=int,
+        default=None,
+        help="Default mode: print most-recent N observations (default 10)",
+    )
+
     # CP9 — Pillar 3 active guidance query.
     guide_cmd = sub.add_parser(
         "guide",
@@ -5615,6 +5824,8 @@ def main(argv: Iterable[str] | None = None) -> int:
         return 0
     if args.command == "history":
         return _profile_history_cli(args)
+    if args.command == "cognitive-budget":
+        return _cognitive_budget_cli(args)
     if args.command == "profile":
         if args.profile_action == "show":
             return _profile_show()

--- a/tests/test_cognitive_budget.py
+++ b/tests/test_cognitive_budget.py
@@ -1,0 +1,426 @@
+"""Tests for CP-OPERATOR-COGNITIVE-BUDGET-01 (Event 88) — operator
+approval-time history hash-chained stream + D11 fatigue detector.
+
+Coverage:
+- blueprint validation (must be one of declared blueprint slugs)
+- op_class validation (must be one of declared classes)
+- elapsed_seconds validation (must be ≥ 0; bool / non-numeric rejected)
+- correlation_id validation (must be non-empty string)
+- reason validation (lazy-token + min-char rejection)
+- record_approval writes valid cp7-chained-v1 envelope
+- walk_approvals returns chronological observations + filters
+- detect_fatigue threshold logic — both p50 and sub-second-rate triggers
+- summarize stats shape
+- chain integrity across multiple writes
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from episteme import _cognitive_budget as cb
+
+
+class ValidateBlueprintTests(unittest.TestCase):
+    def test_valid_blueprint_accepted(self):
+        for bp in cb.VALID_BLUEPRINTS:
+            cb.validate_blueprint(bp)
+        # Should NOT raise
+
+    def test_unknown_blueprint_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            cb.validate_blueprint("not_a_real_blueprint")
+        self.assertIn("unknown blueprint", str(ctx.exception))
+
+    def test_empty_blueprint_rejected(self):
+        with self.assertRaises(ValueError):
+            cb.validate_blueprint("")
+        with self.assertRaises(ValueError):
+            cb.validate_blueprint("   ")
+
+    def test_non_string_blueprint_rejected(self):
+        with self.assertRaises(ValueError):
+            cb.validate_blueprint(None)  # type: ignore[arg-type]
+        with self.assertRaises(ValueError):
+            cb.validate_blueprint(123)  # type: ignore[arg-type]
+
+
+class ValidateOpClassTests(unittest.TestCase):
+    def test_valid_op_class_accepted(self):
+        for oc in cb.VALID_OP_CLASSES:
+            cb.validate_op_class(oc)
+
+    def test_unknown_op_class_rejected(self):
+        with self.assertRaises(ValueError):
+            cb.validate_op_class("xterm")
+
+    def test_empty_op_class_rejected(self):
+        with self.assertRaises(ValueError):
+            cb.validate_op_class("")
+
+
+class ValidateElapsedSecondsTests(unittest.TestCase):
+    def test_zero_accepted(self):
+        cb.validate_elapsed_seconds(0)
+        cb.validate_elapsed_seconds(0.0)
+
+    def test_positive_accepted(self):
+        cb.validate_elapsed_seconds(0.5)
+        cb.validate_elapsed_seconds(120)
+
+    def test_negative_rejected(self):
+        with self.assertRaises(ValueError):
+            cb.validate_elapsed_seconds(-0.001)
+
+    def test_bool_rejected(self):
+        with self.assertRaises(ValueError):
+            cb.validate_elapsed_seconds(True)  # type: ignore[arg-type]
+
+    def test_non_numeric_rejected(self):
+        with self.assertRaises(ValueError):
+            cb.validate_elapsed_seconds("0.5")  # type: ignore[arg-type]
+
+
+class ValidateCorrelationIdTests(unittest.TestCase):
+    def test_valid_correlation_id_accepted(self):
+        cb.validate_correlation_id("h_abc123")
+
+    def test_empty_correlation_id_rejected(self):
+        with self.assertRaises(ValueError):
+            cb.validate_correlation_id("")
+        with self.assertRaises(ValueError):
+            cb.validate_correlation_id("   ")
+
+    def test_non_string_correlation_id_rejected(self):
+        with self.assertRaises(ValueError):
+            cb.validate_correlation_id(None)  # type: ignore[arg-type]
+
+
+class ValidateReasonTests(unittest.TestCase):
+    def test_lazy_token_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            cb.validate_reason("n/a")
+        self.assertIn("lazy-token", str(ctx.exception))
+
+    def test_lazy_token_korean_rejected(self):
+        with self.assertRaises(ValueError):
+            cb.validate_reason("해당 없음")
+
+    def test_short_reason_rejected(self):
+        with self.assertRaises(ValueError) as ctx:
+            cb.validate_reason("too short")
+        self.assertIn("at least", str(ctx.exception))
+
+    def test_substantive_reason_accepted(self):
+        cb.validate_reason("Smoke-test approval observation for ablation.")
+
+
+class RecordApprovalTests(unittest.TestCase):
+    def test_writes_valid_envelope(self):
+        with tempfile.TemporaryDirectory() as td:
+            envelope = cb.record_approval(
+                "h_abc123",
+                "fence_reconstruction",
+                "edit",
+                0.42,
+                "Manual record from tests for envelope shape verification.",
+                recorder="testuser",
+                reflective_dir=Path(td),
+            )
+            self.assertEqual(envelope["schema_version"], "cp7-chained-v1")
+            payload = envelope["payload"]
+            self.assertEqual(payload["type"], "approval_record")
+            self.assertEqual(payload["correlation_id"], "h_abc123")
+            self.assertEqual(payload["blueprint"], "fence_reconstruction")
+            self.assertEqual(payload["op_class"], "edit")
+            self.assertEqual(payload["elapsed_seconds"], 0.42)
+            self.assertEqual(payload["recorder"], "testuser")
+            self.assertIn("recorded_at", payload)
+            self.assertTrue(envelope["entry_hash"].startswith("sha256:"))
+
+    def test_invalid_blueprint_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaises(ValueError):
+                cb.record_approval(
+                    "h_x", "fake_blueprint", "edit", 0.5,
+                    "Substantive reason for the approval observation.",
+                    reflective_dir=Path(td),
+                )
+
+    def test_invalid_op_class_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaises(ValueError):
+                cb.record_approval(
+                    "h_x", "fence_reconstruction", "wat", 0.5,
+                    "Substantive reason for the approval observation.",
+                    reflective_dir=Path(td),
+                )
+
+    def test_negative_elapsed_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaises(ValueError):
+                cb.record_approval(
+                    "h_x", "fence_reconstruction", "edit", -0.1,
+                    "Substantive reason for the approval observation.",
+                    reflective_dir=Path(td),
+                )
+
+    def test_lazy_reason_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaises(ValueError):
+                cb.record_approval(
+                    "h_x", "fence_reconstruction", "edit", 0.5, "tbd",
+                    reflective_dir=Path(td),
+                )
+
+
+class WalkApprovalsTests(unittest.TestCase):
+    def test_walk_empty_returns_empty(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(cb.walk_approvals(reflective_dir=Path(td)), [])
+
+    def test_walk_returns_chronological(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            base = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+            for i in range(3):
+                cb.record_approval(
+                    f"h_{i}", "fence_reconstruction", "edit", 0.1 * (i + 1),
+                    f"Observation entry {i} for chronological ordering check.",
+                    recorder="t",
+                    reflective_dir=d,
+                    _now=base + timedelta(seconds=i),
+                )
+            entries = cb.walk_approvals(reflective_dir=d)
+            self.assertEqual(len(entries), 3)
+            self.assertEqual(entries[0]["payload"]["correlation_id"], "h_0")
+            self.assertEqual(entries[2]["payload"]["correlation_id"], "h_2")
+
+    def test_walk_filters_by_blueprint(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            cb.record_approval(
+                "h_a", "fence_reconstruction", "edit", 0.5,
+                "Fence reconstruction observation for filter test.",
+                recorder="t", reflective_dir=d,
+            )
+            cb.record_approval(
+                "h_b", "axiomatic_judgment", "edit", 0.5,
+                "Axiomatic judgment observation for filter test.",
+                recorder="t", reflective_dir=d,
+            )
+            fence = cb.walk_approvals(blueprint="fence_reconstruction", reflective_dir=d)
+            self.assertEqual(len(fence), 1)
+            self.assertEqual(fence[0]["payload"]["correlation_id"], "h_a")
+
+    def test_walk_filters_by_op_class(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            cb.record_approval(
+                "h_a", "fence_reconstruction", "edit", 0.5,
+                "Edit observation for op_class filter test.",
+                recorder="t", reflective_dir=d,
+            )
+            cb.record_approval(
+                "h_b", "fence_reconstruction", "bash", 0.5,
+                "Bash observation for op_class filter test.",
+                recorder="t", reflective_dir=d,
+            )
+            edits = cb.walk_approvals(op_class="edit", reflective_dir=d)
+            self.assertEqual(len(edits), 1)
+            self.assertEqual(edits[0]["payload"]["correlation_id"], "h_a")
+
+    def test_walk_limit_returns_last_n(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            base = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+            for i in range(5):
+                cb.record_approval(
+                    f"h_{i}", "fence_reconstruction", "edit", 0.1,
+                    f"Observation {i} for limit test (must be ≥ 15 chars).",
+                    recorder="t", reflective_dir=d,
+                    _now=base + timedelta(seconds=i),
+                )
+            tail = cb.walk_approvals(limit=2, reflective_dir=d)
+            self.assertEqual(len(tail), 2)
+            self.assertEqual(tail[0]["payload"]["correlation_id"], "h_3")
+            self.assertEqual(tail[1]["payload"]["correlation_id"], "h_4")
+
+
+class ListBlueprintsWithHistoryTests(unittest.TestCase):
+    def test_returns_recorded_blueprints(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            cb.record_approval(
+                "h_a", "fence_reconstruction", "edit", 0.5,
+                "Fence reconstruction observation for list test.",
+                recorder="t", reflective_dir=d,
+            )
+            cb.record_approval(
+                "h_b", "cascade_escalation", "cascade", 1.0,
+                "Cascade escalation observation for list test.",
+                recorder="t", reflective_dir=d,
+            )
+            bps = cb.list_blueprints_with_history(reflective_dir=d)
+            self.assertEqual(bps, {"fence_reconstruction", "cascade_escalation"})
+
+    def test_empty_when_no_history(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(cb.list_blueprints_with_history(reflective_dir=Path(td)), set())
+
+
+class DetectFatigueTests(unittest.TestCase):
+    def test_no_history_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertIsNone(cb.detect_fatigue(reflective_dir=Path(td)))
+
+    def test_p50_threshold_fires_signal(self):
+        """20 sub-second observations → p50 ≈ 0.5s < 1.5s threshold → fires."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            base = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+            for i in range(20):
+                cb.record_approval(
+                    f"h_{i}", "fence_reconstruction", "edit", 0.5,
+                    f"Sub-second observation {i} for p50-fires fatigue test.",
+                    recorder="t", reflective_dir=d,
+                    _now=base + timedelta(seconds=i),
+                )
+            sig = cb.detect_fatigue(reflective_dir=d)
+            self.assertIsNotNone(sig)
+            assert sig is not None  # for type-checker
+            self.assertEqual(sig["signal"], "attention_bottleneck")
+            self.assertIn("p50_below_threshold", sig["triggers"])
+            self.assertIn("sub_second_rate_above_threshold", sig["triggers"])
+            self.assertEqual(sig["sample_size"], 20)
+            self.assertAlmostEqual(sig["p50"], 0.5, places=3)
+            self.assertAlmostEqual(sig["sub_second_rate"], 1.0, places=3)
+
+    def test_slow_pattern_no_signal(self):
+        """20 slow approvals (3s each) → p50 = 3s > 1.5s; sub_second_rate = 0 → no signal."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            base = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+            for i in range(20):
+                cb.record_approval(
+                    f"h_{i}", "fence_reconstruction", "edit", 3.0,
+                    f"Slow approval observation {i} for no-fatigue path test.",
+                    recorder="t", reflective_dir=d,
+                    _now=base + timedelta(seconds=i),
+                )
+            sig = cb.detect_fatigue(reflective_dir=d)
+            self.assertIsNone(sig)
+
+    def test_sub_second_rate_only_fires(self):
+        """Mix: 11 sub-second + 9 slow → p50 ≈ 0.5s (still below threshold) AND
+        sub_second_rate = 0.55 > 0.5 → both triggers fire. Test that it
+        fires under the rate condition specifically by checking trigger list."""
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            base = datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc)
+            for i in range(11):
+                cb.record_approval(
+                    f"h_fast_{i}", "fence_reconstruction", "edit", 0.5,
+                    f"Fast observation {i} for mixed-pattern test.",
+                    recorder="t", reflective_dir=d,
+                    _now=base + timedelta(seconds=i),
+                )
+            for i in range(9):
+                cb.record_approval(
+                    f"h_slow_{i}", "fence_reconstruction", "edit", 5.0,
+                    f"Slow observation {i} for mixed-pattern test.",
+                    recorder="t", reflective_dir=d,
+                    _now=base + timedelta(seconds=20 + i),
+                )
+            sig = cb.detect_fatigue(reflective_dir=d)
+            self.assertIsNotNone(sig)
+            assert sig is not None
+            self.assertIn("sub_second_rate_above_threshold", sig["triggers"])
+
+    def test_invalid_window_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaises(ValueError):
+                cb.detect_fatigue(window=0, reflective_dir=Path(td))
+
+    def test_invalid_threshold_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            with self.assertRaises(ValueError):
+                cb.detect_fatigue(p50_threshold_seconds=-1, reflective_dir=Path(td))
+            with self.assertRaises(ValueError):
+                cb.detect_fatigue(sub_second_rate_threshold=1.5, reflective_dir=Path(td))
+
+
+class SummarizeTests(unittest.TestCase):
+    def test_empty_summary(self):
+        with tempfile.TemporaryDirectory() as td:
+            summ = cb.summarize(reflective_dir=Path(td))
+            self.assertEqual(summ["count"], 0)
+            self.assertIsNone(summ["p50"])
+            self.assertEqual(summ["by_blueprint"], {})
+            self.assertIsNone(summ["fatigue"])
+
+    def test_summary_shape(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            for i in range(3):
+                cb.record_approval(
+                    f"h_{i}", "fence_reconstruction", "edit", 1.0,
+                    f"Observation {i} for summary shape test (≥ 15 chars).",
+                    recorder="t", reflective_dir=d,
+                )
+            summ = cb.summarize(reflective_dir=d)
+            self.assertEqual(summ["count"], 3)
+            self.assertAlmostEqual(summ["p50"], 1.0, places=3)
+            self.assertEqual(summ["by_blueprint"], {"fence_reconstruction": 3})
+
+
+class ChainIntegrityTests(unittest.TestCase):
+    def test_chain_intact_after_writes(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td)
+            for i in range(5):
+                cb.record_approval(
+                    f"h_{i}", "fence_reconstruction", "edit", 0.5,
+                    f"Chain integrity test observation {i}.",
+                    recorder="t", reflective_dir=d,
+                )
+            verdict = cb.verify_chain(reflective_dir=d)
+            self.assertTrue(verdict.intact)
+            self.assertEqual(verdict.total_entries, 5)
+
+
+class LoadThresholdsTests(unittest.TestCase):
+    def test_defaults_when_no_override(self):
+        with tempfile.TemporaryDirectory() as td:
+            window, p50, rate = cb.load_thresholds(Path(td))
+            self.assertEqual(window, cb.DEFAULT_WINDOW)
+            self.assertEqual(p50, cb.DEFAULT_P50_THRESHOLD_SECONDS)
+            self.assertEqual(rate, cb.DEFAULT_SUB_SECOND_RATE_THRESHOLD)
+
+    def test_override_file_parsed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            ep = cwd / ".episteme"
+            ep.mkdir()
+            (ep / "cognitive_budget_thresholds").write_text(
+                "window=50\np50=2.0\nsub_second_rate=0.3\n"
+            )
+            window, p50, rate = cb.load_thresholds(cwd)
+            self.assertEqual(window, 50)
+            self.assertEqual(p50, 2.0)
+            self.assertEqual(rate, 0.3)
+
+    def test_malformed_falls_back(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            ep = cwd / ".episteme"
+            ep.mkdir()
+            (ep / "cognitive_budget_thresholds").write_text("not parseable\n")
+            window, p50, rate = cb.load_thresholds(cwd)
+            self.assertEqual(window, cb.DEFAULT_WINDOW)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

CP-OPERATOR-COGNITIVE-BUDGET-01 first slice — closes the last main v1.1 CP and provides the executable substrate for D11 (Operator Fatigue Guardrails) named in the v1.1 spec at Event 56.

## What ships

- **New module** \`src/episteme/_cognitive_budget.py\`: chain-anchored \`approval_times.jsonl\` stream + \`record_approval\` / \`walk_approvals\` / \`list_blueprints_with_history\` / \`detect_fatigue\` / \`summarize\` / \`verify_chain\`. Validation discipline mirrors \`_profile_history\` (Event 82): blueprint enum-strict, op_class enum-strict, elapsed_seconds ≥ 0 (bool rejected), reason ≥ 15 chars + lazy-token rejection (EN+KR).
- **D11 fatigue detector** — flags \`attention_bottleneck\` when rolling p50 < 1.5s OR sub_second_rate > 0.5 over last 20 observations. Both triggers evaluated independently. Per-project threshold override at \`<cwd>/.episteme/cognitive_budget_thresholds\`.
- **New CLI** \`episteme cognitive-budget\` with \`--list / --summary / --check / --record / --tail / --window / --blueprint / --op-class / --elapsed-seconds / --reason\`. Mirrors \`episteme history axis\` shape.
- **chain verify integration** — new \`approval_times\` stream surfaces in \`episteme chain verify\` alongside profile_history / policy_history / etc.

## Tests

**43/43 new tests + full suite 745/745 + 21 subtests green** (was 702 before this Event).

Validation x4 axes, record round-trip, walk + filter (blueprint, op_class, limit), \`list_blueprints_with_history\`, \`detect_fatigue\` threshold paths (empty / p50-fires / slow-no-fire / sub-second-rate-fires / invalid args), \`summarize\` stats shape, chain integrity across writes, threshold-override file parsing.

## Deferred-by-design

Matches Event 82 / 83 / 85 first-slice pattern:
- **Auto-instrumentation hooks** (PreToolUse marker + PostToolUse record + adapters/claude.py registration) deferred to a follow-up Event. Operators record observations manually via the CLI until then.
- **Hot-path consumer integration** (advisory surfacing in derived_knobs.py + Phase 12 audit extension distinguishing cost-exceeded-benefit from discipline-failure) deferred to v1.1.1+.

## v1.1 cycle status post-Event-88

**10 of 10 main v1.1 CPs first-sliced** (was 9/9 after Event 87 merge wave). Last main CP is now closed; release-please PR #44 (v1.1.0-rc1) ready to bundle the full v1.1 main work into a single rc1 cut.

## Test plan

- [x] \`pytest tests/test_cognitive_budget.py -xvs\` → 43/43 pass
- [x] \`pytest tests/\` → 745/745 + 21 subtests pass
- [x] CLI smoke: \`episteme cognitive-budget --record h_smoke --blueprint fence_reconstruction --op-class edit --elapsed-seconds 0.5 --reason "..."\` → wrote envelope, hash returned
- [x] CLI smoke: \`episteme cognitive-budget --summary\` → renders stats + fatigue signal correctly
- [x] \`episteme chain verify\` → new \`approval_times\` stream INTACT alongside others
- [ ] Operator-side review of D11 thresholds vs lived-behavior expectations

## Spec

\`~/episteme-private/docs/cp-v1.1-architectural.md\` § CP-OPERATOR-COGNITIVE-BUDGET-01