### PR TITLE
Event 96 — Adapter Portability Audit + canonical event schema (design-only)

### DIFF
--- a/core/hooks/_event_translation.py
+++ b/core/hooks/_event_translation.py
@@ -1,0 +1,525 @@
+"""Canonical event schema for cross-adapter portability — Event 96 design stub.
+
+DESIGN-ONLY. This module defines the interface every adapter will satisfy
+once the migration sequenced in `docs/ADAPTER_PORTABILITY.md` ships. It
+contains:
+
+  * Lifecycle / ToolKind / Decision enums
+  * CanonicalEvent + ShellExecInput / FileWriteInput / FileEditInput payloads
+  * HostAdapter Protocol — the interface every adapter implements
+  * `claude_payload_to_canonical()` reference implementation (the only host
+    currently translated; serves as the worked example for new adapters)
+
+NO HOOKS IMPORT THIS MODULE TODAY. Existing hooks operate directly on Claude-
+shaped payloads (per Phase 0 reality documented in
+`docs/ADAPTER_PORTABILITY.md` § 3). Phase 3+ of the migration migrates one
+hook at a time to consume CanonicalEvent instead.
+
+Importing this module costs nothing — no runtime side effects, no I/O, no
+process spawning. It is a vocabulary, not a runtime.
+
+The canonical schema is versioned. Today: v1. Schema changes that break
+canonical-event consumers are governance events (per kernel Evolution
+Contract); minor additions are not.
+
+See also:
+  * `docs/ADAPTER_PORTABILITY.md` — the audit that motivated this module
+  * `core/schemas/canonical-event.json` — JSON schema mirror for cross-language adapters (TODO Phase 1)
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional, Protocol, Union, runtime_checkable
+
+
+SCHEMA_VERSION = "canonical-event/v1"
+
+
+# ── Enums ───────────────────────────────────────────────────────────────────
+
+
+class Lifecycle(str, Enum):
+    """When in the host's tool-call lifecycle the event fires.
+
+    Mapping to host-specific event names is the adapter's responsibility.
+    Hosts that lack an equivalent for a given lifecycle phase MUST declare
+    it as unsupported in `HostAdapter.supported_lifecycles()`; hooks that
+    depend on the absent phase degrade to no-op or advisory on that host.
+    """
+
+    INTENT_TO_EXECUTE = "intent_to_execute"
+    """Host is about to invoke a tool. Hooks may BLOCK by returning DENY."""
+
+    EXECUTION_COMPLETED = "execution_completed"
+    """Host has finished invoking a tool. Hooks observe outcome (calibration,
+    state tracking, telemetry). Cannot block — already executed."""
+
+    SESSION_OPENED = "session_opened"
+    """Host opens a new agent session. Hooks may print context banners,
+    seed state, etc."""
+
+    SESSION_CLOSED = "session_closed"
+    """Host closes a session. Hooks may run final QA gates (tests pass?),
+    persist state, perform handoff snapshots."""
+
+    CONTEXT_COMPACTING = "context_compacting"
+    """Host is about to compact long-running session context. Hooks may
+    snapshot transcripts before loss."""
+
+    PERMISSION_REQUESTED = "permission_requested"
+    """Host is requesting permission for an op the operator has not
+    pre-authorized. Hooks may auto-allow / deny / forward."""
+
+
+class ToolKind(str, Enum):
+    """What kind of tool the host is invoking.
+
+    Hosts use different vocabularies (Claude: 'Bash' / 'Write' / 'Edit' /
+    'MultiEdit'; Cursor: 'run_terminal_cmd' / 'edit_file'; Codex: function-
+    call by name; ...). The adapter maps host vocabulary → ToolKind.
+
+    `OTHER` is the fallback for tool kinds the canonical schema does not
+    yet cover. Hooks that specialize on a specific ToolKind will skip
+    `OTHER` events; hooks that operate on all events will see them.
+    """
+
+    SHELL_EXEC = "shell_exec"
+    """Execute a shell command. Equivalent to Claude's 'Bash'."""
+
+    FILE_WRITE = "file_write"
+    """Write a new file. Equivalent to Claude's 'Write'."""
+
+    FILE_EDIT = "file_edit"
+    """Edit an existing file (single edit). Equivalent to Claude's 'Edit'."""
+
+    FILE_MULTI_EDIT = "file_multi_edit"
+    """Multiple edits to the same file in one call. Equivalent to Claude's
+    'MultiEdit'."""
+
+    FILE_READ = "file_read"
+    """Read a file (rarely intercepted; reads are usually low-impact)."""
+
+    NETWORK_FETCH = "network_fetch"
+    """Network call (HTTP, MCP server, etc.). Often intercepted for
+    egress policy."""
+
+    AGENT_TASK = "agent_task"
+    """Spawn a sub-agent / dispatch to another agent. Equivalent to
+    Claude's 'Task' / 'Agent'."""
+
+    OTHER = "other"
+    """Tool kind not yet in the canonical vocabulary. Adapter should still
+    set `host_tool_name` so hooks can disambiguate if needed."""
+
+
+class Decision(str, Enum):
+    """Hook decision returned to the adapter.
+
+    The adapter translates Decision back to its host's expected return
+    code / response shape (Claude: exit 0 = ALLOW, exit 2 = DENY; other
+    hosts may use different signals).
+    """
+
+    ALLOW = "allow"
+    """Op proceeds. Hook may have written advisory to stderr."""
+
+    DENY = "deny"
+    """Op is blocked. Hook MUST emit operator-visible reason on stderr."""
+
+    ADVISORY = "advisory"
+    """Op proceeds but hook emitted advisory message. Equivalent to ALLOW
+    for hosts that don't distinguish; hosts that surface advisory text
+    differently can use this signal."""
+
+    NO_OP = "no_op"
+    """Hook did nothing meaningful (event not relevant to this hook).
+    Equivalent to ALLOW from the host's perspective."""
+
+
+# ── Payload variants ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ShellExecInput:
+    """Canonical input for ToolKind.SHELL_EXEC events."""
+
+    command_text: str
+    """The shell command, normalized to a single string. Adapter is
+    responsible for joining argv lists, dequoting, etc."""
+
+    description: Optional[str] = None
+    """Optional human-facing description of the command (Claude provides
+    this; other hosts may not)."""
+
+
+@dataclass(frozen=True)
+class FileWriteInput:
+    """Canonical input for ToolKind.FILE_WRITE events."""
+
+    target_path: str
+    """Absolute or cwd-relative path of the file being written."""
+
+    content: Optional[str] = None
+    """File content if available at hook-time. Adapters MAY omit this
+    for size reasons; hooks that need content must handle absence."""
+
+
+@dataclass(frozen=True)
+class FileEditInput:
+    """Canonical input for ToolKind.FILE_EDIT events."""
+
+    target_path: str
+    old_text: Optional[str] = None
+    new_text: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class GenericInput:
+    """Catch-all input for ToolKind.OTHER and tool kinds not yet modeled.
+
+    The full host-shaped tool input is preserved under `host_payload` so
+    hooks that need host-specific fields can still access them, while
+    portable hooks operate on canonical fields only.
+    """
+
+    host_payload: dict
+    """The original host tool_input dict, unmodified."""
+
+
+ToolInput = Union[
+    ShellExecInput,
+    FileWriteInput,
+    FileEditInput,
+    GenericInput,
+]
+
+
+# ── Tool response (for EXECUTION_COMPLETED events) ──────────────────────────
+
+
+@dataclass(frozen=True)
+class ToolResponse:
+    """Canonical response shape for EXECUTION_COMPLETED events.
+
+    Hosts disagree wildly on response field names — the audit
+    documented Claude's `returnCodeInterpretation` + `interrupted` shape,
+    Gemini's `isError` bool, conventional `exit_code`, etc. The adapter
+    MUST translate to this canonical shape:
+    """
+
+    exit_code: Optional[int]
+    """Numeric exit code if available; None if host doesn't surface one
+    (in which case `status` is the load-bearing signal)."""
+
+    status: str
+    """One of: 'success', 'error', 'unknown'. Always populated."""
+
+    stdout: Optional[str] = None
+    stderr: Optional[str] = None
+    interrupted: bool = False
+
+
+# ── The canonical event ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CanonicalEvent:
+    """The single shape every hook consumes after Phase 4 of the migration.
+
+    Today no hook reads CanonicalEvent — Phase 3+ migrate them one at a
+    time. This dataclass is the migration target.
+    """
+
+    schema_version: str
+    """Always SCHEMA_VERSION (`canonical-event/v1`) for events emitted by
+    this module. Future schema versions live alongside; consumers SHOULD
+    check version compatibility."""
+
+    lifecycle: Lifecycle
+    tool_kind: ToolKind
+    cwd: str
+    correlation_id: str
+    """Stable id for joining INTENT_TO_EXECUTE ↔ EXECUTION_COMPLETED
+    events for the same op. Hosts that don't provide one: adapter MUST
+    synthesize via SHA-1 over (timestamp, cwd, command_text) so paired
+    hooks produce the same id."""
+
+    tool_input: ToolInput
+    """Type-narrowed input. Hooks that specialize on a ToolKind can rely
+    on the matching dataclass shape."""
+
+    tool_response: Optional[ToolResponse] = None
+    """Populated only for EXECUTION_COMPLETED; None for other lifecycles."""
+
+    host_tool_name: Optional[str] = None
+    """The original host vocabulary tool name (e.g. 'Bash', 'run_terminal_cmd').
+    Hooks SHOULD prefer ToolKind enum; this field is for debugging /
+    advisory text / host-specific fallbacks."""
+
+    host_metadata: dict = field(default_factory=dict)
+    """Adapter escape hatch — anything host-specific that may matter to a
+    hook but isn't canonical. Use sparingly; prefer extending the schema
+    when a field becomes load-bearing across multiple hosts."""
+
+
+# ── HostAdapter Protocol ────────────────────────────────────────────────────
+
+
+@runtime_checkable
+class HostAdapter(Protocol):
+    """The interface every adapter implements.
+
+    Implementations live under `adapters/<host_name>/` and are wired into
+    `episteme sync` so the right adapter is invoked when registering
+    hooks for a given host.
+    """
+
+    name: str
+    """Stable identifier — `'claude'`, `'cursor'`, `'hermes'`, etc."""
+
+    def supported_lifecycles(self) -> set[Lifecycle]:
+        """Lifecycles this host can fire. Hooks that depend on absent
+        lifecycles will be registered as no-op on this host."""
+        ...
+
+    def supported_tool_kinds(self) -> set[ToolKind]:
+        """Tool kinds this host distinguishes. Hosts that only have
+        coarse-grained tool calls may map all to OTHER."""
+        ...
+
+    def to_canonical(self, host_payload: dict) -> CanonicalEvent:
+        """Translate a host-shaped JSON payload into a CanonicalEvent.
+
+        MUST NOT raise for malformed payloads — adapter should return a
+        best-effort event with `tool_kind = OTHER` and
+        `host_metadata['translation_warning']` populated.
+        """
+        ...
+
+    def from_decision(self, decision: Decision) -> int:
+        """Translate a hook Decision back to the host's expected exit
+        code. Default convention: ALLOW = 0, DENY = 2, ADVISORY = 0,
+        NO_OP = 0. Hosts with different conventions override this."""
+        ...
+
+    def install_hooks(
+        self,
+        hooks_dir: str,
+        registration_target: Optional[str] = None,
+    ) -> None:
+        """Register the kernel's hook scripts with the host's hook
+        mechanism. Adapter-specific: Claude writes ~/.claude/settings.json;
+        Cursor writes workspace rules; Hermes writes config.yaml; etc."""
+        ...
+
+
+# ── Reference implementation: Claude payload → CanonicalEvent ───────────────
+
+
+_CLAUDE_TOOL_KIND_MAP: dict[str, ToolKind] = {
+    "Bash": ToolKind.SHELL_EXEC,
+    "Write": ToolKind.FILE_WRITE,
+    "Edit": ToolKind.FILE_EDIT,
+    "MultiEdit": ToolKind.FILE_MULTI_EDIT,
+    "Read": ToolKind.FILE_READ,
+    "WebFetch": ToolKind.NETWORK_FETCH,
+    "WebSearch": ToolKind.NETWORK_FETCH,
+    "Task": ToolKind.AGENT_TASK,
+    "Agent": ToolKind.AGENT_TASK,
+}
+
+_CLAUDE_LIFECYCLE_MAP: dict[str, Lifecycle] = {
+    # Claude's hook event names. Set by the adapter when registering
+    # hooks; included in the payload only on some Claude versions.
+    "PreToolUse": Lifecycle.INTENT_TO_EXECUTE,
+    "PostToolUse": Lifecycle.EXECUTION_COMPLETED,
+    "SessionStart": Lifecycle.SESSION_OPENED,
+    "Stop": Lifecycle.SESSION_CLOSED,
+    "SubagentStop": Lifecycle.SESSION_CLOSED,
+    "PreCompact": Lifecycle.CONTEXT_COMPACTING,
+    "PermissionRequest": Lifecycle.PERMISSION_REQUESTED,
+}
+
+
+def claude_payload_to_canonical(
+    payload: dict,
+    *,
+    lifecycle_hint: Optional[Lifecycle] = None,
+) -> CanonicalEvent:
+    """Reference translation: Claude Code stdin payload → CanonicalEvent.
+
+    Lifecycle resolution order:
+      1. If `payload['hook_event_name']` is present and known, use the
+         `_CLAUDE_LIFECYCLE_MAP` mapping (some Claude Code versions
+         include the event name on the payload itself).
+      2. Otherwise use `lifecycle_hint` (the lifecycle the hook is wired
+         to via settings.json — the adapter knows because it registered
+         the hook for that specific event).
+      3. Default to `Lifecycle.INTENT_TO_EXECUTE`.
+
+    This function is illustrative — in the migration's Phase 2 it becomes
+    the only place Claude's payload shape is referenced; every hook
+    consumes the resulting CanonicalEvent.
+    """
+    lifecycle = (
+        _CLAUDE_LIFECYCLE_MAP.get(
+            str(payload.get("hook_event_name") or payload.get("hookEventName") or "")
+        )
+        or lifecycle_hint
+        or Lifecycle.INTENT_TO_EXECUTE
+    )
+    host_tool_name = (
+        payload.get("tool_name") or payload.get("toolName") or ""
+    ).strip()
+    tool_kind = _CLAUDE_TOOL_KIND_MAP.get(host_tool_name, ToolKind.OTHER)
+
+    raw_input = payload.get("tool_input") or payload.get("toolInput") or {}
+    if not isinstance(raw_input, dict):
+        raw_input = {}
+
+    if tool_kind is ToolKind.SHELL_EXEC:
+        tool_input: ToolInput = ShellExecInput(
+            command_text=str(
+                raw_input.get("command")
+                or raw_input.get("cmd")
+                or raw_input.get("bash_command")
+                or ""
+            ),
+            description=raw_input.get("description"),
+        )
+    elif tool_kind is ToolKind.FILE_WRITE:
+        tool_input = FileWriteInput(
+            target_path=str(
+                raw_input.get("file_path")
+                or raw_input.get("path")
+                or raw_input.get("target_file")
+                or ""
+            ),
+            content=raw_input.get("content"),
+        )
+    elif tool_kind is ToolKind.FILE_EDIT:
+        tool_input = FileEditInput(
+            target_path=str(
+                raw_input.get("file_path")
+                or raw_input.get("path")
+                or raw_input.get("target_file")
+                or ""
+            ),
+            old_text=raw_input.get("old_string"),
+            new_text=raw_input.get("new_string"),
+        )
+    else:
+        tool_input = GenericInput(host_payload=dict(raw_input))
+
+    response_data = payload.get("tool_response") or payload.get("toolResponse")
+    response: Optional[ToolResponse] = None
+    if isinstance(response_data, dict):
+        response = _claude_response_to_canonical(response_data)
+
+    correlation_id = (
+        payload.get("tool_use_id")
+        or payload.get("toolUseId")
+        or payload.get("request_id")
+        or _synthesize_correlation_id(payload, tool_input)
+    )
+
+    return CanonicalEvent(
+        schema_version=SCHEMA_VERSION,
+        lifecycle=lifecycle,
+        tool_kind=tool_kind,
+        cwd=str(payload.get("cwd") or ""),
+        correlation_id=str(correlation_id),
+        tool_input=tool_input,
+        tool_response=response,
+        host_tool_name=host_tool_name or None,
+        host_metadata={
+            "host": "claude",
+            "raw_payload_keys": sorted(payload.keys()),
+        },
+    )
+
+
+def _claude_response_to_canonical(resp: dict) -> ToolResponse:
+    """Translate Claude's tool_response shape to canonical.
+
+    Mirrors `core/hooks/calibration_telemetry.py` extraction logic. Once
+    Phase 3 lands and that hook consumes CanonicalEvent, the extraction
+    code unifies here and that hook becomes a thin caller.
+    """
+    exit_code: Optional[int] = None
+    for key in ("exit_code", "exitCode", "returncode", "return_code", "status_code"):
+        v = resp.get(key)
+        if isinstance(v, int):
+            exit_code = v
+            break
+
+    if exit_code is None:
+        for bool_key in ("isError", "is_error"):
+            if bool_key in resp and isinstance(resp[bool_key], bool):
+                exit_code = 1 if resp[bool_key] else 0
+                break
+
+    interrupted = bool(resp.get("interrupted", False))
+    if exit_code is None and interrupted:
+        exit_code = 130  # SIGINT convention
+
+    rci = resp.get("returnCodeInterpretation")
+    if exit_code is None and ("returnCodeInterpretation" in resp or "isImage" in resp):
+        if rci is None or (isinstance(rci, str) and not rci.strip()):
+            exit_code = 0
+        elif isinstance(rci, str):
+            import re as _re
+            m = _re.search(r"exit\s+code\s+(-?\d+)", rci, _re.IGNORECASE)
+            exit_code = int(m.group(1)) if m else 1
+
+    if exit_code is None:
+        status = "unknown"
+    elif exit_code == 0:
+        status = "success"
+    else:
+        status = "error"
+
+    return ToolResponse(
+        exit_code=exit_code,
+        status=status,
+        stdout=resp.get("stdout"),
+        stderr=resp.get("stderr"),
+        interrupted=interrupted,
+    )
+
+
+def _synthesize_correlation_id(payload: dict, tool_input: ToolInput) -> str:
+    """When the host doesn't provide a correlation id, synthesize one.
+
+    Mirrors the SHA-1 fallback in `calibration_telemetry.py`.
+    """
+    import hashlib
+    import time
+
+    cwd = str(payload.get("cwd") or "")
+    bucket = str(int(time.time()))
+    if isinstance(tool_input, ShellExecInput):
+        seed = f"{bucket}|{cwd}|{tool_input.command_text}"
+    elif isinstance(tool_input, (FileWriteInput, FileEditInput)):
+        seed = f"{bucket}|{cwd}|{tool_input.target_path}"
+    else:
+        seed = f"{bucket}|{cwd}|other"
+    return "h_" + hashlib.sha1(seed.encode("utf-8", errors="replace")).hexdigest()[:16]
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "Lifecycle",
+    "ToolKind",
+    "Decision",
+    "ShellExecInput",
+    "FileWriteInput",
+    "FileEditInput",
+    "GenericInput",
+    "ToolInput",
+    "ToolResponse",
+    "CanonicalEvent",
+    "HostAdapter",
+    "claude_payload_to_canonical",
+]

