### PR TITLE
Event 102 — Light editorial substrate + three architecture diagrams

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,31 +1,33 @@
 @import "tailwindcss";
 
 /* ──────────────────────────────────────────────────────────────────────────
-   episteme — operator console tokens
-   Colors are scarce by construction. Signal colors earn their brightness
-   by being rare. No gradients. No saturated blues. Bone white, not pure.
+   episteme — editorial light substrate (Event 102)
+   Warm cream substrate, dark warm ink, four scarce signal accents
+   recalibrated for light-contrast. No gradients on type. No saturated
+   blues. Cream is not pure white; ink is not pure black — both warm.
    ────────────────────────────────────────────────────────────────────────── */
 
 @theme {
-  /* Substrate */
-  --color-void: #07080a;
-  --color-surface: #0d0f13;
-  --color-elevated: #14171d;
-  --color-hairline: #1a1e26;
-  --color-line: #272c36;
-  --color-line-strong: #3a404c;
+  /* Substrate (light, layered cream — book paper) */
+  --color-void: #f4f0e8;          /* page substrate — warm cream */
+  --color-surface: #ece6d8;        /* layered surface */
+  --color-elevated: #e0d8c5;       /* panel / card */
+  --color-hairline: #d0c7b0;       /* delicate borders */
+  --color-line: #a89a7e;           /* stronger lines */
+  --color-line-strong: #807156;    /* deepest line */
 
-  /* Type on substrate */
-  --color-bone: #e8e9ec;
-  --color-ash: #8b909b;
-  --color-muted: #4f5562;
-  --color-whisper: #373c45;
+  /* Type on substrate (warm ink — not pure black) */
+  --color-bone: #1a1612;           /* primary ink */
+  --color-ash: #524a40;            /* secondary text */
+  --color-muted: #8a8174;          /* muted */
+  --color-whisper: #b8ae9c;        /* very light, near-hairline */
 
-  /* Signals — used sparingly for state communication */
-  --color-verified: #7de0b0;
-  --color-unknown: #f5b764;
-  --color-disconfirm: #e87464;
-  --color-chain: #64a0f5;
+  /* Signals — recalibrated for light substrate (deeper hues, no neon).
+     Each pulled toward editorial-print accent palette. */
+  --color-verified: #2f7a4f;       /* forest green */
+  --color-unknown: #b07013;        /* ochre / amber */
+  --color-disconfirm: #b33c28;     /* terra-cotta */
+  --color-chain: #2d5ba3;          /* deep blue — chain identity preserved */
 
   /* Fonts wired via next/font in layout.tsx */
   --font-display: var(--font-fraunces);
@@ -58,31 +60,33 @@ body {
 }
 
 /* Hairline grid overlay — 1px, 4% opacity, 48px cadence.
-   Rendered once in <body>, pointer-events none, z-index -1. */
+   Rendered once in <body>, pointer-events none, z-index -1.
+   On light substrate, ink-on-cream rather than light-on-dark. */
 .grid-overlay {
   position: fixed;
   inset: 0;
   pointer-events: none;
   z-index: -1;
   background-image:
-    linear-gradient(to right, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+    linear-gradient(to right, rgba(0, 0, 0, 0.04) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.04) 1px, transparent 1px);
   background-size: 48px 48px;
   mask-image: radial-gradient(ellipse at center, black 30%, transparent 85%);
 }
 
-/* Noise layer — very low opacity film grain */
+/* Noise layer — film grain, lower opacity on light substrate so it
+   reads as paper texture, not as visible noise. */
 .noise-layer {
   position: fixed;
   inset: 0;
   pointer-events: none;
   z-index: -1;
-  opacity: 0.06;
-  mix-blend-mode: overlay;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
-/* Scrollbar — thin, muted */
+/* Scrollbar — thin, muted, ink-on-cream */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
@@ -91,17 +95,17 @@ body {
   background: var(--color-void);
 }
 ::-webkit-scrollbar-thumb {
-  background: var(--color-hairline);
+  background: var(--color-line);
   border-radius: 1px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--color-line);
+  background: var(--color-line-strong);
 }
 
 /* Utility: ambient pulse for unknown quadrants */
 @keyframes pulse-unknown {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(245, 183, 100, 0); }
-  50% { box-shadow: 0 0 24px -4px rgba(245, 183, 100, 0.25); }
+  0%, 100% { box-shadow: 0 0 0 0 rgba(176, 112, 19, 0); }
+  50% { box-shadow: 0 0 24px -4px rgba(176, 112, 19, 0.3); }
 }
 .pulse-unknown {
   animation: pulse-unknown 4.2s var(--ease-standard) infinite;
@@ -109,7 +113,7 @@ body {
 
 /* Hash chain new-entry flash */
 @keyframes flash-chain {
-  0% { background: rgba(100, 160, 245, 0.22); border-color: rgba(100, 160, 245, 0.6); }
+  0% { background: rgba(45, 91, 163, 0.18); border-color: rgba(45, 91, 163, 0.65); }
   100% { background: transparent; border-color: var(--color-hairline); }
 }
 .flash-chain {
@@ -118,43 +122,43 @@ body {
 
 /* Broken-link alert */
 @keyframes flash-break {
-  0%, 100% { background: rgba(232, 116, 100, 0.18); }
-  50% { background: rgba(232, 116, 100, 0.28); }
+  0%, 100% { background: rgba(179, 60, 40, 0.16); }
+  50% { background: rgba(179, 60, 40, 0.26); }
 }
 .flash-break {
   animation: flash-break 1.8s var(--ease-standard) infinite;
 }
 
 /* ──────────────────────────────────────────────────────────────────────────
-   v1.1 polish — atmosphere, gradient borders, progressive blur,
+   Editorial richness — atmosphere, gradient borders, progressive blur,
    column-grid data streams, mask-word reveal, corner markers.
-   Bridges "austere terminal" → "alive operator console" without
-   touching typography, narrative, or signal palette.
+   Recalibrated for light substrate: ink-on-cream rather than
+   light-on-dark; chromatic glows softened to whispers, not auras.
    ────────────────────────────────────────────────────────────────────────── */
 
-/* 1. Atmospheric radial glow mesh.
-   Two low-opacity color glows using signal accents at the page corners.
-   Heavy blur + tiny opacity = chromatic without saturation. */
+/* 1. Atmospheric chromatic whispers.
+   On light substrate, signal-color glows read as faint warm tints in
+   the page corners, not as dark-mode auras. Opacity reduced 30-50%. */
 .atmosphere {
   position: fixed;
   inset: 0;
   z-index: -1;
   pointer-events: none;
   background:
-    radial-gradient(circle at 18% 8%, rgba(100, 160, 245, 0.055), transparent 42%),
-    radial-gradient(circle at 82% 92%, rgba(232, 116, 100, 0.042), transparent 42%),
-    radial-gradient(circle at 50% 50%, rgba(125, 224, 176, 0.025), transparent 55%);
+    radial-gradient(circle at 18% 8%, rgba(45, 91, 163, 0.045), transparent 42%),
+    radial-gradient(circle at 82% 92%, rgba(176, 112, 19, 0.038), transparent 42%),
+    radial-gradient(circle at 50% 50%, rgba(47, 122, 79, 0.022), transparent 55%);
   filter: blur(80px);
 }
 
-/* 2. Gradient-lit panel borders.
-   Two-stop light-from-top simulation via double-background on padding-box
-   + border-box. Brighter on top edge, fades to near-invisible at bottom. */
+/* 2. Gradient-lit panel borders — light-from-top simulation.
+   On cream substrate, the "light" comes from a soft ink shadow at top
+   fading to near-transparent at bottom. Inverts the dark-mode logic. */
 .panel-gradient {
   background:
     linear-gradient(color-mix(in oklab, var(--color-surface) 92%, transparent), color-mix(in oklab, var(--color-surface) 92%, transparent))
       padding-box,
-    linear-gradient(180deg, rgba(255, 255, 255, 0.14) 0%, rgba(255, 255, 255, 0.02) 55%, rgba(255, 255, 255, 0.06) 100%)
+    linear-gradient(180deg, rgba(0, 0, 0, 0.10) 0%, rgba(0, 0, 0, 0.02) 55%, rgba(0, 0, 0, 0.05) 100%)
       border-box;
   border: 1px solid transparent;
 }
@@ -162,15 +166,12 @@ body {
 .panel-gradient-strong {
   background:
     linear-gradient(var(--color-elevated), var(--color-elevated)) padding-box,
-    linear-gradient(180deg, rgba(255, 255, 255, 0.22) 0%, rgba(255, 255, 255, 0.04) 50%, rgba(255, 255, 255, 0.1) 100%)
+    linear-gradient(180deg, rgba(0, 0, 0, 0.14) 0%, rgba(0, 0, 0, 0.03) 50%, rgba(0, 0, 0, 0.08) 100%)
       border-box;
   border: 1px solid transparent;
 }
 
-/* 3. Progressive-blur top gradient.
-   Six overlapping backdrop-blur bands masked to different stripes so blur
-   intensity increases toward the nav edge. Makes the header feel correctly
-   floating over atmospheric content. */
+/* 3. Progressive-blur top gradient (theme-agnostic — blur is opacity-free) */
 .gradient-blur {
   position: fixed;
   z-index: 40;
@@ -223,10 +224,7 @@ body {
   mask: linear-gradient(to top, rgba(0, 0, 0, 0) 75%, rgba(0, 0, 0, 1) 87.5%, rgba(0, 0, 0, 1) 100%);
 }
 
-/* 4. Animated column-grid data streams.
-   Fixed full-height 4-column grid under page content. Each divider hosts
-   a short vertical gradient line that translates top→bottom on a loop,
-   staggered per column. Tinted with --color-chain for identity. */
+/* 4. Animated column-grid data streams — ink-on-cream with chain tint. */
 .column-grid {
   position: fixed;
   inset: 0;
@@ -238,16 +236,16 @@ body {
 }
 .column-grid-inner {
   width: 100%;
-  max-width: 80rem; /* matches max-w-7xl */
+  max-width: 80rem;
   height: 100%;
-  border-left: 1px solid rgba(255, 255, 255, 0.04);
-  border-right: 1px solid rgba(255, 255, 255, 0.04);
+  border-left: 1px solid rgba(0, 0, 0, 0.05);
+  border-right: 1px solid rgba(0, 0, 0, 0.05);
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   position: relative;
 }
 .column-grid-inner > div {
-  border-right: 1px solid rgba(255, 255, 255, 0.04);
+  border-right: 1px solid rgba(0, 0, 0, 0.05);
   position: relative;
   overflow: hidden;
   display: none;
@@ -267,9 +265,9 @@ body {
   background: linear-gradient(
     to bottom,
     transparent 0%,
-    rgba(100, 160, 245, 0.0) 10%,
-    rgba(100, 160, 245, 0.45) 50%,
-    rgba(100, 160, 245, 0.0) 90%,
+    rgba(45, 91, 163, 0.0) 10%,
+    rgba(45, 91, 163, 0.45) 50%,
+    rgba(45, 91, 163, 0.0) 90%,
     transparent 100%
   );
   animation: data-stream-flow linear infinite;
@@ -299,12 +297,13 @@ body {
   100% { transform: translateY(0); opacity: 1; }
 }
 
-/* 6. Corner markers — outward-offset + glyphs at panel corners. */
+/* 6. Corner markers — outward-offset + glyphs at panel corners.
+   Ink-on-cream visibility: 0.30 alpha vs prior 0.22 white-on-dark. */
 .corner-marker {
   position: absolute;
   width: 10px;
   height: 10px;
-  color: rgba(255, 255, 255, 0.22);
+  color: rgba(0, 0, 0, 0.30);
   pointer-events: none;
 }
 .corner-marker svg { width: 100%; height: 100%; }

--- a/web/src/components/site/FrameworkExplainer.tsx
+++ b/web/src/components/site/FrameworkExplainer.tsx
@@ -1,4 +1,5 @@
 import { Sectioned } from "@/components/ui/Sectioned";
+import { FrameworkLoopDiagram } from "@/components/site/diagrams/FrameworkLoopDiagram";
 
 const stages = [
   {
@@ -44,10 +45,13 @@ export function FrameworkExplainer() {
           </span>
         </h2>
         <p className="font-sans text-[0.9375rem] leading-relaxed text-ash md:col-span-5">
-          Speed comes from loop completion, not step-skipping. The agent that
-          consistently closes Observe → Orient → Decide → Act outruns the one
-          that collapses stages to feel fast.
+          The agent that consistently closes Observe → Orient → Decide → Act
+          outruns the one that collapses stages to feel fast.
         </p>
+      </div>
+
+      <div className="mb-12">
+        <FrameworkLoopDiagram />
       </div>
 
       <ol className="grid grid-cols-1 gap-0 border border-hairline md:grid-cols-5">

--- a/web/src/components/site/PillarsGrid.tsx
+++ b/web/src/components/site/PillarsGrid.tsx
@@ -1,4 +1,5 @@
 import { Sectioned } from "@/components/ui/Sectioned";
+import { PillarsArchitectureDiagram } from "@/components/site/diagrams/PillarsArchitectureDiagram";
 
 const pillars = [
   {
@@ -38,10 +39,14 @@ export function PillarsGrid() {
           </span>
         </h2>
         <p className="font-sans text-[0.9375rem] leading-relaxed text-ash md:col-span-5">
-          Agents fail confidently when they confuse fluent pattern-match with
-          reasoning. episteme does not block that failure mode — it makes the
-          mode structurally unavailable. Pillars below.
+          Each pillar earns its place by making a specific failure mode
+          structurally unavailable. The architecture below is what visitors
+          install, not what we describe.
         </p>
+      </div>
+
+      <div className="mb-14">
+        <PillarsArchitectureDiagram />
       </div>
 
       <ol className="grid grid-cols-1 gap-0 border border-hairline md:grid-cols-3">

--- a/web/src/components/site/ProtocolsSection.tsx
+++ b/web/src/components/site/ProtocolsSection.tsx
@@ -1,5 +1,6 @@
 import { Sectioned } from "@/components/ui/Sectioned";
 import { ProtocolNode } from "@/components/viz/ProtocolNode";
+import { HashChainDiagram } from "@/components/site/diagrams/HashChainDiagram";
 import { fixtureProtocols } from "@/lib/fixtures/chain";
 
 export function ProtocolsSection() {
@@ -19,10 +20,23 @@ export function ProtocolsSection() {
           </span>
         </h2>
         <p className="font-sans text-[0.9375rem] leading-relaxed text-ash md:col-span-5">
-          Hover any node to surface its because-chain: the signal that was
-          observed, the cause that was inferred, the decision that landed.
-          Every protocol is chain-linked — provenance is non-optional.
+          Each Reasoning Surface seal lands as one envelope on a SHA-256-linked
+          chain. The chain is read at session boot; a corrupted past fails
+          closed. Provenance is non-optional, by construction.
         </p>
+      </div>
+
+      <div className="mb-14">
+        <HashChainDiagram />
+      </div>
+
+      <div className="mb-6 flex items-baseline justify-between gap-4 border-t border-hairline pt-6">
+        <h3 className="font-display text-[1.25rem] text-bone">
+          Live protocols on the chain
+        </h3>
+        <span className="font-mono text-[0.6875rem] uppercase tracking-[0.16em] text-muted">
+          hover any node · because-chain on the back
+        </span>
       </div>
 
       <ul className="grid grid-cols-1 gap-5 md:grid-cols-2">

--- a/web/src/components/site/diagrams/FrameworkLoopDiagram.tsx
+++ b/web/src/components/site/diagrams/FrameworkLoopDiagram.tsx
@@ -1,0 +1,180 @@
+// 5-stage framework loop — Frame → Decompose → Execute → Verify → Handoff.
+// Pentagon layout with directional arrows; consumes theme tokens via Tailwind
+// classes (currentColor on stroke / class-based on fill) so the diagram
+// inherits substrate-flip cleanly.
+
+const STAGES = [
+  { id: "frame", n: "01", label: "Frame", note: "core question · constraints" },
+  { id: "decompose", n: "02", label: "Decompose", note: "method · 2+ options" },
+  { id: "execute", n: "03", label: "Execute", note: "smallest reversible move" },
+  { id: "verify", n: "04", label: "Verify", note: "vs metric · not effort" },
+  { id: "handoff", n: "05", label: "Handoff", note: "auth docs · residuals" },
+];
+
+// Pentagon vertex positions (cx=300 cy=240 r=180; first vertex at top, then clockwise).
+function vertex(i: number): { x: number; y: number } {
+  const angle = (Math.PI * 2 * i) / STAGES.length - Math.PI / 2;
+  return {
+    x: 300 + 180 * Math.cos(angle),
+    y: 240 + 180 * Math.sin(angle),
+  };
+}
+
+export function FrameworkLoopDiagram() {
+  const points = STAGES.map((_, i) => vertex(i));
+
+  return (
+    <figure className="relative mx-auto w-full max-w-4xl">
+      <svg
+        viewBox="0 0 600 480"
+        role="img"
+        aria-label="Five-stage framework loop: Frame, Decompose, Execute, Verify, Handoff — closing the OODA tempo"
+        className="h-auto w-full text-line"
+      >
+        {/* Pentagon arcs (open arrows from i → i+1) */}
+        {points.map((p, i) => {
+          const next = points[(i + 1) % points.length];
+          const mx = (p.x + next.x) / 2;
+          const my = (p.y + next.y) / 2;
+          // Push midpoint slightly outward from center to create gentle outward arc.
+          const dx = mx - 300;
+          const dy = my - 240;
+          const dist = Math.hypot(dx, dy);
+          const ox = mx + (dx / dist) * 24;
+          const oy = my + (dy / dist) * 24;
+          return (
+            <g key={`arc-${i}`}>
+              <path
+                d={`M ${p.x} ${p.y} Q ${ox} ${oy} ${next.x} ${next.y}`}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1}
+                strokeOpacity={0.5}
+                markerEnd="url(#fl-arrow)"
+              />
+            </g>
+          );
+        })}
+
+        {/* Center caption */}
+        <g transform="translate(300 232)" textAnchor="middle">
+          <text
+            className="fill-bone font-display"
+            fontSize={18}
+            letterSpacing={0.4}
+          >
+            the loop
+          </text>
+          <text
+            y={22}
+            className="fill-muted font-mono"
+            fontSize={9}
+            letterSpacing={2}
+          >
+            OBSERVE · ORIENT · DECIDE · ACT
+          </text>
+          <text
+            y={40}
+            className="fill-ash font-mono"
+            fontSize={9}
+            letterSpacing={1.4}
+          >
+            speed comes from completion, not from skipping
+          </text>
+        </g>
+
+        {/* Stage nodes */}
+        {STAGES.map((s, i) => {
+          const { x, y } = points[i];
+          // Node label position offset radially outward from center.
+          const dx = x - 300;
+          const dy = y - 240;
+          const dist = Math.hypot(dx, dy);
+          const lx = x + (dx / dist) * 38;
+          const ly = y + (dy / dist) * 38;
+          // Notes positioned slightly further out, smaller font.
+          const nx = x + (dx / dist) * 60;
+          const ny = y + (dy / dist) * 60;
+          // Anchor based on quadrant.
+          const anchor =
+            Math.abs(dx) < 30 ? "middle" : dx > 0 ? "start" : "end";
+
+          return (
+            <g key={s.id}>
+              {/* Outer pulse ring on hover (decorative). */}
+              <circle
+                cx={x}
+                cy={y}
+                r={26}
+                fill="var(--color-elevated)"
+                stroke="currentColor"
+                strokeWidth={1}
+                strokeOpacity={0.85}
+              />
+              <circle
+                cx={x}
+                cy={y}
+                r={26}
+                fill="none"
+                stroke="var(--color-chain)"
+                strokeWidth={1}
+                strokeOpacity={0.18}
+              />
+              {/* Stage number */}
+              <text
+                x={x}
+                y={y + 5}
+                textAnchor="middle"
+                className="fill-bone font-display"
+                fontSize={16}
+              >
+                {s.n}
+              </text>
+              {/* Stage label */}
+              <text
+                x={lx}
+                y={ly}
+                textAnchor={anchor}
+                className="fill-bone font-display"
+                fontSize={15}
+                dominantBaseline="middle"
+              >
+                {s.label}
+              </text>
+              {/* Stage note */}
+              <text
+                x={nx}
+                y={ny + 14}
+                textAnchor={anchor}
+                className="fill-muted font-mono"
+                fontSize={9}
+                letterSpacing={1.1}
+                dominantBaseline="middle"
+              >
+                {s.note}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Arrow head marker */}
+        <defs>
+          <marker
+            id="fl-arrow"
+            viewBox="0 0 10 10"
+            refX={9}
+            refY={5}
+            markerWidth={6}
+            markerHeight={6}
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+          </marker>
+        </defs>
+      </svg>
+      <figcaption className="mt-3 text-center font-mono text-[0.6875rem] uppercase tracking-[0.16em] text-muted">
+        figure 1 · the five-stage loop · the kernel refuses to skip ahead
+      </figcaption>
+    </figure>
+  );
+}

--- a/web/src/components/site/diagrams/HashChainDiagram.tsx
+++ b/web/src/components/site/diagrams/HashChainDiagram.tsx
@@ -1,0 +1,344 @@
+// Hash-chain envelope visualization.
+// Three envelopes side-by-side, each showing prev_hash / payload / hash.
+// A chain-link arrow flows hash(N) → prev_hash(N+1). A fourth envelope
+// renders in disconfirm-tone with a broken-link glyph to communicate
+// tamper-evidence: a corrupted past is unprovable to replay.
+
+const CHAIN = [
+  {
+    seq: "GENESIS",
+    label: "boot",
+    prev: "0x00…00",
+    payload: "kernel-init",
+    hash: "0x9a3e…1b2c",
+  },
+  {
+    seq: "#001",
+    label: "blueprint-B fired",
+    prev: "0x9a3e…1b2c",
+    payload: "fence-reconstruct · removal-evidence",
+    hash: "0x4f72…d8a1",
+  },
+  {
+    seq: "#002",
+    label: "cascade resolved",
+    prev: "0x4f72…d8a1",
+    payload: "blast-radius=11 · sync-plan=clean",
+    hash: "0xb1c5…e740",
+  },
+];
+
+export function HashChainDiagram() {
+  return (
+    <figure className="relative mx-auto w-full max-w-5xl">
+      <svg
+        viewBox="0 0 900 320"
+        role="img"
+        aria-label="Append-only hash chain — three envelopes with prev_hash, payload, hash; a fourth envelope shows tamper detection"
+        className="h-auto w-full text-line"
+      >
+        <defs>
+          <marker
+            id="hc-arrow"
+            viewBox="0 0 10 10"
+            refX={9}
+            refY={5}
+            markerWidth={6}
+            markerHeight={6}
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--color-chain)" />
+          </marker>
+          <marker
+            id="hc-arrow-break"
+            viewBox="0 0 10 10"
+            refX={9}
+            refY={5}
+            markerWidth={6}
+            markerHeight={6}
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--color-disconfirm)" />
+          </marker>
+        </defs>
+
+        {/* Three sealed envelopes (chain head) */}
+        {CHAIN.map((env, i) => {
+          const x = 40 + i * 200;
+          return (
+            <g key={env.seq}>
+              <rect
+                x={x}
+                y={70}
+                width={170}
+                height={170}
+                fill="var(--color-elevated)"
+                stroke="var(--color-chain)"
+                strokeWidth={1.2}
+                strokeOpacity={0.75}
+              />
+              <text
+                x={x + 12}
+                y={92}
+                className="fill-chain font-mono"
+                fontSize={11}
+                letterSpacing={1.2}
+              >
+                envelope · {env.seq}
+              </text>
+              <text
+                x={x + 12}
+                y={106}
+                className="fill-muted font-mono"
+                fontSize={9}
+                letterSpacing={1}
+              >
+                {env.label}
+              </text>
+
+              {/* prev_hash field */}
+              <line
+                x1={x + 12}
+                y1={120}
+                x2={x + 158}
+                y2={120}
+                stroke="currentColor"
+                strokeOpacity={0.3}
+                strokeWidth={1}
+              />
+              <text
+                x={x + 12}
+                y={138}
+                className="fill-ash font-mono"
+                fontSize={9}
+                letterSpacing={1.4}
+              >
+                PREV_HASH
+              </text>
+              <text
+                x={x + 12}
+                y={152}
+                className="fill-bone font-mono"
+                fontSize={10}
+              >
+                {env.prev}
+              </text>
+
+              {/* payload field */}
+              <line
+                x1={x + 12}
+                y1={162}
+                x2={x + 158}
+                y2={162}
+                stroke="currentColor"
+                strokeOpacity={0.3}
+                strokeWidth={1}
+              />
+              <text
+                x={x + 12}
+                y={178}
+                className="fill-ash font-mono"
+                fontSize={9}
+                letterSpacing={1.4}
+              >
+                PAYLOAD
+              </text>
+              <text
+                x={x + 12}
+                y={192}
+                className="fill-bone font-mono"
+                fontSize={9}
+              >
+                {env.payload}
+              </text>
+
+              {/* hash field */}
+              <line
+                x1={x + 12}
+                y1={202}
+                x2={x + 158}
+                y2={202}
+                stroke="currentColor"
+                strokeOpacity={0.3}
+                strokeWidth={1}
+              />
+              <text
+                x={x + 12}
+                y={218}
+                className="fill-ash font-mono"
+                fontSize={9}
+                letterSpacing={1.4}
+              >
+                HASH
+              </text>
+              <text
+                x={x + 12}
+                y={232}
+                className="fill-bone font-mono"
+                fontSize={10}
+              >
+                {env.hash}
+              </text>
+
+              {/* Chain-link arrow to next envelope */}
+              {i < CHAIN.length - 1 && (
+                <g>
+                  <line
+                    x1={x + 170}
+                    y1={155}
+                    x2={x + 200}
+                    y2={155}
+                    stroke="var(--color-chain)"
+                    strokeWidth={1.4}
+                    strokeOpacity={0.85}
+                    markerEnd="url(#hc-arrow)"
+                  />
+                  <text
+                    x={x + 185}
+                    y={148}
+                    textAnchor="middle"
+                    className="fill-chain font-mono"
+                    fontSize={9}
+                    letterSpacing={1.2}
+                  >
+                    seal
+                  </text>
+                </g>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Tamper-evidence callout — fourth envelope dashed in disconfirm tone */}
+        <g>
+          <line
+            x1={640}
+            y1={155}
+            x2={680}
+            y2={155}
+            stroke="var(--color-disconfirm)"
+            strokeWidth={1.4}
+            strokeOpacity={0.85}
+            strokeDasharray="3 3"
+            markerEnd="url(#hc-arrow-break)"
+          />
+          <rect
+            x={690}
+            y={70}
+            width={170}
+            height={170}
+            fill="none"
+            stroke="var(--color-disconfirm)"
+            strokeWidth={1.2}
+            strokeOpacity={0.85}
+            strokeDasharray="3 3"
+          />
+          <text
+            x={702}
+            y={92}
+            className="fill-disconfirm font-mono"
+            fontSize={11}
+            letterSpacing={1.2}
+          >
+            tampered #002
+          </text>
+          <text
+            x={702}
+            y={106}
+            className="fill-muted font-mono"
+            fontSize={9}
+            letterSpacing={1}
+          >
+            payload silently rewritten
+          </text>
+          <text
+            x={702}
+            y={138}
+            className="fill-ash font-mono"
+            fontSize={9}
+            letterSpacing={1.4}
+          >
+            EXPECTED PREV_HASH
+          </text>
+          <text
+            x={702}
+            y={152}
+            className="fill-bone font-mono"
+            fontSize={10}
+          >
+            0x4f72…d8a1
+          </text>
+          <text
+            x={702}
+            y={178}
+            className="fill-ash font-mono"
+            fontSize={9}
+            letterSpacing={1.4}
+          >
+            COMPUTED PREV_HASH
+          </text>
+          <text
+            x={702}
+            y={192}
+            className="fill-disconfirm font-mono"
+            fontSize={10}
+          >
+            0x88e0…ff3b
+          </text>
+          <text
+            x={702}
+            y={218}
+            className="fill-disconfirm font-mono"
+            fontSize={9}
+            letterSpacing={1.4}
+          >
+            VERIFY · FAIL
+          </text>
+          <text
+            x={702}
+            y={232}
+            className="fill-muted font-mono"
+            fontSize={9}
+          >
+            chain rejects · session boots fail-closed
+          </text>
+        </g>
+
+        {/* Header */}
+        <g>
+          <text
+            x={40}
+            y={36}
+            className="fill-muted font-mono"
+            fontSize={10}
+            letterSpacing={2}
+          >
+            APPEND-ONLY · SHA-256-LINKED · cp7-chained-v1
+          </text>
+          <text
+            x={40}
+            y={56}
+            className="fill-bone font-display"
+            fontSize={20}
+          >
+            Tamper-evident memory, not a log.
+          </text>
+        </g>
+
+        {/* Footer note */}
+        <text
+          x={40}
+          y={300}
+          className="fill-ash font-mono"
+          fontSize={10}
+          letterSpacing={1.2}
+        >
+          a corrupted past is not just noticed — it is unprovable to replay.
+        </text>
+      </svg>
+      <figcaption className="mt-3 text-center font-mono text-[0.6875rem] uppercase tracking-[0.16em] text-muted">
+        figure 3 · the chain · GENESIS → seal → seal · tamper → fail-closed
+      </figcaption>
+    </figure>
+  );
+}

--- a/web/src/components/site/diagrams/PillarsArchitectureDiagram.tsx
+++ b/web/src/components/site/diagrams/PillarsArchitectureDiagram.tsx
@@ -1,0 +1,335 @@
+// Three-pillar architecture diagram.
+// Left column: Pillar 1 — four named blueprints (A · B · C · D).
+// Center column: Pillar 2 — three chained envelopes (append-only hash chain).
+// Right column: Pillar 3 — three advisory query nodes (active guidance).
+// Horizontal arrows show the data flow: every blueprint write seals into
+// the chain; the chain feeds the guidance query at the next decision.
+// A return arrow at the bottom closes the loop — guidance modifies the
+// next blueprint firing.
+
+const BLUEPRINTS = [
+  { tag: "A", name: "Axiomatic Judgment" },
+  { tag: "B", name: "Fence Reconstruction" },
+  { tag: "C", name: "Consequence Chain" },
+  { tag: "D", name: "Architectural Cascade" },
+];
+
+const ENVELOPES = [
+  { seq: "GENESIS", payload: "ø" },
+  { seq: "#001", payload: "blueprint-B-fired" },
+  { seq: "#002", payload: "cascade-resolved" },
+];
+
+const GUIDANCE = [
+  { kind: "query", label: "PreToolUse · context-signature match" },
+  { kind: "advise", label: "stderr advisory · one per op" },
+  { kind: "digest", label: "SessionStart · synthesized protocols" },
+];
+
+export function PillarsArchitectureDiagram() {
+  return (
+    <figure className="relative mx-auto w-full max-w-5xl">
+      <svg
+        viewBox="0 0 900 480"
+        role="img"
+        aria-label="Three-pillar architecture: Cognitive Blueprints, Append-Only Hash Chain, Active Guidance"
+        className="h-auto w-full text-line"
+      >
+        <defs>
+          <marker
+            id="pa-arrow"
+            viewBox="0 0 10 10"
+            refX={9}
+            refY={5}
+            markerWidth={6}
+            markerHeight={6}
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+          </marker>
+          <marker
+            id="pa-arrow-chain"
+            viewBox="0 0 10 10"
+            refX={9}
+            refY={5}
+            markerWidth={6}
+            markerHeight={6}
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--color-chain)" />
+          </marker>
+        </defs>
+
+        {/* Pillar headings */}
+        <g textAnchor="middle">
+          <text
+            x={150}
+            y={30}
+            className="fill-muted font-mono"
+            fontSize={10}
+            letterSpacing={2}
+          >
+            PILLAR 01
+          </text>
+          <text
+            x={150}
+            y={48}
+            className="fill-bone font-display"
+            fontSize={18}
+          >
+            Cognitive Blueprints
+          </text>
+
+          <text
+            x={450}
+            y={30}
+            className="fill-muted font-mono"
+            fontSize={10}
+            letterSpacing={2}
+          >
+            PILLAR 02
+          </text>
+          <text
+            x={450}
+            y={48}
+            className="fill-bone font-display"
+            fontSize={18}
+          >
+            Append-Only Hash Chain
+          </text>
+
+          <text
+            x={750}
+            y={30}
+            className="fill-muted font-mono"
+            fontSize={10}
+            letterSpacing={2}
+          >
+            PILLAR 03
+          </text>
+          <text
+            x={750}
+            y={48}
+            className="fill-bone font-display"
+            fontSize={18}
+          >
+            Active Guidance
+          </text>
+        </g>
+
+        {/* Pillar 1 — Blueprint stack */}
+        {BLUEPRINTS.map((b, i) => {
+          const y = 90 + i * 64;
+          return (
+            <g key={b.tag}>
+              <rect
+                x={50}
+                y={y}
+                width={200}
+                height={48}
+                fill="var(--color-elevated)"
+                stroke="currentColor"
+                strokeWidth={1}
+                strokeOpacity={0.7}
+              />
+              <text
+                x={66}
+                y={y + 22}
+                className="fill-chain font-mono"
+                fontSize={13}
+                letterSpacing={1.2}
+              >
+                {b.tag}
+              </text>
+              <text
+                x={88}
+                y={y + 22}
+                className="fill-bone font-display"
+                fontSize={13}
+              >
+                {b.name}
+              </text>
+              <text
+                x={66}
+                y={y + 38}
+                className="fill-muted font-mono"
+                fontSize={9}
+                letterSpacing={1.1}
+              >
+                blueprint-validator · fallback · dogfood
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Pillar 2 — Chained envelopes */}
+        {ENVELOPES.map((env, i) => {
+          const y = 100 + i * 96;
+          return (
+            <g key={env.seq}>
+              <rect
+                x={370}
+                y={y}
+                width={160}
+                height={64}
+                fill="var(--color-elevated)"
+                stroke="var(--color-chain)"
+                strokeWidth={1.2}
+                strokeOpacity={0.75}
+              />
+              <text
+                x={384}
+                y={y + 18}
+                className="fill-chain font-mono"
+                fontSize={10}
+                letterSpacing={1.2}
+              >
+                envelope · {env.seq}
+              </text>
+              <text
+                x={384}
+                y={y + 36}
+                className="fill-ash font-mono"
+                fontSize={9}
+              >
+                prev_hash
+              </text>
+              <text
+                x={384}
+                y={y + 50}
+                className="fill-bone font-mono"
+                fontSize={9}
+              >
+                payload · {env.payload}
+              </text>
+              <text
+                x={384}
+                y={y + 60}
+                className="fill-ash font-mono"
+                fontSize={9}
+              >
+                hash
+              </text>
+              {/* Inter-envelope chain link */}
+              {i < ENVELOPES.length - 1 && (
+                <line
+                  x1={450}
+                  y1={y + 64}
+                  x2={450}
+                  y2={y + 96}
+                  stroke="var(--color-chain)"
+                  strokeWidth={1.2}
+                  strokeOpacity={0.55}
+                  markerEnd="url(#pa-arrow-chain)"
+                />
+              )}
+            </g>
+          );
+        })}
+
+        {/* Pillar 3 — Guidance nodes */}
+        {GUIDANCE.map((g, i) => {
+          const y = 100 + i * 96;
+          return (
+            <g key={g.kind}>
+              <rect
+                x={650}
+                y={y}
+                width={200}
+                height={64}
+                fill="var(--color-elevated)"
+                stroke="currentColor"
+                strokeWidth={1}
+                strokeOpacity={0.7}
+              />
+              <text
+                x={666}
+                y={y + 22}
+                className="fill-verified font-mono"
+                fontSize={10}
+                letterSpacing={1.2}
+              >
+                {g.kind}
+              </text>
+              <text
+                x={666}
+                y={y + 42}
+                className="fill-bone font-mono"
+                fontSize={10}
+              >
+                {g.label}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Flow arrows: Pillar 1 → Pillar 2 (every fire seals to chain) */}
+        <line
+          x1={250}
+          y1={170}
+          x2={370}
+          y2={140}
+          stroke="currentColor"
+          strokeWidth={1}
+          strokeOpacity={0.55}
+          markerEnd="url(#pa-arrow)"
+        />
+        <text
+          x={310}
+          y={146}
+          className="fill-muted font-mono"
+          fontSize={9}
+          letterSpacing={1}
+        >
+          seal
+        </text>
+
+        {/* Flow arrows: Pillar 2 → Pillar 3 (chain query feeds guidance) */}
+        <line
+          x1={530}
+          y1={228}
+          x2={650}
+          y2={228}
+          stroke="currentColor"
+          strokeWidth={1}
+          strokeOpacity={0.55}
+          markerEnd="url(#pa-arrow)"
+        />
+        <text
+          x={590}
+          y={222}
+          className="fill-muted font-mono"
+          fontSize={9}
+          letterSpacing={1}
+          textAnchor="middle"
+        >
+          query
+        </text>
+
+        {/* Return loop: Pillar 3 → Pillar 1 (guidance shapes next firing) */}
+        <path
+          d="M 750 410 Q 450 460 150 410"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1}
+          strokeOpacity={0.4}
+          strokeDasharray="4 4"
+          markerEnd="url(#pa-arrow)"
+        />
+        <text
+          x={450}
+          y={455}
+          className="fill-muted font-mono"
+          fontSize={10}
+          letterSpacing={1.2}
+          textAnchor="middle"
+        >
+          guidance shapes the next blueprint firing — the loop is bidirectional
+        </text>
+      </svg>
+      <figcaption className="mt-3 text-center font-mono text-[0.6875rem] uppercase tracking-[0.16em] text-muted">
+        figure 2 · three pillars · seal · query · guide · the loop closes on itself
+      </figcaption>
+    </figure>
+  );
+}


### PR DESCRIPTION
## Summary

Two cohesive aesthetic shifts in one PR — substrate flip + structural visuals — because the diagrams must read against the new palette to be honestly verified.

### Phase A · Light editorial substrate (`web/src/app/globals.css`)

- **@theme tokens recalibrated.** Substrate flipped from near-black to warm cream book-paper palette (`--color-void: #f4f0e8`); type tokens to warm dark ink (`--color-bone: #1a1612`); signal accents recalibrated for light-contrast — chain `#2d5ba3` (deep blue), verified `#2f7a4f` (forest green), unknown `#b07013` (ochre), disconfirm `#b33c28` (terra-cotta). The four signals retain semantic distinction on cream where the prior neon palette would have washed out.
- **`rgba(255,255,255,*)` bands inverted to `rgba(0,0,0,*)`** across `.grid-overlay`, `.panel-gradient`, `.panel-gradient-strong`, `.column-grid-inner`, `.corner-marker`. Atmospheric chromatic glows softened ~30-50% to read as faint warm tints rather than dark-mode auras. Noise-layer mix-blend-mode flipped `overlay → multiply` with reduced opacity so cream substrate reads as paper texture.
- **Cascade is automatic.** Tailwind 4 `@theme` recomputes utility classes from custom properties at build, so the token swap propagates to all 12 site components consuming `bg-bone / text-ash / border-hairline` etc. without per-component editing.

### Phase B · Three architecture diagrams (`web/src/components/site/diagrams/`)

- **`FrameworkLoopDiagram.tsx`** — circular 5-node SVG: Frame → Decompose → Execute → Verify → Handoff on a pentagon vertex set with directional arrows; center caption *"OBSERVE · ORIENT · DECIDE · ACT — speed comes from completion, not from skipping."* Each node carries stage number + label + role-note matching `kernel/REASONING_SURFACE.md` field semantics. Wired into `FrameworkExplainer.tsx`.
- **`PillarsArchitectureDiagram.tsx`** — three-column SVG: Pillar 1 (4 named blueprints A·B·C·D stacked) → Pillar 2 (3 chained envelopes GENESIS/#001/#002 with `prev_hash`/`payload`/`hash` structure) → Pillar 3 (3 guidance touchpoints from CP9). Horizontal flow arrows: `seal` (P1 → P2), `query` (P2 → P3). Bottom dashed return arrow P3 → P1: *"guidance shapes the next blueprint firing — the loop is bidirectional."* Wired into `PillarsGrid.tsx`.
- **`HashChainDiagram.tsx`** — three sealed envelopes with realistic SHA-256 prefixes; chain-link arrows labeled `seal` between them. **Tamper-evidence callout:** a fourth dashed envelope rendered in disconfirm tone shows EXPECTED vs COMPUTED `prev_hash` mismatch with `VERIFY · FAIL` and *"chain rejects · session boots fail-closed."* Wired into `ProtocolsSection.tsx`.

## Anti-Doxa-decoration discipline

Every visual node carries ≥ 1 named architectural element. Pillar 1 names four blueprints by full name + tag. Pillar 2 envelopes show the actual `cp7-chained-v1` envelope structure with field labels matching `core/hooks/_chain.py`. Pillar 3 names the three real guidance touchpoints. Hash-chain diagram includes the tamper-detection negative space precisely so a reader walks away knowing what *fail-closed* looks like, not just that the chain "exists." Diagrams without semantic content are decoration; these carry information density.

## Theme portability

All three diagrams consume design tokens via `currentColor` on stroke + class-based `fill-bone / fill-ash / fill-chain / fill-verified / fill-disconfirm / fill-muted` Tailwind utilities AND `var(--color-elevated) / var(--color-chain) / var(--color-disconfirm)` raw CSS variables for shape fills/strokes. A future theme revisit cascades through diagrams automatically.

## Soak invariant intact

Zero touches to `kernel/`, `core/hooks/`, `core/blueprints/`, `src/episteme/`, `tests/`, `templates/`, `labs/`. Web GTM surface only.

## Blueprint D self-dogfood

Reasoning Surface declared `flaw_classification: doc-code-drift`, `posture_selected: patch`, `blast_radius_map[]` listing every public surface touched (with `not-applicable` kernel-state surface group named with rationale), `sync_plan[]` with one concrete step per `needs_update` entry (10 steps after Blueprint D validator restructured the plan from coarse 6-step to per-surface 10-step granularity).

## Test plan

- [x] `pnpm build` from `web/` returns clean (✓ Compiled in 7.9s · TypeScript 7.3s · all 12 static pages generated)
- [x] `git grep -nE 'rgba\(255,\s*255,\s*255' web/src/app/globals.css` returns zero hits in active CSS bands
- [x] All three diagram components render to inline SVG with semantic kernel-vocabulary labels
- [ ] Operator visual review on Vercel preview deployment — palette acceptance + diagram aesthetic acceptance is the load-bearing gate
- [ ] Operator review of signal-accent contrast on cream substrate (chain-blue / verified-green / unknown-ochre / disconfirm-terra-cotta — none should wash out at small sizes)