### PR TITLE
fix(web): Event 111 — strip residual jargon (PillarsArch second chain, SymbiosisTimeline hex/path/percentages, CodeSample fence-reconstruct)

### DIFF
--- a/web/src/components/site/CodeSample.tsx
+++ b/web/src/components/site/CodeSample.tsx
@@ -21,7 +21,7 @@ const lines = [
   { t: "mut", v: "matching protocols from prior decisions" },
   { t: "out", v: "  · drop-check-without-call-graph-walk → block" },
   { t: "out", v: "  · widen-enum-without-downstream-audit → escalate" },
-  { t: "out", v: "  · null-on-constrained-column → fence-reconstruct first" },
+  { t: "out", v: "  · adding NULL to a constrained column → reconstruct the fence first" },
   { t: "out", v: "" },
   { t: "chain", v: "↳ surface committed · linked to prior decisions" },
 ];

--- a/web/src/components/site/SymbiosisTimeline.tsx
+++ b/web/src/components/site/SymbiosisTimeline.tsx
@@ -56,7 +56,7 @@ const ACTS: Act[] = [
     n: "03",
     title: "Three Critical findings — corroborated by historical telemetry",
     narration:
-      "Munger latticework runs: Inversion · Second-order effects · Margin of safety. Three findings emerge. Independently, the operator's own profile-audit drift on `asymmetry_posture: loss-averse` (running at 20% / 7% against a 55% / 30% floor across 15 prior records) had already predicted exactly this failure mode.",
+      "Munger latticework runs: Inversion · Second-order effects · Margin of safety. Three findings emerge. Independently, the operator's own behavioral telemetry — already flagging that recent decisions had drifted below the loss-averse floor the operator had committed to — had predicted exactly this failure mode.",
     artifact_kind: "advisory",
     artifact: `[episteme] Adversarial review — 3 Critical findings
 
@@ -73,8 +73,9 @@ const ACTS: Act[] = [
       The rewrite signals panic without recovering the leak.
 
 [profile audit] CORROBORATES — independent evidence
-  asymmetry_posture: loss-averse · drift 20% / 7% vs 55% / 30% floor
-  The kernel's historical telemetry already had the answer.`,
+  Recent decisions had drifted below the loss-averse floor
+  the operator had committed to. The kernel's behavioral
+  telemetry already had the answer.`,
   },
   {
     n: "04",
@@ -91,21 +92,22 @@ const ACTS: Act[] = [
     narration:
       "Axiomatic Judgment fires on the conflict between Source A (\"ship the bundle now\") and Source B (\"reversible-first + loss-averse posture\"). The resolved rule is hash-chained into the framework, tamper-evident, re-applicable.",
     artifact_kind: "protocol",
-    artifact: `~/.episteme/framework/protocols.jsonl  (cp7-chained-v1)
+    artifact: `Protocol synthesized — written to the tamper-evident chain.
 
-context_signature:
-  blueprint:        axiomatic_judgment
-  op_class:         irreversible-bundle-proposal
-  constraint_head:  privatize-and-rewrite-and-tag
-  runtime_marker:   mid-soak-window
+context where this rule applies:
+  blueprint:    Axiomatic Judgment
+  op class:     irreversible bundle proposal
+  trigger:      privatize + rewrite history + tag, all together
+  when:         mid-soak window
 
-selected_rule:
-  "When an irreversible bundle is proposed under named noise signature
-   (status-pressure or false-urgency), AND the operator's profile-audit
-   drift flags asymmetry_posture below its elicited floor, decompose the
-   bundle along reversibility lines BEFORE any operation runs."
+the rule:
+  "When an irreversible bundle is proposed under named noise
+   (status-pressure or false-urgency), AND behavioral telemetry
+   flags drift below the loss-averse floor, decompose the bundle
+   along reversibility lines BEFORE any operation runs."
 
-this_hash: b2e7a4f8c1d6e9b0a3c5d7e8f1b4c6a9d0e2f573`,
+next time this shape of decision appears, the kernel surfaces
+this rule before the agent defaults to its training distribution.`,
   },
   {
     n: "06",

--- a/web/src/components/site/diagrams/PillarsArchitectureDiagram.tsx
+++ b/web/src/components/site/diagrams/PillarsArchitectureDiagram.tsx
@@ -15,9 +15,9 @@ const BLUEPRINTS = [
 ];
 
 const ENVELOPES = [
-  { seq: "GENESIS", payload: "ø" },
-  { seq: "#001", payload: "blueprint-B-fired" },
-  { seq: "#002", payload: "cascade-resolved" },
+  { seq: "commit 001", payload: "feat: scaffold project" },
+  { seq: "commit 002", payload: "feat: add user login" },
+  { seq: "commit 003", payload: "fix: rate-limit edge case" },
 ];
 
 const GUIDANCE = [


### PR DESCRIPTION
## Summary

Operator's grep audit after #68 caught three places where EPISTEME-internal jargon still leaked into the marketing surface. This PR closes them.

## What was still leaking

1. **PillarsArchitectureDiagram.tsx ENVELOPES** — the *second* hash chain (inside the Pillars diagram, separate from HashChainDiagram) still had \`blueprint-B-fired\` / \`cascade-resolved\` payloads. I universalized HashChainDiagram in #68 but missed this one.

2. **SymbiosisTimeline.tsx** — three residual leaks:
   - 40-char hex placeholder \`b2e7a4f8c1d6e9b0a3c5d7e8f1b4c6a9d0e2f573\` that read as fabricated.
   - Internal path \`~/.episteme/framework/protocols.jsonl (cp7-chained-v1)\` that meant nothing to outside readers.
   - Raw audit percentages (\`drift 20% / 7% vs 55% / 30% floor\`) that read as EPISTEME-internal data.

3. **CodeSample.tsx line 24** — internal protocol shorthand \`null-on-constrained-column → fence-reconstruct first\`.

## Fixes

| File | Change |
|---|---|
| PillarsArchitectureDiagram.tsx | ENVELOPES → git commits matching HashChainDiagram (\`feat: scaffold project\` / \`feat: add user login\` / \`fix: rate-limit edge case\`) |
| SymbiosisTimeline.tsx narration | "drift 20% / 7% vs 55% / 30% floor" → "drifted below the loss-averse floor the operator had committed to" |
| SymbiosisTimeline.tsx advisory artifact | Same percentage prose-rewrite, kept the \"telemetry already had the answer\" punchline |
| SymbiosisTimeline.tsx protocol artifact | Removed 40-char hex; replaced internal-path header with \"Protocol synthesized — written to the tamper-evident chain.\"; rewrote the rule with plain-English context labels (\"trigger:\", \"when:\") |
| CodeSample.tsx line 24 | \"null-on-constrained-column → fence-reconstruct first\" → \"adding NULL to a constrained column → reconstruct the fence first\" |

## Verification

- [x] \`grep '0x[0-9a-fA-F]{4,}|cp7-chained|blueprint-B-fired|cascade-resolved|fence-reconstruct' web/src/components/site/\` → **zero hits**
- [x] \`grep '[0-9a-f]{20,}'\` for long hexes → **zero hits**
- [x] \`grep '20% */ *7%|55% */ *30%'\` for audit percentages → **zero hits**
- [x] \`pnpm build\` clean across all 12 routes
- [x] Story narrative semantically preserved (Event 65 still real, just the jargon-y operator-internal noise stripped)

## Soak invariant

Zero touches to \`kernel/*\` / \`core/hooks/*\` / \`core/blueprints/*\` / \`src/episteme/*\` / \`tests/*\` / \`templates/*\` / \`labs/*\`. Public-tier scope: web/ only.