### PR TITLE
fix(evolve): Event 103 — friction-analyzer no-match filter

### DIFF
--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -603,6 +603,57 @@ def _telemetry_dir() -> Path:
     return Path.home() / ".episteme" / "telemetry"
 
 
+# Event 103 — commands whose `exit_code == 1` is a "no-match / not-found"
+# signal-by-design, not an operational failure. When the friction analyzer
+# treats every non-zero exit as friction, predictions paired with these
+# tools' benign exit=1 outcomes pollute the top-N rankings (observed at
+# 2026-05-03 diagnostic pass: all 4 reported friction events were `grep`
+# returning 1 from no-match in `git status && grep` patterns, not real
+# disconfirmation fires). Exit codes ≥ 2 from these tools indicate real
+# errors (invalid flag, regex parse failure, I/O fault) and are NOT
+# filtered — only the literal exit=1 no-match shape is.
+_GREP_LIKE_NOMATCH_COMMANDS = frozenset({
+    "grep", "egrep", "fgrep", "rg", "ag", "ack",
+    "diff", "cmp",
+    "find",
+    "test",
+})
+
+
+def _is_grep_like_no_match(cmd: str, exit_code: int) -> bool:
+    """True iff `exit_code == 1` AND the terminal command in the pipe /
+    sequence is in `_GREP_LIKE_NOMATCH_COMMANDS`. The terminal command is
+    the last segment after the rightmost `;`, `&&`, `||`, or `|`. A leading
+    path (`/usr/bin/grep`) is stripped to its basename before lookup.
+
+    Conservative by design: returns False on any of these — exit_code != 1,
+    empty cmd, parse-ambiguous shapes (quoted separators, complex shell).
+    A wrong-False keeps the record in friction (the historical behavior);
+    a wrong-True silently drops a real failure, so the asymmetry favors
+    keeping records when in doubt.
+    """
+    if exit_code != 1 or not cmd:
+        return False
+    # Find the rightmost separator and take everything after it.
+    last_segment = cmd
+    for sep in ("&&", "||", ";", "|"):
+        idx = last_segment.rfind(sep)
+        if idx >= 0:
+            last_segment = last_segment[idx + len(sep):]
+    last_segment = last_segment.strip()
+    if not last_segment:
+        return False
+    # First whitespace-delimited token is the command name; strip leading
+    # path components so `/usr/bin/grep` resolves to `grep`.
+    tokens = last_segment.split()
+    if not tokens:
+        return False
+    head = tokens[0]
+    if "/" in head:
+        head = head.rsplit("/", 1)[-1]
+    return head in _GREP_LIKE_NOMATCH_COMMANDS
+
+
 def _load_telemetry_pairs(
     telemetry_dir: Path,
 ) -> tuple[dict[str, dict], dict[str, dict]]:
