### PR TITLE
fix(tests): Event 104 — CI test isolation (unblocks Linux green)

### DIFF
--- a/tests/test_arm_a_auto_instrumentation.py
+++ b/tests/test_arm_a_auto_instrumentation.py
@@ -269,10 +269,25 @@ class PairedHookTests(unittest.TestCase):
         import shutil
         shutil.rmtree(self.tmp_home, ignore_errors=True)
 
+    @unittest.skipUnless(
+        (_REPO_ROOT / "core" / "memory" / "global" / "operator_profile.md").is_file(),
+        "requires operator profile at core/memory/global/operator_profile.md "
+        "(gitignored — present in operator's local env, absent on CI runners). "
+        "Marker-write logic is covered by test_pre_hook_skips_unwatched_file + "
+        "ProfileAxisParserTests + ProfileDiffTests + AutoRecordedFlagTests; "
+        "this test verifies real-path resolution which only matters when the "
+        "real path actually exists.",
+    )
     def test_pre_hook_creates_marker_for_real_profile_path(self):
         """Pre hook called with the REAL canonical operator_profile.md
         path should write a marker. We can verify this without
-        actually editing the real file because the hook only reads."""
+        actually editing the real file because the hook only reads.
+
+        Event 104 — guarded by `skipUnless` so CI runners (where the
+        operator's profile is gitignored and absent) skip cleanly rather
+        than fail. Marker-write logic is covered by sibling tests; this
+        one specifically verifies real-path-resolution which requires
+        the real file."""
         real_profile = (
             _REPO_ROOT / "core" / "memory" / "global" / "operator_profile.md"
         ).resolve()

--- a/tests/test_session_context_noise_watch.py
+++ b/tests/test_session_context_noise_watch.py
@@ -169,12 +169,48 @@ class _IsolatedEpistemeHome:
         self._tmp.cleanup()
 
 
+class _TmpCwd:
+    """Chdir into a tmp dir for the duration of the test.
+
+    Event 104 — `sc.main()` reads cwd-relative paths (`docs/NEXT_STEPS.md`,
+    `HARNESS.md`, `.episteme/reasoning-surface.json`). When the test runs in
+    the operator's real repo cwd, those files exist and their contents are
+    appended to the captured banner — so a substring like `"noise watch:"`
+    appearing in `docs/NEXT_STEPS.md` prose (e.g. documenting the producer's
+    own banner format) leaks into the test output and breaks `assertNotIn`.
+
+    Chdir-isolation makes `Path('docs/NEXT_STEPS.md').exists()` return False
+    for the duration of the test, so the banner producer alone determines
+    whether the noise-watch line appears.
+    """
+    def __init__(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig: str | None = None
+
+    def __enter__(self) -> Path:
+        self._orig = os.getcwd()
+        os.chdir(self._tmp.name)
+        return Path(self._tmp.name)
+
+    def __exit__(self, *a):  # noqa: ARG002
+        if self._orig is not None:
+            try:
+                os.chdir(self._orig)
+            except OSError:
+                pass
+        self._tmp.cleanup()
+
+
 class NoiseWatchMainIntegration(unittest.TestCase):
-    """End-to-end: main() emits the noise-watch line when the knob is set."""
+    """End-to-end: main() emits the noise-watch line when the knob is set.
+
+    Event 104 — wrapped in `_TmpCwd` so cwd-relative file reads (especially
+    `docs/NEXT_STEPS.md`) cannot pollute the captured banner with prose
+    substrings that incidentally match the noise-watch line format."""
 
     def test_main_includes_noise_watch_when_knob_set(self):
         import io
-        with _IsolatedEpistemeHome(), _TmpKnobs(
+        with _TmpCwd(), _IsolatedEpistemeHome(), _TmpKnobs(
             knobs={
                 "noise_watch_set": ["status-pressure", "false-urgency"],
             }
@@ -190,7 +226,7 @@ class NoiseWatchMainIntegration(unittest.TestCase):
 
     def test_main_silent_on_noise_watch_when_knob_absent(self):
         import io
-        with _IsolatedEpistemeHome(), _TmpKnobs(knobs=None):
+        with _TmpCwd(), _IsolatedEpistemeHome(), _TmpKnobs(knobs=None):
             buf = io.StringIO()
             with patch("sys.stdout", buf):
                 rc = sc.main()


### PR DESCRIPTION
## Summary

Master CI has been failing on Linux (Python 3.10 / 3.11 / 3.12) since at least Event 99 (5+ events of red-master that were merged anyway). README's \"766/766 + 21 subtests green\" claim is **local-only** — the operator's macOS env has files that Linux CI runners do not.

Two distinct test isolation failures, fixed symmetrically.

## Failure 1 — cwd pollution leaks `docs/NEXT_STEPS.md` prose into the banner

**Test:** `tests/test_session_context_noise_watch.py::NoiseWatchMainIntegration::test_main_silent_on_noise_watch_when_knob_absent`

`sc.main()` appends `docs/NEXT_STEPS.md` content to the SessionStart banner (line 384-387 of `core/hooks/session_context.py`). When the test runs in the operator's real cwd, NEXT_STEPS.md exists and contains prose like `\"noise watch: status-pressure, false-urgency\"` — the producer's own banner format documented inline. The substring leaks into the captured banner and breaks `assertNotIn(\"noise watch:\", out)` even when `_TmpKnobs(knobs=None)` correctly clears the knob value.

**Fix:** New `_TmpCwd` context manager that chdir's into a tmp dir for the duration of the test, so `Path(\"docs/NEXT_STEPS.md\").exists()` returns False and the banner producer alone determines whether the noise-watch line appears. Applied symmetrically to both the silent-when-absent and includes-when-set tests — the positive test was passing coincidentally (prose substring matched the producer output) and deserves the same isolation discipline.

## Failure 2 — test asserts a gitignored fixture file exists

**Test:** `tests/test_arm_a_auto_instrumentation.py::PairedHookTests::test_pre_hook_creates_marker_for_real_profile_path`

Test asserts `core/memory/global/operator_profile.md` exists at the canonical real-path. That directory is gitignored — present in the operator's local env, absent on CI runners. Test fails immediately at the assertion with `AssertionError: real operator_profile.md must exist`.

**Fix:** `@unittest.skipUnless` decorator that skips when the real profile is absent. Sibling tests cover marker-write logic when the real path is unavailable: `test_pre_hook_skips_unwatched_file` + `ProfileAxisParserTests` + `ProfileDiffTests` + `AutoRecordedFlagTests`. The skipped test specifically verifies real-path resolution which is only meaningful when the path actually exists.

## Test plan

- [x] Local `pytest -q` returns 772 passed + 21 subtests, **0 failures** (was 771 + 1 fail before this patch).
- [x] Targeted: `pytest -q tests/test_session_context_noise_watch.py tests/test_arm_a_auto_instrumentation.py` → 32 passed.
- [x] Soak-invariant intact: zero touches to `kernel/*` / `core/hooks/*` / `core/blueprints/*` / `src/episteme/*` / `templates/*` / `labs/*`.
- [ ] CI green on Python 3.10 / 3.11 / 3.12 (Linux). Expected: 771 passed + 1 skipped (the gitignored-fixture test) + 21 subtests.

## Why this matters

The RC-cycle discipline depends on CI being a meaningful signal. When CI has been red for 5+ events without anyone fixing it, a regression that breaks something different is invisible — drowned in the existing red. This PR restores CI as a working detector; future regressions will be caught at PR time rather than rolled forward through master.

## Blueprint D self-dogfood

Reasoning Surface declared with `blast_radius_map[]` + per-surface `sync_plan[]` before any edit ran. Validator caught my flaw_classification enum violation (used `test-isolation-bug`, not in the spec's enum) — refused to proceed until corrected to `core-logic-misalignment`.