--- a/docs/ADAPTER_PORTABILITY.md
+++ b/docs/ADAPTER_PORTABILITY.md
@@ -1,0 +1,336 @@
+# Adapter Portability Audit
+
+**Status**: `audit (Event 96, 2026-04-30)` — read-only inventory + migration design. No runtime changes proposed in this document.
+
+**Author goal (verbatim, from operator directive)**: *"The true essence of our tool requires that this 'truth-seeking' is not locked to a single vendor. Analyze what it takes to make the kernel truly model-agnostic so it works perfectly outside of Claude Code."*
+
+This doc is the honest answer. It draws clear lines between what is genuinely portable today, what is aspirational, and what specifically needs to land before a second adapter can be wired with parity.
+
+---
+
+## 1. Executive summary — what is honestly model-agnostic today
+
+| Layer | Portability | Reality |
+|---|---|---|
+| **Kernel constitution** (`kernel/*.md`) | Truly portable | Pure markdown. Travels to any host. Reads correctly under any runtime. |
+| **Schemas** (`core/schemas/*.json`) | Truly portable | JSON schemas; tool-neutral. Memory Contract v1, Evolution Contract v1, blueprint contracts all schema-defined. |
+| **Blueprints** (`core/blueprints/*.yaml`) | Truly portable | YAML; selector predicates are pure-data. |
+| **Operator profile** (`core/memory/global/*.md`) | Truly portable | Markdown identity layer; renders correctly under any runtime. |
+| **Hook *substrate*** (`core/hooks/_*.py` — 16 private modules) | Truly portable | Pure Python logic: chain integrity, scenario detection, blueprint validation, context-signature hashing, framework I/O. No host coupling. |
+| **Hook *entry points*** (`core/hooks/*.py` — 18 entry-point scripts) | **Partially portable** | Stdin-JSON contract works on any host. BUT: tool-name strings (`"Bash"`, `"Write"`, `"Edit"`, `"MultiEdit"`), tool-input schema keys (`.command`, `.file_path`), and tool-response schema keys (`.returnCodeInterpretation`, `.interrupted`) are **Claude-Code-shaped**. Hooks already handle camelCase ⇄ snake_case duality, but the canonical tool-name vocabulary is Claude's. |
+| **Adapter directory** (`adapters/{claude,hermes}/`) | **Aspirational** | Only `README.md` files exist in each. **No adapter code is written.** The "Claude adapter" is implemented entirely as a side-effect of `episteme sync` writing `~/.claude/settings.json`. |
+| **Other adapter targets** (`adapters/{codex,opencode,omo,omx,cursor,...}`) | **Does not exist** | Documented as targets in `docs/LAYER_MODEL.md` § *Tool Adapters*; **no directory, no README, no code**. |
+
+### One-line honest claim
+
+> *"The kernel is markdown-portable. The hook layer is Claude-tool-shaped. The adapter layer is one-of-five-or-more — only Claude is wired. Outside Claude Code today, the kernel still governs identity (markdown survives), but it does not enforce the Reasoning Surface — because the enforcement mechanism (hooks + canonical event interception) only exists for Claude."*
+
+That is what *model-agnostic* means today. Anything stronger is aspiration the audit found unfunded.
+
+---
+
+## 2. Adapter directory inventory
+
+### `adapters/claude/`
+- **Files**: `README.md` (2.6 KB) only.
+- **Adapter implementation**: indirect — happens inside `episteme sync` (Python CLI), which writes `~/.claude/CLAUDE.md`, `~/.claude/settings.json`, `~/.claude/agents/*`, `~/.claude/skills/*`, and per-project `<repo>/.claude/settings.json`.
+- **Hook registration mechanism**: `~/.claude/settings.json` references `core/hooks/*.py` by absolute path with the host runtime's Python (`sys.executable`). Hooks are spawned as subprocesses by Claude Code on each event firing.
+- **Verdict**: Load-bearing reference adapter. Documented well; not isolated as code in `adapters/claude/`.
+
+### `adapters/hermes/`
+- **Files**: `README.md` (3.1 KB) only.
+- **Adapter implementation**: indirect — `episteme sync` writes `~/.hermes/OPERATOR.md` and `~/.hermes/skills/*`. **No hooks are installed.** README explicitly says: *"Claude Code hooks are Claude-specific — they don't transfer to Hermes. To replicate safety behavior in Hermes, configure its built-in command approval system in `config.yaml`."*
+- **Verdict**: Identity-and-skills sync only. Does NOT carry hook-level enforcement. The kernel's *governance authority* travels (markdown); the kernel's *enforcement* does not.
+
+### `adapters/{codex,opencode,omo,omx,cursor,...}`
+- **Status**: Do not exist on disk. Documented as targets in `docs/LAYER_MODEL.md` § 4 (Tool Adapters), described as adapters that consume the cognitive contract via `AGENTS.md` (Codex, opencode) or governance subagent (opencode), or shared skills/personas (OMO/OMX).
+- **Verdict**: Aspirational. No adapter code; no hook installation; no enforcement.
+
+### Coverage matrix today
+
+| Adapter | Markdown identity sync | Skills sync | Hook enforcement | Adapter code |
+|---|:-:|:-:|:-:|:-:|
+| Claude Code | ✓ | ✓ | ✓ | indirect (in `episteme sync`) |
+| Hermes | ✓ | ✓ | ✗ | indirect (in `episteme sync`) |
+| Codex | partial (`AGENTS.md`) | partial | ✗ | none |
+| opencode | partial (`AGENTS.md`) | partial | ✗ | none |
+| OMO / OMX | partial | partial | ✗ | none |
+| Cursor / Continue / Cody / etc. | not addressed | not addressed | ✗ | none |
+
+**Hook enforcement parity = 1 of 5+ targets.** The "model-agnostic" claim cannot be defended at the enforcement layer until this column has at least one more `✓`.
+
+---
+
+## 3. Hook coupling analysis — every Claude-specific assumption found
+
+The hooks live in `core/hooks/`. There are 18 entry-point scripts and 16 private substrate modules. The substrate modules are pure logic — no host coupling. The entry-point scripts contain all the host-shape coupling. Below is the catalog.
+
+### 3.1 Tool-name vocabulary (Claude-specific)
+
+**Where it appears**: `block_dangerous.py`, `state_tracker.py`, `calibration_telemetry.py`, `episodic_writer.py`, `fence_synthesis.py`, `reasoning_surface_guard.py`, `format.py`, `test_runner.py`, `prompt_guard.py`, `workflow_guard.py`, `context_guard.py`.
+
+**The pattern**:
+```python
+tool = _tool_name(payload)   # reads payload['tool_name'] or payload['toolName']
+if tool in {"Write", "Edit", "MultiEdit"}: ...
+elif tool == "Bash": ...
+```
+
+**Coupling severity**: **High**. These tool names are Claude Code's vocabulary. Cursor uses `run_terminal_cmd` / `edit_file`. Codex uses different internal names. OpenAI's function-calling uses arbitrary user-defined names. Without an adapter-level translation layer, hooks cannot identify the tool kind on a non-Claude host.
+
+**Required to fix**: Replace magic strings with a `ToolKind` enum (e.g. `SHELL_EXEC`, `FILE_WRITE`, `FILE_EDIT`, `FILE_MULTI_EDIT`). Adapters translate their host's tool names → `ToolKind` before invoking the hook.
+
+### 3.2 Tool-input schema (Claude-specific)
+
+**Where it appears**: every Bash-handling hook reads `tool_input.command` or `.cmd` or `.bash_command`. Every Write/Edit-handling hook reads `tool_input.file_path` or `.path` or `.target_file`.
+
+**The pattern**:
+```python
+ti = _tool_input(payload)
+cmd = str(ti.get("command") or ti.get("cmd") or ti.get("bash_command") or "")
+fp = ti.get("file_path") or ti.get("path") or ti.get("target_file")
+```
+
+**Coupling severity**: **Medium-low**. The `or`-fallback chains already accept a small dialect range. But the universe of valid keys is enumerated by Claude's schema; new hosts with different keys (e.g., Cursor's `args.command`) require additional fallbacks. This pattern is fragile by accumulation.
+
+**Required to fix**: Canonical input schema with named fields (`shell_exec.command_text`, `file_write.target_path`). Adapters translate host schema → canonical.
+
+### 3.3 Tool-response schema (Claude-specific, partial Gemini fallback)
+
+**Where it appears**: `calibration_telemetry.py` (lines 66-162). This is the most polyglot file in the codebase — it explicitly handles Claude Code's `returnCodeInterpretation` + `interrupted` shape, Gemini-CLI's `isError` boolean, and the more conventional `exit_code` / `returncode` numeric fields.
+
+**The pattern**:
+```python
+# Tries: exit_code, exitCode, returncode, return_code, status_code
+# Then: nested under metadata/meta
+# Then: isError/is_error bool mapping
+# Then: Claude's returnCodeInterpretation + interrupted pattern
+# Then: regex-extract from "exit code N" strings
+```
+
+**Coupling severity**: **Medium**. This is the most adapter-aware hook — it already encodes one runtime-dialect-and-a-half. But each new host (Cursor, Codex's tool-result format, etc.) needs another fallback chain branch.
+
+**Required to fix**: Canonical tool-response schema (`{exit_code: int, status: "success" | "error" | "unknown", stdout: str, stderr: str}`). Adapter translates host response → canonical.
+
+### 3.4 Hook event taxonomy (Claude-specific)
+
+**Where it appears**: Every entry-point hook implicitly knows which event it fires on (PreToolUse, PostToolUse, Stop, SessionStart, PreCompact, etc.). The wiring is in `~/.claude/settings.json` — hooks don't read the event name from the payload; they're invoked because the host fired the matching event.
+
+**The Claude event names**: `PreToolUse`, `PostToolUse`, `Stop`, `SessionStart`, `SubagentStop`, `PreCompact`, `PermissionRequest`.
+
+**Coupling severity**: **High**. Other hosts have completely different event taxonomies:
+- **Cursor**: pre/post completion hooks, file-change watchers — different lifecycle.
+- **Codex / opencode**: AGENTS.md-only — no hook system at all.
+- **OpenAI Assistants API**: function-call lifecycle — no PreToolUse/PostToolUse equivalent in the same shape.
+- **MCP servers**: tool-call lifecycle, but defined per server.
+
+**Required to fix**: Canonical event taxonomy:
+```
+INTENT_TO_EXECUTE       (≈ PreToolUse)
+EXECUTION_COMPLETED     (≈ PostToolUse)
+SESSION_OPENED          (≈ SessionStart)
+SESSION_CLOSED          (≈ Stop / SubagentStop)
+CONTEXT_COMPACTING      (≈ PreCompact)
+PERMISSION_REQUESTED    (≈ PermissionRequest)
+```
+
+Adapters bridge their host's lifecycle to the canonical taxonomy. Some hosts will not have all events — that is acceptable; the adapter declares which canonical events it supports, and hooks that depend on absent events degrade to advisory or no-op.
+
+### 3.5 Hook registration mechanism (Claude-specific)
+
+**Where it appears**: `episteme sync` writes `~/.claude/settings.json` with hook registrations. The format is Claude Code-specific — a JSON document with `hooks.{eventName}.commands` arrays referencing absolute paths to `core/hooks/*.py`.
+
+**Coupling severity**: **High** *but* this is **adapter responsibility**. Each adapter knows its host's hook registration mechanism (Claude: settings.json; Cursor: workspace rules; Hermes: config.yaml command-approval; Codex: not applicable). The registration code does not need to be portable; only the canonical event abstraction does.
+
+**Required to fix**: Per-adapter registration code, each writing the host's hook config in the host's format. The kernel provides the hook scripts; the adapter installs them.
+
+### 3.6 Working directory + payload shape (Claude convention)
+
+**Where it appears**: `payload.cwd` (Claude convention). `payload.tool_use_id` / `toolUseId` / `request_id` for correlation.
+
+**Coupling severity**: **Low**. These are common conventions; most hosts provide cwd in some form. Already polyglot via `or`-chains.
+
+**Required to fix**: Document canonical fields (`event.cwd`, `event.correlation_id`); adapters translate.
+
+### 3.7 Color/TTY assumptions in stderr formatting
+
+**Where it appears**: `reasoning_surface_guard.py` writes ANSI-colored advisory messages to stderr. Other hooks emit plain text.
+
+**Coupling severity**: **None for portability** — ANSI codes work on any modern terminal. This is not a coupling concern.
+
+---
+
+## 4. The honest claim audit
+
+### Claim: *"the kernel is model-agnostic"*
+
+**Honest version**: The kernel is markdown-portable; identity and policy travel to any runtime. The enforcement mechanism (hooks) is Claude-tool-shaped today. Other adapters carry the markdown but not the enforcement.
+
+### Claim: *"the kernel intercepts state mutation regardless of which external tool, MCP server, or agent framework generated the command"* (`docs/ARCHITECTURE.md` L22)
+
+**Honest version**: True *within Claude Code* (where the hook layer can intercept Bash / Write / Edit / MultiEdit calls regardless of what tool generated them). Not yet true *across runtimes* (a Bash command issued from Codex does not fire any episteme hook because Codex has no hook integration).
+
+### Claim: *"BYOS (Bring Your Own Skill)"*
+
+**Honest version**: True. The kernel does not provide skills; it intercepts state mutation. This claim is independent of adapter coverage — once a host is wired, BYOS holds for that host.
+
+### Claim: *"adapters are pluggable"*
+
+**Honest version**: Aspirational. The adapter abstraction exists in documentation (`docs/LAYER_MODEL.md` § 4) but not in code. Wiring a new adapter today requires reading the Claude implementation pattern out of `episteme sync` and re-implementing it for the new host — there is no adapter base class, no canonical event schema, no plug-in interface.
+
+---
+
+## 5. Per-target feasibility matrix
+
+| Target | Has equivalent hook lifecycle? | Has tool-call interception point? | Effort to wire (relative) | Blocker today |
+|---|:-:|:-:|:-:|---|
+| **Claude Code** (reference) | Yes — full lifecycle | Yes — PreToolUse | — | (already wired) |
+| **Cursor** | Yes — workspace rules + file watchers | Partial — chat-side rules; less granular than PreToolUse | **2× Claude effort** | No canonical event schema; tool name vocabulary differs |
+| **Hermes** | Yes — has hooks dir + command approval | Yes — config.yaml command approval | **3× Claude effort** | Different event taxonomy; needs canonical schema |
+| **Codex** | No — AGENTS.md is read-only context, no runtime hooks | No — Codex CLI has no PreToolUse equivalent | **5× Claude effort** | Would need a wrapper-CLI proxy that intercepts before passing through to Codex; substantial architecture work |
+| **opencode** | Subagent system, but no per-tool-call hook | No | **4× Claude effort** | Same as Codex — needs wrapper or LSP-shaped extension |
+| **OMO / OMX** | Skills sync only | No | N/A — identity layer only | Out of scope for hook enforcement |
+| **OpenAI Assistants API / MCP servers** | Function-call lifecycle, but server-side | Partial — could intercept at MCP layer | **6× Claude effort** | Would require an episteme MCP server that hosts the canonical event interface |
+| **GitHub Copilot / Continue / Cody / generic IDE** | None | None | **9× Claude effort** | Would require an editor extension or LSP wrapper |
+
+**Highest-leverage second adapter**: **Cursor**. Reasoning:
+- Has a hook-shaped abstraction (workspace rules + chat-side intercept).
+- Substantial user base overlap with Claude Code (developers using AI coding assistants).
+- Wiring Cursor proves the canonical-event design *across two hosts*, which validates the abstraction.
+
+**Most architecturally-revealing second adapter**: **Codex**. Wiring Codex (or any AGENTS.md-only host) forces the kernel to confront enforcement *outside* a hook lifecycle — the kernel must either build a wrapper proxy or downgrade enforcement to advisory-only. This pushes the design.
+
+---
+
+## 6. Migration design — canonical event schema
+
+### 6.1 The interface
+
+```
+host event           ↓                                  ↓ canonical event       ↓ hook decision
+─────────────────    adapter translation layer    ─────────────────────────    ────────────────
+{                                                  CanonicalEvent(
+  "tool_name":                                       lifecycle: INTENT_TO_EXECUTE,
+    "Bash",                                          tool_kind:  SHELL_EXEC,
+  "tool_input": {                                    cwd:         "/path",
+    "command":                                       correlation_id: "claude-call-123",
+      "git push"                                     payload: ShellExecInput(
+  },                                                   command_text: "git push"
+  "cwd": "/path",                                    ),
+  "tool_use_id":                                     host_metadata: { … }
+    "claude-call-123"                              )
+}
+```
+
+### 6.2 Three layers, one decoupling
+
+```
++------------------------------------------------------------+
+| Adapter (per-host)                                          |
+|   - Translate host events → CanonicalEvent                  |
+|   - Translate kernel decisions ← canonical                  |
+|   - Register hooks via host's mechanism                     |
++--------------------------+---------------------------------+
+                           ↓ canonical event
++------------------------------------------------------------+
+| Hook scripts (host-agnostic)                                |
+|   - Operate on CanonicalEvent only                          |
+|   - Match on ToolKind / Lifecycle enums, not magic strings  |
+|   - Emit canonical decisions (proceed / block / advise)     |
++--------------------------+---------------------------------+
+                           ↓ pure logic
++------------------------------------------------------------+
+| Substrate (`core/hooks/_*.py`)                              |
+|   - Already host-agnostic                                   |
+|   - Chain integrity, blueprints, scenario detection,        |
+|     framework I/O, context-signature hashing                |
++------------------------------------------------------------+
+```
+
+### 6.3 Stub interface — `core/hooks/_event_translation.py`
+
+A first-pass design lives at [`/core/hooks/_event_translation.py`](../core/hooks/_event_translation.py) (added in this Event 96 PR — design-only, no runtime). Defines:
+
+- `Lifecycle` enum
+- `ToolKind` enum
+- `CanonicalEvent` dataclass
+- `HostAdapter` protocol — the interface every adapter satisfies
+- Translation helpers: `claude_payload_to_canonical(payload: dict) -> CanonicalEvent` (reference implementation)
+
+The current hooks are unchanged. The interface is a target for future migration, not a live dependency.
+
+---
+
+## 7. Recommended sequencing — what to ship first
+
+The audit suggests six phases, in order. Each phase is small, reversible, and produces standalone value.
+
+### Phase 1 — Define the canonical event schema (this PR)
+- Add `core/hooks/_event_translation.py` (Protocol + dataclasses, no runtime)
+- Add `core/schemas/canonical-event.json` (JSON schema for cross-language adapters)
+- Document in `docs/ADAPTER_PORTABILITY.md` (this file)
+- **Effort**: ~1 day. **Risk**: low. **Reversibility**: full.
+
+### Phase 2 — Reference translation: Claude payload → canonical
+- In `core/hooks/_event_translation.py`, implement `claude_payload_to_canonical()` 
+- Build a fixture set: representative Claude payloads + expected canonical translations
+- Tests verify round-trip
+- **Effort**: ~1 day. **Risk**: low. **Reversibility**: full.
+
+### Phase 3 — Refactor one hook to operate on canonical events
+- Pick the simplest: `block_dangerous.py` (57 lines, single-purpose, low surface area)
+- Refactor to read canonical events; use Claude translation layer for backward compat
+- Existing tests must pass unchanged; behavior identical
+- **Effort**: ~half-day. **Risk**: low (one hook, fully tested). **Reversibility**: full.
+
+### Phase 4 — Refactor remaining entry-point hooks (incremental)
+- One hook per Event; each on its own PR; each validated against the existing test suite
+- Order by simplicity: format.py → test_runner.py → checkpoint.py → … → reasoning_surface_guard.py (last; biggest surface area)
+- **Effort**: ~5 days, spread across 18 small PRs. **Risk**: medium (the big guard touches many code paths). **Reversibility**: per-hook.
+
+### Phase 5 — Build the second adapter (Cursor)
+- Add `adapters/cursor/` with installer code that registers Cursor's workspace rules pointing at `core/hooks/*.py` 
+- Implement Cursor → canonical translation (the reverse of Phase 2)
+- Run the same Reasoning Surface contract test suite under Cursor; verify identical decisions
+- **Effort**: ~3-5 days. **Risk**: medium-high (Cursor's API surface may not support all canonical events; some hooks may degrade to advisory). **Reversibility**: full.
+
+### Phase 6 — Cross-adapter test parity
+- Build a test suite that runs the same canonical-event fixtures through both adapters and verifies identical hook decisions
+- Document any host-specific gaps (e.g., "Cursor does not support PreCompact; precompact_backup.py is no-op on Cursor")
+- **Effort**: ~2 days. **Risk**: low. **Reversibility**: full.
+
+**Total effort to defensible model-agnostic claim**: ~12-15 working days, spread across 25+ small PRs.
+
+---
+
+## 8. Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|:-:|:-:|---|
+| Canonical event schema misses a host's load-bearing event | Medium | High | Phase 1 stays in design-only mode; Phase 5 (Cursor) will reveal gaps before Phase 4 (full hook refactor) commits to the schema. If Cursor reveals a needed event, schema gets a v2. |
+| Hook refactor introduces behavior regressions | Medium | High | Each hook refactor is its own Event/PR with the existing test suite as a regression gate. Reasoning Surface contract tests must pass identically before merge. |
+| Cursor adapter cannot achieve enforcement parity | Medium | Medium | Acceptable. Document the gaps; the canonical schema names which events are required vs optional; hooks degrade to advisory-only for missing-event hosts. |
+| The "model-agnostic" claim becomes a perpetual aspiration | Low (high if we don't sequence) | High | This audit is the precondition for honest claims. After Phase 5 ships, the claim becomes defensible; before, the claim must be qualified to "Claude Code today; portable design verified." |
+| Codex / opencode never get hook enforcement (no lifecycle to hook into) | High | Medium | Acceptable. AGENTS.md identity layer travels; advisory-only is honest for hookless hosts; document the limitation explicitly. |
+| The canonical schema becomes its own coupling layer (kernel ↔ schema instead of kernel ↔ Claude) | Low | Medium | Schema is versioned per Memory Contract pattern; deprecation path exists if a major redesign is needed. |
+
+---
+
+## 9. What this audit does NOT propose
+
+- **No runtime changes** to existing hooks. All Phase 3+ work is sequenced in future Events.
+- **No removal of Claude-specific code paths**. Claude remains the reference adapter; backward compat preserved at every step.
+- **No claim that Codex / opencode / generic IDEs will get full enforcement parity**. Some hosts genuinely have no hook lifecycle; advisory-only is the honest ceiling for them.
+- **No commitment to a deadline**. This is a multi-quarter migration, sequenced for low risk per step.
+
+---
+
+## 10. Closing — what changed about the claim
+
+Before this audit: *"episteme is model-agnostic."*
+
+After this audit: *"episteme's identity layer (kernel + profile + memory) is model-agnostic today, ported to any host that reads markdown. The enforcement layer (hooks + Reasoning Surface contract) is Claude-Code-shaped today. The migration design is documented; the next two adapters can be wired in 12-15 working days against the canonical event schema once it lands. Hosts without a hook lifecycle (Codex, generic IDEs) will get advisory-only enforcement — honest about what's possible, not what we wish were possible."*
+
+That second statement is the defensible one. It is also the one this audit recommends putting on the project's external surfaces (README, marketing, conference talks) the moment it becomes accurate — which is *after* Phase 5 ships, not before.
+
+The honest claim now is the precondition for the strong claim later. The audit is the bridge.


### PR DESCRIPTION
## Summary

Honest audit of the *"model-agnostic"* claim. Operator directive: *"The true essence of our tool requires that this 'truth-seeking' is not locked to a single vendor. Analyze what it takes to make the kernel truly model-agnostic so it works perfectly outside of Claude Code."*

This is not a code change. It is a **planning artifact + a future-target schema**. Existing hooks are unchanged. No behavior change in any guard, blueprint, or substrate. Tests still 766 + 21 green.

## What the audit found

| Layer | Honest portability today |
|---|---|
| Kernel constitution / schemas / blueprints / operator profile | Truly portable (markdown + JSON + YAML — travels everywhere) |
| Hook **substrate** (\`core/hooks/_*.py\` × 16 modules) | Truly portable — pure logic, no host coupling |
| Hook **entry points** (\`core/hooks/*.py\` × 18 scripts) | **Partially portable** — handle camelCase ⇄ snake_case duality, but tool-name vocabulary (\`Bash\` / \`Write\` / \`Edit\` / \`MultiEdit\`), tool-input schema (\`.command\` / \`.file_path\`), tool-response schema (\`.returnCodeInterpretation\` / \`.interrupted\`), and hook event taxonomy (PreToolUse / PostToolUse / Stop / etc.) are all Claude-Code-shaped |
| \`adapters/{claude,hermes}/\` | **Documentation only** — README files, no adapter code. The "Claude adapter" lives inside \`episteme sync\` as a side-effect. The "Hermes adapter" syncs identity but explicitly does NOT carry hook enforcement |
| \`adapters/{codex,opencode,omo,omx,cursor,...}/\` | **Do not exist** — documented as targets in \`docs/LAYER_MODEL.md\` § 4 but nothing on disk |

**One-line honest claim:**
> *"The kernel's identity layer (markdown + profile + memory) is model-agnostic today. The enforcement layer (hooks + Reasoning Surface contract) is Claude-Code-shaped today. Migration to true cross-adapter parity needs ~12-15 working days across 25+ small PRs, sequenced in 6 phases."*

## What this PR ships (Phase 1 of the migration)

### 1. \`docs/ADAPTER_PORTABILITY.md\` (336 lines)

Comprehensive audit with:
- Inventory of every Claude-Code-specific assumption found in \`core/hooks/\`, with file/line references
- 6 categories of coupling cataloged by severity (tool-name vocabulary · tool-input schema · tool-response schema · hook event taxonomy · hook registration mechanism · payload conventions)
- Per-target feasibility matrix — Cursor (2× Claude effort), Hermes (3×), Codex (5×), opencode (4×), OpenAI/MCP (6×), generic IDEs (9×)
- Recommended sequencing across 6 phases (this PR is Phase 1)
- Risk register

### 2. \`core/hooks/_event_translation.py\` (525 lines · design-only)

Canonical event schema as a Python target:
- \`Lifecycle\` enum — \`INTENT_TO_EXECUTE\` / \`EXECUTION_COMPLETED\` / \`SESSION_OPENED\` / \`SESSION_CLOSED\` / \`CONTEXT_COMPACTING\` / \`PERMISSION_REQUESTED\`
- \`ToolKind\` enum — \`SHELL_EXEC\` / \`FILE_WRITE\` / \`FILE_EDIT\` / \`FILE_MULTI_EDIT\` / \`FILE_READ\` / \`NETWORK_FETCH\` / \`AGENT_TASK\` / \`OTHER\`
- \`Decision\` enum — \`ALLOW\` / \`DENY\` / \`ADVISORY\` / \`NO_OP\`
- \`CanonicalEvent\` dataclass + per-ToolKind input variants (\`ShellExecInput\`, \`FileWriteInput\`, \`FileEditInput\`, \`GenericInput\`)
- \`ToolResponse\` dataclass for \`EXECUTION_COMPLETED\` events
- \`HostAdapter\` Protocol — the interface every adapter satisfies
- \`claude_payload_to_canonical()\` — reference translation, the worked example for new adapters
- \`SCHEMA_VERSION = "canonical-event/v1"\`

**No existing hook imports this module.** It is a vocabulary, not a runtime.

## Why this matters now

> *"Constitution과 received forward — having direction and visibility forward, finding it ourselves"* — operator's framing.

The kernel cannot pull itself or the user forward in a vendor-locked direction. The audit is the precondition for honest claims. Phases 2-5 are the work that makes the claim defensible. This Event commits to neither overclaim ("episteme runs anywhere") nor abandonment ("we'll always be Claude-only") — it commits to a sequenced migration with an honest baseline.

## Recommended next steps (Phases 2-6, future Events)

| Phase | Scope | Effort |
|---|---|---|
| 2 | Build fixture set: representative Claude payloads + expected canonical translations + round-trip tests | ~1 day |
| 3 | Refactor first hook (\`block_dangerous.py\`) to consume \`CanonicalEvent\`. Behavior identical; existing tests must pass | ~half-day |
| 4 | Refactor remaining 17 entry-point hooks one at a time | ~5 days, 18 small PRs |
| 5 | Build the second adapter (Cursor recommended). Verify identical hook decisions across both adapters | ~3-5 days |
| 6 | Cross-adapter test parity suite | ~2 days |

After Phase 5 ships, the strong claim becomes defensible. Before that, the README / marketing should use the Phase-0 honest claim.

## Soak-invariant note (read carefully)

This PR adds ONE new private module to \`core/hooks/\`: \`_event_translation.py\`.

Strict soak interpretation: \`core/hooks/\` is a soak-protected surface; touching it is a soak event.

Pragmatic soak interpretation: the new module is **additive-only**, has **zero importers** in the existing hook layer, and **contributes no runtime behavior** — it is a vocabulary, not a runtime. Existing hooks unchanged. Existing tests pass identically (766 + 21).

If operator prefers stricter quarantine, the file can be relocated to a new \`core/portability/\` directory in a follow-up — current placement matches the conventional underscore-prefixed substrate pattern (sibling to \`_arm_a_pre.py\`, \`_blueprint_d.py\`, \`_chain.py\`, \`_framework.py\`, etc.).

## Test plan

- [x] \`PYTHONPATH=. pytest -q\`: 766 passed + 21 subtests passed in 6.23s (zero regression)
- [x] Module imports cleanly: \`import _event_translation; print(SCHEMA_VERSION)\` → \`canonical-event/v1\`
- [x] Smoke-tested both translation paths:
  - Bash payload → \`CanonicalEvent(lifecycle=INTENT_TO_EXECUTE, tool_kind=SHELL_EXEC, command_text='ls -la', …)\`
  - Edit + tool_response payload → \`CanonicalEvent(lifecycle=EXECUTION_COMPLETED, tool_kind=FILE_EDIT, tool_response=ToolResponse(status='success', …), …)\`
- [x] Pyright clean (zero diagnostics on the new module)
- [x] \`block_dangerous.py\` correctly intercepted my own test fixture during smoke-testing — the kernel's discipline working on its own audit. Logged with humor.
- [ ] Reviewer to spot-check the audit doc for accuracy of the per-target feasibility matrix
- [ ] Reviewer to confirm the soak-invariant interpretation chosen here is acceptable, or request relocation to \`core/portability/\`

## What this PR does NOT do

- Does NOT change any existing hook behavior
- Does NOT remove Claude-specific code paths
- Does NOT claim cross-adapter parity is shipped
- Does NOT commit to a deadline for Phases 2-6

## Final thought

The audit's most useful property may be that it converts an aspirational claim ("model-agnostic") into a sequenced engineering plan with honest milestones. The kernel's own thesis applied to the kernel's own positioning: *commit to disconfirmation in advance; the next adapter wired against the canonical schema is the disconfirmation condition*.