### PR TITLE
fix(web): Event 112 — drop redundant 'envelope · ' prefix that overflowed Pillars rect

### DIFF
--- a/web/src/components/site/diagrams/PillarsArchitectureDiagram.tsx
+++ b/web/src/components/site/diagrams/PillarsArchitectureDiagram.tsx
@@ -175,7 +175,7 @@ export function PillarsArchitectureDiagram() {
                 fontSize={10}
                 letterSpacing={1.2}
               >
-                envelope · {env.seq}
+                {env.seq}
               </text>
               <text
                 x={376}


### PR DESCRIPTION
Operator visual review caught: `envelope · commit 001` / `002` / `003` overflowed the 180px-wide envelope rect in PillarsArchitectureDiagram.

The `envelope · ` prefix was redundant — the diagram structure already identifies these as envelopes (rect shape + the section header "Pillar 02 · Append-Only Hash Chain"). Dropping it shortens the label 20 → 10 chars, comfortably fitting the rect width.

Headings now render as bare `commit 001` / `commit 002` / `commit 003` — same identifier shape as HashChainDiagram for visual consistency.

`pnpm build` clean across all 12 routes.