### PR TITLE
fix(web/security): Event 105 — postcss XSS override (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -34,5 +34,10 @@
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "pnpm": {
+    "overrides": {
+      "postcss": ">=8.5.10"
+    }
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss: '>=8.5.10'
+
 importers:
 
   .:
@@ -1993,10 +1996,6 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -4496,7 +4495,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.20
       caniuse-lite: 1.0.30001788
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
@@ -4619,12 +4618,6 @@ snapshots:
   picomatch@4.0.4: {}
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.10:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves a moderate-severity transitive postcss XSS vulnerability ([GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93)) in web/. \`pnpm audit\` reports postcss < 8.5.10 has an XSS vector via Unescaped \`</style>\` in CSS Stringify Output.

## Root cause

The dep tree had two postcss versions:
- **postcss@8.4.31** (vulnerable) — transitive via \`next@16.2.4\`
- **postcss@8.5.10** (patched) — transitive via \`@tailwindcss/postcss@4.2.4\`

## Fix

Add a \`pnpm.overrides\` block to \`web/package.json\` forcing postcss \`>=8.5.10\` across all dependents. After \`pnpm install\`, the dep tree unifies on the patched version.

\`\`\`json
\"pnpm\": {
  \"overrides\": {
    \"postcss\": \">=8.5.10\"
  }
}
\`\`\`

## Verification

- [x] \`pnpm audit\` → \"No known vulnerabilities found\" (was 1 moderate before)
- [x] \`pnpm why postcss\` → single 8.5.10 version (was split 8.4.31 + 8.5.10)
- [x] \`pnpm build\` → clean prerender across all 12 routes (en/ko/es/zh readme, opengraph, demos, etc.)
- [ ] CI green on Vercel preview + GitHub checks

## Deferred discovery

When next.js organically ships a release with postcss \`>=8.5.10\`, the pnpm override becomes redundant. Remove the override block and re-run \`pnpm install\` at that point. Tracking via the GHSA-qx2v-qp2m-jg93 advisory + next.js release notes.

## Soak invariant intact

Zero touches to \`kernel/*\` / \`core/hooks/*\` / \`core/blueprints/*\` / \`src/episteme/*\` / \`tests/*\` / \`templates/*\` / \`labs/*\`. Public-tier scope: web/ deps only.

## Blueprint D self-dogfood

Reasoning Surface declared with \`flaw_classification: vulnerability\`, blast_radius_map naming web/package.json + web/pnpm-lock.yaml, sync_plan covering install / audit / build verification before commit.