### PR TITLE
docs(i18n): Event 109 — README.{ko,es,zh}.md parity for OWASP 2026 + Industry convergence

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -77,6 +77,27 @@ El resultado: **un Thinking Framework específico de tu proyecto que se acumula*
 
 ---
 
+## Ejecución zero-trust
+
+El [**OWASP Top 10 for Agentic Applications (2026)**](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) — revisado por más de 100 expertos de la industria — identifica prompt injection, goal hijacking, overreach, memory poisoning y unbounded action como las principales clases de riesgo para agentes autónomos. La estructura Knowns / Unknowns / Assumptions / Disconfirmation es un contador *estructural* a cada uno:
+
+| OWASP Agentic Risk (2026) | contador de episteme |
+|---|---|
+| Manipulación directa de objetivos / prompt injection | Core Question declarada antes de la ejecución; las desviaciones afloran como Unknowns |
+| Inyección indirecta de instrucciones | Knowns / Disconfirmation separan el estado confiable del contenido del prompt; el agente se compromete a un resultado falsable antes de actuar sobre la entrada recuperada |
+| Overreach / acción no limitada | Régimen de restricciones declarado en Frame; política reversible-first aplicada |
+| Alucinación fluida | El campo Unknowns no puede quedar vacío; las suposiciones deben nombrarse antes de actuar sobre ellas |
+| Envenenamiento de memoria | Protocolos Pillar 2 hash-chained — append-only, tamper-evident; reescrituras silenciosas de estado previo son detectadas por `verify_chain` |
+| Bucles de planificación infinita | Condición de Disconfirmation requerida; el bucle sale cuando la evidencia se dispara |
+
+Ninguna suposición se confía hasta ser nombrada. Ninguna acción se toma sin la precondición (Knowns) y el régimen de restricciones declarados. El kernel es la capa de verificación entre intención y ejecución.
+
+### Convergencia industrial — 2025–2026
+
+Frameworks y artículos académicos importantes en la misma ventana convergen sobre los mismos patrones arquitectónicos que el kernel envía: checkpoints pre-invocación a nivel del sistema de archivos ([Capsule Security ClawGuard](https://www.businesswire.com/news/home/20260415670902/), 2026), memoria hash-chained tamper-evident ([SSGM](https://arxiv.org/abs/2603.11768) — Lam et al., 2026), alineación basada en razones en lugar de listas de reglas ([Anthropic's Claude Constitution](https://www.anthropic.com/constitution), 2026-01-22), bucle cognitivo de cinco fases con capa de gobernanza ([SCL R-CCAM](https://arxiv.org/abs/2511.17673) — Kim, 2025), e integridad de agente de cinco pilares ([Proofpoint Agent Integrity Framework 2026](https://www.proofpoint.com/us/resources/white-papers/agent-integrity-framework)). El kernel precede a estas publicaciones (CP1 enviado 2026-04-21; v1.0.0 GA 2026-04-28); la convergencia es validación independiente, no linaje. Mapa completo de atribución en [`kernel/REFERENCES.md`](./kernel/REFERENCES.md) bajo *Convergent contemporary work*.
+
+---
+
 ## Cognitive Arms — v1.1+
 
 Los cuatro Blueprints (arriba) y los tres Pillars — Cognitive Blueprints · Append-Only Hash Chain · Framework Synthesis & Active Guidance — son la *base estructural inmóvil* de v1.0. Los Pillars no se mueven. v1.1 añade **3 Cognitive Arms** que operan encima: motores activos y fluidos que refactorizan el propio conocimiento del kernel a lo largo del tiempo.

--- a/README.ko.md
+++ b/README.ko.md
@@ -154,6 +154,27 @@ episteme doctor
 
 ---
 
+## 제로 트러스트 실행
+
+[**OWASP Top 10 for Agentic Applications (2026)**](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) — 100명 이상의 업계 전문가가 동료 검토한 자율 에이전트의 주요 위험 분류 — 는 prompt injection, goal hijacking, overreach, memory poisoning, unbounded action을 핵심 위험 클래스로 식별한다. Knowns / Unknowns / Assumptions / Disconfirmation 구조는 각각에 대한 *구조적* 반박이다:
+
+| OWASP Agentic Risk (2026) | episteme의 반박 |
+|---|---|
+| 직접 목표 조작 / prompt injection | 실행 전 Core Question 선언; 이탈은 Unknowns로 표면화 |
+| 간접 명령 주입 | Knowns / Disconfirmation이 신뢰 가능한 상태와 prompt 내용을 분리; 검색된 입력에 따라 행동하기 전 falsifiable한 결과에 commit |
+| Overreach / unbounded action | Frame에서 제약 체제 선언; reversible-first 정책 강제 |
+| 유창한 환각 | Unknowns 필드는 비워둘 수 없음; 행동 전 가정은 명명되어야 함 |
+| 메모리 오염 | Pillar 2 hash-chained protocols — append-only, tamper-evident; 사전 상태의 침묵 재작성은 `verify_chain`이 감지 |
+| 무한 계획 루프 | Disconfirmation 조건 필수; 증거 발화 시 루프 종료 |
+
+명명되지 않은 가정은 신뢰되지 않는다. 전제조건(Knowns)과 제약 체제가 선언되지 않은 한 어떤 행동도 취해지지 않는다. 커널은 의도와 실행 사이의 검증 레이어다.
+
+### 업계 수렴 — 2025–2026
+
+같은 시기의 주요 프레임워크와 학술 논문이 커널이 출하한 동일한 아키텍처 패턴으로 수렴하고 있다: 파일 시스템 수준의 사전 호출 체크포인트 ([Capsule Security ClawGuard](https://www.businesswire.com/news/home/20260415670902/), 2026), hash-chained tamper-evident memory ([SSGM](https://arxiv.org/abs/2603.11768) — Lam et al., 2026), 규칙 목록 대신 이유 기반 정렬 ([Anthropic Claude Constitution](https://www.anthropic.com/constitution), 2026-01-22), 거버넌스 레이어를 갖춘 5단계 인지 루프 ([SCL R-CCAM](https://arxiv.org/abs/2511.17673) — Kim, 2025), 5-pillar agent integrity ([Proofpoint Agent Integrity Framework 2026](https://www.proofpoint.com/us/resources/white-papers/agent-integrity-framework)). 커널은 이러한 출판물보다 앞선다 (CP1 2026-04-21 출하; v1.0.0 GA 2026-04-28); 수렴은 독립적 검증이지 계보가 아니다. 전체 attribution map은 [`kernel/REFERENCES.md`](./kernel/REFERENCES.md) *Convergent contemporary work* 섹션 참조.
+
+---
+
 ## 이 아키텍처가 해결하는 실패 모드
 
 `kernel/FAILURE_MODES.md`는 11가지 명명된 실패 모드를 정의한다 — **Kahneman**의 6가지 추론 모드(WYSIATI, question substitution, anchoring, narrative fallacy, planning fallacy, overconfidence)에 3가지 거버넌스 모드(Chesterton's fence, Goodhart drift, Ashby variety mismatch)와 v1.0 RC의 2가지 추가 모드(framework-as-Doxa, cascade-theater)를 더한 것이다.

--- a/README.zh.md
+++ b/README.zh.md
@@ -77,6 +77,27 @@
 
 ---
 
+## 零信任执行
+
+[**OWASP Top 10 for Agentic Applications (2026)**](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) — 由 100 多位业界专家同行评议 — 将 prompt injection、goal hijacking、overreach、memory poisoning、unbounded action 列为自主代理的主要风险类别。Knowns / Unknowns / Assumptions / Disconfirmation 结构对每一项都是*结构性*反制：
+
+| OWASP Agentic Risk (2026) | episteme 的反制 |
+|---|---|
+| 直接目标操纵 / prompt injection | 执行前声明 Core Question；偏差以 Unknowns 形式浮现 |
+| 间接指令注入 | Knowns / Disconfirmation 将可信状态与 prompt 内容分离；代理在依据检索到的输入行动之前承诺一个可证伪的结果 |
+| Overreach / unbounded action | 在 Frame 中声明约束规则；强制 reversible-first 策略 |
+| 流畅幻觉 | Unknowns 字段不可为空；行动前必须命名假设 |
+| 内存投毒 | Pillar 2 hash-chained protocols — append-only、tamper-evident；对先前状态的静默重写由 `verify_chain` 检测 |
+| 无限规划循环 | Disconfirmation 条件必填；证据触发时循环退出 |
+
+未命名的假设不被信任。未声明前提条件 (Knowns) 与约束规则之前不采取任何行动。kernel 是意图与执行之间的验证层。
+
+### 业界收敛 — 2025–2026
+
+同一时间窗内的主要框架与学术论文，正向 kernel 已交付的相同架构模式收敛：文件系统层的 pre-invocation checkpoint ([Capsule Security ClawGuard](https://www.businesswire.com/news/home/20260415670902/), 2026)、hash-chained 防篡改内存 ([SSGM](https://arxiv.org/abs/2603.11768) — Lam et al., 2026)、基于理由而非规则清单的对齐 ([Anthropic Claude Constitution](https://www.anthropic.com/constitution), 2026-01-22)、带治理层的五阶段认知循环 ([SCL R-CCAM](https://arxiv.org/abs/2511.17673) — Kim, 2025)、五支柱 agent integrity ([Proofpoint Agent Integrity Framework 2026](https://www.proofpoint.com/us/resources/white-papers/agent-integrity-framework))。kernel 早于这些出版物 (CP1 于 2026-04-21 交付；v1.0.0 GA 于 2026-04-28)；这种收敛是独立验证，并非血统。完整 attribution map 见 [`kernel/REFERENCES.md`](./kernel/REFERENCES.md) 中 *Convergent contemporary work* 章节。
+
+---
+
 ## Cognitive Arms — v1.1+
 
 上述四个 Blueprint 和三个 Pillar — Cognitive Blueprints · Append-Only Hash Chain · Framework Synthesis & Active Guidance — 是 v1.0 *不变的结构基础*。Pillar 不会移动。v1.1 在其之上加入了 **3 Cognitive Arms**：随着时间推移、不断重构 kernel 自身知识的流动型主动引擎。


### PR DESCRIPTION
## Summary

Closes the i18n parity gap from Event 107 (PR #65, English README OWASP 2026 + Industry convergence). The Korean, Spanish, and Chinese README versions had **no equivalent Zero-trust / OWASP section** prior to this PR — they were behind on multiple recent English-side updates.

Each i18n README now carries:
- A **Zero-trust execution** section citing [**OWASP Top 10 for Agentic Applications (2026)**](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) — peer-reviewed by 100+ industry experts — with the 6-row threat → counter table.
- An **Industry convergence — 2025–2026** subsection naming the same six external works (Capsule ClawGuard, SSGM, Anthropic Constitution, SCL R-CCAM, Proofpoint AIF, OWASP 2026) with the explicit kernel-predates-publication timeline.

## Translation discipline

- **README.ko.md** (Korean — operator's native language): \"제로 트러스트 실행\" inserted before \"이 아키텍처가 해결하는 실패 모드\". Highest-confidence translation.
- **README.es.md** (Spanish): \"Ejecución zero-trust\" inserted before \"Cognitive Arms\". Translation by agent — operator review recommended for idiomatic naturalness.
- **README.zh.md** (Chinese): \"零信任执行\" inserted before \"Cognitive Arms\". Translation by agent — operator review recommended.

**Load-bearing terms preserved untranslated** per agent_feedback's kernel-tone-discipline rule: Reasoning Surface, Pillar 2, hash-chain, Knowns / Unknowns / Assumptions / Disconfirmation, prompt injection, OWASP, Cognitive Arms, etc.

## Verification

- [x] \`pnpm build\` clean across all 12 routes incl. /readme/ko, /readme/es, /readme/zh
- [x] \`pytest -q\` → 772 passed + 21 subtests, zero regressions
- [ ] Operator visual review on Vercel preview for idiomatic naturalness (es / zh)
- [ ] CI green on Linux 3.10 / 3.11 / 3.12

## Soak invariant

Zero touches to \`kernel/*\` / \`core/hooks/*\` / \`core/blueprints/*\` / \`src/episteme/*\` / \`tests/*\` / \`templates/*\` / \`labs/*\`. Public-tier scope: README.{ko,es,zh}.md only.