@@ -676,6 +727,14 @@ def _render_friction_report(
             continue
         exit_code = out.get("exit_code")
         if not isinstance(exit_code, int) or exit_code == 0:
+            continue
+        # Event 103 — drop benign no-match outcomes (grep / diff / test /
+        # find returning exit=1 from a not-found result). These are not
+        # operational failures and previously polluted the top-N ranking.
+        cmd_for_filter = str(
+            pred.get("command_executed") or out.get("command_executed") or ""
+        )
+        if _is_grep_like_no_match(cmd_for_filter, exit_code):
             continue
         pred_env = pred.get("epistemic_prediction") or {}
         unknowns = pred_env.get("unknowns") or []

--- a/tests/test_evolve_friction.py
+++ b/tests/test_evolve_friction.py
@@ -294,5 +294,189 @@ class FrictionAnalyzerTests(unittest.TestCase):
             self.assertNotIn("remote diverged since last pull sync", buf_neg.getvalue())
 
 
+class GrepLikeNoMatchFilterTests(unittest.TestCase):
+    """Event 103 — `_is_grep_like_no_match` filters benign exit=1 from
+    grep / diff / test / find / cmp out of the friction stream while
+    keeping (a) real failures from those tools at exit ≥ 2, and (b) any
+    non-zero exit from non-grep-class commands."""
+
+    def test_grep_no_match_exit_1_is_filtered_out(self):
+        with tempfile.TemporaryDirectory() as td:
+            tdir = Path(td)
+            _write_jsonl(
+                tdir / "2026-04-20-audit.jsonl",
+                [
+                    _pred(
+                        "g1", op="grep", cmd="grep needle haystack.txt",
+                        unknowns=["whether the pattern matches the file at all"],
+                        disc="pattern not present in file (exit code 1)",
+                        ts="2026-04-20T10:00:00+00:00",
+                    ),
+                    _out(
+                        "g1", exit_code=1,
+                        ts="2026-04-20T10:00:05+00:00",
+                        cmd="grep needle haystack.txt",
+                    ),
+                ],
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli._evolve_friction(telemetry_dir=tdir)
+            self.assertEqual(rc, 0)
+            out = buf.getvalue()
+            self.assertIn(
+                "Friction events (exit_code ≠ 0 despite positive prediction): **0**",
+                out,
+            )
+            self.assertIn("No friction detected yet", out)
+
+    def test_grep_no_match_after_pipe_is_filtered(self):
+        """Most real-world friction was on `cmd1 && cmd2 | grep foo` shapes;
+        the terminal grep dictates the exit semantics."""
+        with tempfile.TemporaryDirectory() as td:
+            tdir = Path(td)
+            _write_jsonl(
+                tdir / "2026-04-20-audit.jsonl",
+                [
+                    _pred(
+                        "p1", op="status+grep",
+                        cmd='git status --short && git log --oneline | grep "foo"',
+                        unknowns=["whether the log mentions the foo token"],
+                        disc="log does not contain the token (grep exit 1)",
+                        ts="2026-04-20T10:00:00+00:00",
+                    ),
+                    _out(
+                        "p1", exit_code=1,
+                        ts="2026-04-20T10:00:05+00:00",
+                        cmd='git status --short && git log --oneline | grep "foo"',
+                    ),
+                ],
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli._evolve_friction(telemetry_dir=tdir)
+            self.assertEqual(rc, 0)
+            self.assertIn(
+                "Friction events (exit_code ≠ 0 despite positive prediction): **0**",
+                buf.getvalue(),
+            )
+
+    def test_real_failure_exit_1_from_non_grep_stays_in_friction(self):
+        """`cargo publish` returning 1 is a real auth/registry failure —
+        the filter must NOT swallow it just because exit_code happens to be 1."""
+        with tempfile.TemporaryDirectory() as td:
+            tdir = Path(td)
+            _write_jsonl(
+                tdir / "2026-04-20-audit.jsonl",
+                [
+                    _pred(
+                        "r1", op="cargo publish", cmd="cargo publish --token X",
+                        unknowns=["whether the registry token is valid for this crate"],
+                        disc="cargo errors with 401 unauthorized or 403 forbidden",
+                        ts="2026-04-20T10:00:00+00:00",
+                    ),
+                    _out(
+                        "r1", exit_code=1,
+                        ts="2026-04-20T10:00:05+00:00",
+                        cmd="cargo publish --token X",
+                    ),
+                ],
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli._evolve_friction(telemetry_dir=tdir)
+            self.assertEqual(rc, 0)
+            out = buf.getvalue()
+            self.assertIn(
+                "Friction events (exit_code ≠ 0 despite positive prediction): **1**",
+                out,
+            )
+            self.assertIn("cargo publish", out)
+
+    def test_grep_real_error_exit_2_stays_in_friction(self):
+        """`grep --invalid-flag` exits 2 — that IS an operational failure
+        and must be preserved (only literal exit==1 is treated as no-match)."""
+        with tempfile.TemporaryDirectory() as td:
+            tdir = Path(td)
+            _write_jsonl(
+                tdir / "2026-04-20-audit.jsonl",
+                [
+                    _pred(
+                        "e1", op="grep", cmd="grep --bogus-flag pattern file.txt",
+                        unknowns=["whether the flag is recognized by this grep build"],
+                        disc="grep rejects flag with usage error (exit 2)",
+                        ts="2026-04-20T10:00:00+00:00",
+                    ),
+                    _out(
+                        "e1", exit_code=2,
+                        ts="2026-04-20T10:00:05+00:00",
+                        cmd="grep --bogus-flag pattern file.txt",
+                    ),
+                ],
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli._evolve_friction(telemetry_dir=tdir)
+            self.assertEqual(rc, 0)
+            self.assertIn(
+                "Friction events (exit_code ≠ 0 despite positive prediction): **1**",
+                buf.getvalue(),
+            )
+
+    def test_absolute_path_grep_is_recognized(self):
+        """`/usr/bin/grep` should resolve to `grep` after basename strip."""
+        with tempfile.TemporaryDirectory() as td:
+            tdir = Path(td)
+            _write_jsonl(
+                tdir / "2026-04-20-audit.jsonl",
+                [
+                    _pred(
+                        "a1", op="grep", cmd="/usr/bin/grep pat file.txt",
+                        unknowns=["whether the absolute-path invocation is filtered too"],
+                        disc="filter must recognize basename across path prefixes",
+                        ts="2026-04-20T10:00:00+00:00",
+                    ),
+                    _out(
+                        "a1", exit_code=1,
+                        ts="2026-04-20T10:00:05+00:00",
+                        cmd="/usr/bin/grep pat file.txt",
+                    ),
+                ],
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli._evolve_friction(telemetry_dir=tdir)
+            self.assertEqual(rc, 0)
+            self.assertIn(
+                "Friction events (exit_code ≠ 0 despite positive prediction): **0**",
+                buf.getvalue(),
+            )
+
+    def test_helper_function_unit_cases(self):
+        """Direct unit tests on `_is_grep_like_no_match` to nail the contract:
+        exit_code == 1 + grep-class terminal command → True; everything
+        else → False (conservative: keeps records when in doubt)."""
+        # Positive cases: exit=1 + grep-class terminal command.
+        self.assertTrue(cli._is_grep_like_no_match("grep foo bar", 1))
+        self.assertTrue(cli._is_grep_like_no_match("egrep -i foo bar", 1))
+        self.assertTrue(cli._is_grep_like_no_match("rg foo", 1))
+        self.assertTrue(cli._is_grep_like_no_match("diff a b", 1))
+        self.assertTrue(cli._is_grep_like_no_match("find . -name x", 1))
+        self.assertTrue(cli._is_grep_like_no_match("ls && grep foo bar.txt", 1))
+        self.assertTrue(cli._is_grep_like_no_match("a | b | grep z", 1))
+        self.assertTrue(cli._is_grep_like_no_match("/usr/local/bin/rg foo", 1))
+        # Negative cases: wrong exit code.
+        self.assertFalse(cli._is_grep_like_no_match("grep foo bar", 0))
+        self.assertFalse(cli._is_grep_like_no_match("grep foo bar", 2))
+        self.assertFalse(cli._is_grep_like_no_match("grep foo bar", 130))
+        # Negative cases: wrong terminal command.
+        self.assertFalse(cli._is_grep_like_no_match("git push", 1))
+        self.assertFalse(cli._is_grep_like_no_match("npm publish", 1))
+        self.assertFalse(cli._is_grep_like_no_match("cargo publish --token X", 1))
+        # Negative cases: empty / parse-ambiguous.
+        self.assertFalse(cli._is_grep_like_no_match("", 1))
+        self.assertFalse(cli._is_grep_like_no_match("   ", 1))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes a signal-quality gap in `episteme evolve friction` observed at the 2026-05-03 diagnostic pass: 656 paired predictions / 4 reported friction events, all 4 concentrated on `cascade:architectural` — but each was a `git status && grep` shape where `grep` returned exit=1 from no-match. Not operational failure, not a real disconfirmation fire. The analyzer at `cli.py:678` treated every `exit_code != 0` as friction unconditionally, polluting the top-N rankings.

## Fix

- **`_GREP_LIKE_NOMATCH_COMMANDS` frozenset** (`grep`, `egrep`, `fgrep`, `rg`, `ag`, `ack`, `diff`, `cmp`, `find`, `test`) + **`_is_grep_like_no_match(cmd, exit_code)`** helper at `src/episteme/cli.py:606–657`.
- Returns True iff `exit_code == 1` AND the terminal command in the pipe / sequence (last segment after the rightmost `;`, `&&`, `||`, or `|`) starts with one of those tools, basename-stripped (`/usr/bin/grep` → `grep`).
- **Conservative-by-design.** Returns False on any ambiguity (empty cmd, parse-ambiguous quoted separators, exit code ≠ 1). Wrong-False keeps the record in friction (historical behavior); wrong-True silently drops a real failure — asymmetry favors keeping records when in doubt.
- The friction loop calls the helper after the existing `exit_code == 0` check, before the prediction-envelope check. Comment names Event 103 + the rationale.

## Why exit=1 only

`grep` family + `diff` / `cmp` use exit=1 as a no-match / differs-found signal-by-design. Exit codes ≥ 2 from these tools indicate real errors (invalid flag, regex parse failure, I/O fault) and are NOT filtered.

## Tests (6 new in `tests/test_evolve_friction.py`)

- `test_grep_no_match_exit_1_is_filtered_out` — bare `grep needle haystack.txt` exit=1 is dropped.
- `test_grep_no_match_after_pipe_is_filtered` — `git status && git log | grep \"foo\"` (the actual session-observed shape) is dropped.
- `test_real_failure_exit_1_from_non_grep_stays_in_friction` — `cargo publish --token X` exit=1 (real auth failure) stays as friction.
- `test_grep_real_error_exit_2_stays_in_friction` — `grep --bogus-flag` exit=2 (real grep error) stays.
- `test_absolute_path_grep_is_recognized` — `/usr/bin/grep` basename-strips correctly.
- `test_helper_function_unit_cases` — 11 direct unit assertions on `_is_grep_like_no_match` covering positive cases (grep / egrep / rg / diff / find / pipe-tail / abs-path), wrong-exit-code cases (0, 2, 130), wrong-terminal-command cases (`git push`, `npm publish`, `cargo publish`), and empty-command cases.

## Test plan

- [x] `pytest -q tests/test_evolve_friction.py` — 14/14 passed (6 new + 8 existing).
- [x] Full suite: 771 passed + 21 subtests passed (no regressions in public-tier tests).
- [x] Pre-existing failure `tests/test_session_context_noise_watch.py::NoiseWatchMainIntegration::test_main_silent_on_noise_watch_when_knob_absent` is test-environment pollution (reads operator's real `~/.episteme/derived_knobs.json` which has `noise_watch_set` configured); verified independent of this patch via `git stash` — same failure occurs without my changes. Logged as separate v1.0.1 polish candidate.
- [x] Soak-invariant intact: zero touches to `kernel/*` / `core/hooks/*` / `core/blueprints/*` / `templates/*` / `labs/*`.
- [x] Manual verification: re-running `episteme evolve friction` against the same telemetry corpus now reports 0 friction events instead of 4 (all 4 prior events were grep no-match shapes correctly filtered).

## Out of public-tier scope

The companion (B) sweep — pruning stale claims in private `docs/NEXT_STEPS.md` (correcting the "six derived knobs unconsumed" framing to per-knob status: 3-of-7 wired since Phase 9, 4-of-7 still unwired; marking line 453 "Fence-check enforcement in hooks" as shipped via Blueprint B / CP5 / Event 12) — landed in `~/episteme-private/docs/NEXT_STEPS.md` per Event 66's Tier 1 privatization policy. Invisible to this PR by design.

## Blueprint D self-dogfood

Reasoning Surface declared with `blast_radius_map[]` + per-surface `sync_plan[]` before any edit ran. The validator caught my own missing string-match between `blast_radius` surface label (`git: branch event-103-next-steps-stale-prune-sweep`) and `sync_plan` surface label (initially `git`) and refused to proceed until aligned — the kernel firing on its own author.