### PR TITLE
Event 93 — release-please pre-release config fix (rc1→rc2 instead of minor-bumping)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,7 +27,8 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false,
+      "prerelease": true,
+      "prerelease-type": "rc",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Closes [#48](https://github.com/junjslee/episteme/pull/48) (closed unmerged). Fixes the version-bump path so the release-please bot increments the rc counter (\`1.1.0-rc1 → 1.1.0-rc2 → 1.1.0-rc3\`) on subsequent \`feat:\` commits instead of minor-bumping past the planned v1.1.0 GA milestone (which is what produced the now-closed \`1.2.0-rc1\` proposal).

## Root cause

\`release-please-config.json\` had \`"prerelease": false\`. With that setting, release-please's \`feat:\`-triggers-minor-bump rule applies regardless of whether the current version carries an \`-rc\` suffix. Result: any \`feat:\` commit lands → version jumps to next minor + keeps the rc label → \`1.1.0-rc1\` → \`1.2.0-rc1\`. The v1.1.0 GA milestone gets skipped silently.

## Fix

\`\`\`diff
-      "prerelease": false,
+      "prerelease": true,
+      "prerelease-type": "rc",
\`\`\`

\`prerelease: true\` toggles release-please into pre-release mode; \`prerelease-type: "rc"\` pins the prerelease label to \`rc\` (vs \`alpha\` / \`beta\` / etc). In this mode, \`feat:\` commits increment the rc counter rather than the minor version.

## Exiting prerelease mode (operator action when ready for GA)

When the operator decides v1.1.0 is ready for GA, two equivalent options:

1. Edit \`.release-please-manifest.json\` from \`"1.1.0-rc<N>"\` → \`"1.1.0"\`
2. Add \`"release-as": "1.1.0"\` to \`release-please-config.json\` (single-shot override)

Either causes the next release-please run to drop the \`-rc\` suffix.

## Test plan

- [ ] Merge this PR → release-please workflow re-fires on master push
- [ ] Verify the regenerated release PR proposes \`1.1.0-rc2\` (not \`1.2.0-rc1\`)
- [ ] CHANGELOG entry under \`[1.1.0-rc2]\` lists the post-rc1 features (Event 91 + Event 92)
- [ ] No code change, so existing test suite (766/766 + 21) untouched — verify CI still green

## Soak invariant

Zero touches under \`kernel/\`, \`src/episteme/\`, \`tests/\`, \`core/hooks/\`, \`templates/\`, \`labs/\`. Config-only.