### PR TITLE
Event 90 · v1.1.0-rc1 audit + COMMANDS.md backfill (post-release hygiene)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -48,8 +48,11 @@ Scope key:
 | Command | Scope | What it does |
 |---|---|---|
 | `episteme kernel {verify,update}` | framework | Kernel integrity manifest — verify working tree against `kernel/MANIFEST.sha256`, or regenerate it. |
-| `episteme chain {verify,reset,upgrade}` | framework | Pillar 2 hash-chain operations over the framework's synthesized protocols. |
+| `episteme chain {verify,reset,upgrade,recover}` | framework | Pillar 2 hash-chain operations over framework + reflective streams. `recover` covers reset / selective / migrate modes (CP-CHAIN-RECOVERY-PROTOCOL-01). |
 | `episteme guide [--deferred]` | framework | List synthesized framework protocols and (with `--deferred`) open deferred discoveries. |
+| `episteme history {axis,policy,protocol}` | framework | Walk Cognitive Arm A supersede-with-history streams: profile axis trajectories (Event 82), policy section changes (Event 83), synthesized-protocol supersede chains (Event 84). |
+| `episteme cognitive-budget {--summary,--check,--record,--list,--tail}` | framework | Inspect operator approval-time observations + D11 fatigue signal (Event 88, Cognitive Arm A). |
+| `episteme profile {show,audit,override,survey,infer,hybrid,gap}` | framework | Profile inspection + Phase 12 audit + per-project override (Event 85, CP-CONTEXT-AWARE-PROFILE-OVERRIDE-01). `audit ack <audit-id>` acknowledges a drift verdict (Event 78). |
 | `episteme inject` | framework | Deploy cognitive enforcement to any directory in one command. |
 | `episteme log` | framework | Show audit log of reasoning-surface checks (passed / advisory / blocked). |
 | `episteme review` | framework | Review sampled Layer 8 spot-check entries (operator verdicts). |


### PR DESCRIPTION
## Summary

Post-rc1 audit found COMMANDS.md was missing the v1.1 commands shipped across Events 78, 80, 82, 83, 84, 85, 88. The cheatsheet is referenced from the CLI epilog and README quick-start — the gap was operator-visible.

## What lands

- \`episteme history {axis,policy,protocol}\` (Events 82, 83, 84)
- \`episteme cognitive-budget {--summary,--check,--record,--list,--tail}\` (Event 88)
- \`episteme profile {show,audit,override,survey,infer,hybrid,gap}\` — including \`audit ack\` (Event 78) and \`override\` (Event 85)
- \`episteme chain {verify,reset,upgrade,recover}\` — gains \`recover\` mode (Event 80)

## Audit findings (out-of-scope of this PR — informational)

End-to-end smoke audit of all 6 v1.1 surfaces (Events 81-88) **passes** mechanically:
- profile_history (Event 82): record + walk + verify ✅
- policy_history (Event 83): record + walk + verify ✅
- protocols supersede-with-history (Event 84): write + walk_supersede_chains + filter ✅
- cognitive_budget (Event 88): record + walk + detect_fatigue + verify ✅
- profile_override (Event 85): write + read + resolve ✅
- guidance ranking (Event 86): query_top_k ✅

**Live state:** all 4 Cognitive Arm A streams \`profile_history\` / \`policy_history\` / \`protocols\` / \`approval_times\` are INTACT but entries=0 — expected because auto-instrumentation is deferred-by-design across Events 82/83/84/88. Operators record manually via CLI until the auto-instrumentation Events ship.

**Operational hygiene** (already executed, not in PR): cleaned up 38 stale \`fence_pending\` markers from pytest temp dirs in \`~/.episteme/state/fence_pending/\`. The 1 real marker from the operator's Desktop project preserved.

## Test plan

- [x] \`pytest tests/\` → 745/745 + 21 subtests pass
- [x] All live CLIs (\`episteme history axis/policy --list\`, \`episteme cognitive-budget --list/--check\`, \`episteme guide\`) tested — graceful empty state
- [x] \`episteme chain verify\` → 8 streams INTACT (protocols / deferred_discoveries / pending_contracts / pending_contracts_archive / profile_audit_acks / profile_history / policy_history / approval_times)