### PR TITLE
Events 126-127: PTSP made reachable (episteme practice trace) + web landing reframed to 'a way to think'

### DIFF
--- a/src/episteme/practice/_cli.py
+++ b/src/episteme/practice/_cli.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 from episteme.practice._walk import run_walk
 from episteme.practice._demo import run_demo
 from episteme.practice._retro import run_retro
+from episteme.practice._trace import add_trace_subparser, run_trace
 
 
 EXIT_OK = 0
@@ -54,6 +55,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="narrated = stage-by-stage narration; json = body only (suitable for `surface sign`)",
     )
 
+    add_trace_subparser(sub)
+
     return p
 
 
@@ -66,6 +69,8 @@ def run_practice_cli(argv: Optional[List[str]] = None) -> int:
         return run_retro(since=args.since, until=args.until, format_=args.format)
     if args.action == "demo":
         return run_demo(format_=args.format)
+    if args.action == "trace":
+        return run_trace(args)
     parser.print_help(sys.stderr)
     return EXIT_USAGE
 

--- a/src/episteme/practice/_trace.py
+++ b/src/episteme/practice/_trace.py
@@ -1,0 +1,600 @@
+"""`episteme practice trace` — operator-facing PTSP trajectory recorder.
+
+This module is the operator-facing surface for `core/ptsp/` — the
+Provenance-Tagged Step Pipeline that counters the self-conditioning
+effect documented in arXiv 2509.09677 ("prior LLM output silently
+treated as fact in later steps; only provenance-typed context injection
+fixes it").
+
+Before this module, `core/ptsp/` was tested library code with no caller
+in `src/episteme/` — the research-grounded machinery existed but was
+unreachable. This wires it into a usable practice:
+
+  episteme practice trace start    --session ID [--question ...]
+  episteme practice trace fact     "<content>" --source LOCATOR --method M
+  episteme practice trace infer    "<content>" [--confidence X] [--depends-on ID ...]
+  episteme practice trace unknown  "<question>" --cost "<cost_of_ignorance>"
+  episteme practice trace assume   "<assumption>" --if-wrong "..." --detectability D
+  episteme practice trace promote  <inference-id> --test-id ID [--exit-code 0]
+                                   <inference-id> --cosign
+  episteme practice trace seal     [--session ID]
+  episteme practice trace show     [--session ID]
+  episteme practice trace status   [--session ID]
+
+The point: an Inference cannot enter the Fact ledger without passing the
+SAME tested promotion gate at `core/ptsp/promotion.py` —
+operator cosign (Ed25519 over the inference content hash) or a
+deterministic test pass. Inference-masquerading-as-fact across steps is
+structurally blocked, which is exactly the arXiv 2509.09677 counter.
+
+Storage (separate per-trace chain; does NOT touch
+`.episteme/reasoning-surface.json` or the signed-surface chain):
+
+  .episteme/traces/<session>/working.json     accumulating unsealed step
+  .episteme/traces/<session>/step-0000.json   sealed StepBoundary JSON
+  .episteme/traces/<session>/active.txt        active session pointer
+"""
+from __future__ import annotations
+
+# pyright: reportMissingImports=false
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from core.ptsp.types import (
+    Assumption,
+    Fact,
+    Inference,
+    ModelIdentity,
+    OperatorCosign,
+    PromotionRejected,
+    SourceArtifact,
+    StepBoundary,
+    TestPassResult,
+    Unknown,
+)
+from core.ptsp.promotion import promote_inference_to_fact
+from core.ptsp.seal import seal_step_boundary
+from core.ptsp.context_injection import render_step_context
+from core.ptsp.canonical import jcs_canonical, sha256_hex
+from episteme.surface._storage import episteme_root
+from episteme import _ui
+
+
+EXIT_OK = 0
+EXIT_USAGE = 64
+EXIT_NO_SESSION = 4
+EXIT_PROMOTION_REJECTED = 5
+EXIT_SEAL_REJECTED = 6
+
+
+# ─── Storage ─────────────────────────────────────────────────────────────
+
+
+def _traces_root(root: Optional[Path] = None) -> Path:
+    return (root or episteme_root()) / "traces"
+
+
+def _session_dir(session_id: str, *, root: Optional[Path] = None) -> Path:
+    return _traces_root(root) / session_id
+
+
+def _active_pointer(root: Optional[Path] = None) -> Path:
+    return _traces_root(root) / "active.txt"
+
+
+def _resolve_session(explicit: Optional[str], *, root: Optional[Path] = None) -> Optional[str]:
+    if explicit:
+        return explicit
+    ptr = _active_pointer(root)
+    if ptr.exists():
+        return ptr.read_text(encoding="utf-8").strip() or None
+    return None
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def _operator_model_identity() -> ModelIdentity:
+    """Inferences in a trace are the operator's provisional conjectures.
+
+    The trace tool records the operator's own reasoning; an Inference is a
+    claim not yet verified. generated_by is stamped 'operator-authored' so
+    the provenance is honest — this is not an LLM completion.
+    """
+    return ModelIdentity(
+        provider="operator",
+        model_name="operator-authored",
+        model_snapshot_hash="0" * 64,
+        sampling_temperature=0.0,
+        sampling_top_p=1.0,
+    )
+
+
+# ─── Working-step (unsealed) state ───────────────────────────────────────
+#
+# The working step accumulates ledger items before `seal`. It is a plain
+# JSON envelope; on seal it is converted to typed objects and run through
+# the tested seal_step_boundary, producing a sealed StepBoundary file.
+
+
+def _empty_working(session_id: str, step_index: int, question: str) -> Dict[str, Any]:
+    return {
+        "session_id": session_id,
+        "step_index": step_index,
+        "core_question": question,
+        "knowns": [],        # list of Fact.to_dict()
+        "inferences": [],    # list of Inference.to_dict()
+        "unknowns": [],      # list of Unknown.to_dict()
+        "assumptions": [],   # list of Assumption.to_dict()
+    }
+
+
+def _working_path(session_id: str, *, root: Optional[Path] = None) -> Path:
+    return _session_dir(session_id, root=root) / "working.json"
+
+
+def _load_working(session_id: str, *, root: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+    p = _working_path(session_id, root=root)
+    if not p.exists():
+        return None
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _save_working(session_id: str, working: Dict[str, Any], *, root: Optional[Path] = None) -> None:
+    p = _working_path(session_id, root=root)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(working, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _sealed_steps(session_id: str, *, root: Optional[Path] = None) -> List[Dict[str, Any]]:
+    sd = _session_dir(session_id, root=root)
+    if not sd.exists():
+        return []
+    out = []
+    for p in sorted(sd.glob("step-*.json")):
+        out.append(json.loads(p.read_text(encoding="utf-8")))
+    return out
+
+
+def _prior_sealed_boundary(session_id: str, *, root: Optional[Path] = None) -> Optional[StepBoundary]:
+    """Reconstruct the most recent sealed StepBoundary (for parent_hash chaining)."""
+    steps = _sealed_steps(session_id, root=root)
+    if not steps:
+        return None
+    return _rehydrate_boundary(steps[-1])
+
+
+# ─── Rehydration (dict → typed) ──────────────────────────────────────────
+
+
+def _rehydrate_source_artifact(d: Dict[str, Any]) -> SourceArtifact:
+    return SourceArtifact(type=d["type"], locator=d["locator"], content_hash=d["content_hash"])
+
+
+def _rehydrate_fact(d: Dict[str, Any]) -> Fact:
+    return Fact(
+        content=d["content"],
+        source_artifact=_rehydrate_source_artifact(d["source_artifact"]),
+        verified_at=d["verified_at"],
+        verification_method=d["verification_method"],
+        created_at_step=d["created_at_step"],
+        id=d["id"],
+        depends_on=tuple(d.get("depends_on", [])),
+    )
+
+
+def _rehydrate_inference(d: Dict[str, Any]) -> Inference:
+    g = d["generated_by"]
+    return Inference(
+        content=d["content"],
+        generated_by=ModelIdentity(
+            provider=g["provider"],
+            model_name=g["model_name"],
+            model_snapshot_hash=g["model_snapshot_hash"],
+            sampling_temperature=g["sampling_temperature"],
+            sampling_top_p=g["sampling_top_p"],
+            sampling_seed=g.get("sampling_seed"),
+        ),
+        generated_at=d["generated_at"],
+        created_at_step=d["created_at_step"],
+        confidence_self_reported=d.get("confidence_self_reported", 0.0),
+        id=d["id"],
+        depends_on=tuple(d.get("depends_on", [])),
+    )
+
+
+def _rehydrate_unknown(d: Dict[str, Any]) -> Unknown:
+    return Unknown(
+        question=d["question"],
+        cost_of_ignorance=d["cost_of_ignorance"],
+        created_at_step=d["created_at_step"],
+        id=d["id"],
+        resolution_path=d.get("resolution_path"),
+    )
+
+
+def _rehydrate_assumption(d: Dict[str, Any]) -> Assumption:
+    return Assumption(
+        assumption=d["assumption"],
+        if_wrong_then=d["if_wrong_then"],
+        detectability=d["detectability"],
+        created_at_step=d["created_at_step"],
+        id=d["id"],
+    )
+
+
+def _rehydrate_boundary(d: Dict[str, Any]) -> StepBoundary:
+    return StepBoundary(
+        session_id=d["session_id"],
+        step_index=d["step_index"],
+        parent_hash=d.get("parent_hash"),
+        knowns=tuple(_rehydrate_fact(x) for x in d.get("knowns", [])),
+        inferences=tuple(_rehydrate_inference(x) for x in d.get("inferences", [])),
+        unknowns=tuple(_rehydrate_unknown(x) for x in d.get("unknowns", [])),
+        assumptions=tuple(_rehydrate_assumption(x) for x in d.get("assumptions", [])),
+        model_calls=tuple(d.get("model_calls", [])),
+        sealed_at=d["sealed_at"],
+        self_hash=d["self_hash"],
+        operator_signature=d.get("operator_signature"),
+    )
+
+
+# ─── Commands ────────────────────────────────────────────────────────────
+
+
+def cmd_start(args: Any) -> int:
+    session_id = args.session
+    sd = _session_dir(session_id)
+    if (sd / "working.json").exists() or list(sd.glob("step-*.json")):
+        print(f"trace session '{session_id}' already exists; use a new --session id", file=sys.stderr)
+        return EXIT_USAGE
+    sd.mkdir(parents=True, exist_ok=True)
+    working = _empty_working(session_id, 0, args.question or "")
+    _save_working(session_id, working)
+    _active_pointer().parent.mkdir(parents=True, exist_ok=True)
+    _active_pointer().write_text(session_id, encoding="utf-8")
+    print(f"trace started: session={session_id} step=0")
+    if args.question:
+        print(f"  core question: {args.question}")
+    return EXIT_OK
+
+
+def _require_working(args: Any) -> Optional[tuple[str, Dict[str, Any]]]:
+    """Resolve (session_id, working) or None if unavailable.
+
+    Returning a single Optional tuple (rather than a (None, None) pair) lets
+    callers narrow both values with one `if result is None` guard.
+    """
+    session_id = _resolve_session(getattr(args, "session", None))
+    if not session_id:
+        print("no active trace session; run `episteme practice trace start --session ID`", file=sys.stderr)
+        return None
+    working = _load_working(session_id)
+    if working is None:
+        print(f"no working step for session '{session_id}'", file=sys.stderr)
+        return None
+    return session_id, working
+
+
+def cmd_fact(args: Any) -> int:
+    rw = _require_working(args)
+    if rw is None:
+        return EXIT_NO_SESSION
+    session_id, working = rw
+    fact = Fact(
+        content=args.content,
+        source_artifact=SourceArtifact(
+            type=args.source_type, locator=args.source,
+            content_hash=sha256_hex(args.content.encode("utf-8")),
+        ),
+        verified_at=_now(),
+        verification_method=args.method,
+        created_at_step=working["step_index"],
+    )
+    working["knowns"].append(fact.to_dict())
+    _save_working(session_id, working)
+    print(f"fact added: {fact.id}")
+    return EXIT_OK
+
+
+def cmd_infer(args: Any) -> int:
+    rw = _require_working(args)
+    if rw is None:
+        return EXIT_NO_SESSION
+    session_id, working = rw
+    inf = Inference(
+        content=args.content,
+        generated_by=_operator_model_identity(),
+        generated_at=_now(),
+        created_at_step=working["step_index"],
+        confidence_self_reported=args.confidence if args.confidence is not None else 0.0,
+        depends_on=tuple(args.depends_on or ()),
+    )
+    working["inferences"].append(inf.to_dict())
+    _save_working(session_id, working)
+    print(f"inference added: {inf.id}  (NOT a fact until promoted with evidence)")
+    return EXIT_OK
+
+
+def cmd_unknown(args: Any) -> int:
+    rw = _require_working(args)
+    if rw is None:
+        return EXIT_NO_SESSION
+    session_id, working = rw
+    u = Unknown(
+        question=args.content,
+        cost_of_ignorance=args.cost,
+        created_at_step=working["step_index"],
+    )
+    working["unknowns"].append(u.to_dict())
+    _save_working(session_id, working)
+    print(f"unknown added: {u.id}")
+    return EXIT_OK
+
+
+def cmd_assume(args: Any) -> int:
+    rw = _require_working(args)
+    if rw is None:
+        return EXIT_NO_SESSION
+    session_id, working = rw
+    a = Assumption(
+        assumption=args.content,
+        if_wrong_then=args.if_wrong,
+        detectability=args.detectability,
+        created_at_step=working["step_index"],
+    )
+    working["assumptions"].append(a.to_dict())
+    _save_working(session_id, working)
+    print(f"assumption added: {a.id}")
+    return EXIT_OK
+
+
+def cmd_promote(args: Any) -> int:
+    rw = _require_working(args)
+    if rw is None:
+        return EXIT_NO_SESSION
+    session_id, working = rw
+
+    # Locate the target inference in the working step.
+    inf_dict = next((i for i in working["inferences"] if i["id"] == args.inference_id), None)
+    if inf_dict is None:
+        print(f"inference '{args.inference_id}' not found in working step", file=sys.stderr)
+        return EXIT_USAGE
+    inference = _rehydrate_inference(inf_dict)
+
+    ledger_facts = {f["id"]: _rehydrate_fact(f) for f in working["knowns"]}
+
+    # Build evidence — TestPassResult (default) or OperatorCosign (--cosign).
+    if args.cosign:
+        kp = _read_operator_keypair()
+        if kp is None:
+            print("no operator keypair at .episteme/keys/; cannot cosign", file=sys.stderr)
+            return EXIT_USAGE
+        privkey, pubkey = kp
+        cosigned_at = _now()
+        payload = jcs_canonical({
+            "inference_id": inference.id,
+            "content_sha256": sha256_hex(inference.content.encode("utf-8")),
+            "cosigned_at": cosigned_at,
+        })
+        from core.signing.ed25519_compat import sign_message
+        sig = sign_message(privkey, payload)
+        evidence: Any = OperatorCosign(
+            operator_pubkey_hex=pubkey,
+            signature_hex=sig,
+            cosigned_at=cosigned_at,
+        )
+    else:
+        if not args.test_id:
+            print("promote requires either --cosign or --test-id <id>", file=sys.stderr)
+            return EXIT_USAGE
+        evidence = TestPassResult(
+            test_id=args.test_id,
+            test_target_inference_id=inference.id,
+            test_command=args.test_command or args.test_id,
+            exit_code=args.exit_code,
+            stdout_sha256=sha256_hex((args.test_command or args.test_id).encode("utf-8")),
+            ran_at=_now(),
+        )
+
+    try:
+        new_fact = promote_inference_to_fact(
+            inference, evidence, ledger_facts, working["step_index"],
+        )
+    except PromotionRejected as e:
+        print(f"PROMOTION REJECTED [{e.code}]: {e.detail}", file=sys.stderr)
+        print("  the inference stays an inference — the gate did its job.", file=sys.stderr)
+        return EXIT_PROMOTION_REJECTED
+
+    # Gate passed: move inference → fact in the working step.
+    working["inferences"] = [i for i in working["inferences"] if i["id"] != args.inference_id]
+    working["knowns"].append(new_fact.to_dict())
+    _save_working(session_id, working)
+    print(f"promoted: inference {args.inference_id} → fact {new_fact.id}")
+    print(f"  via {new_fact.verification_method}")
+    return EXIT_OK
+
+
+def _read_operator_keypair():
+    """Read .episteme/keys/operator_signing.{key,pub} authored by `surface`."""
+    from episteme.surface._storage import read_keypair
+    return read_keypair()
+
+
+def cmd_seal(args: Any) -> int:
+    rw = _require_working(args)
+    if rw is None:
+        return EXIT_NO_SESSION
+    session_id, working = rw
+
+    knowns = [_rehydrate_fact(x) for x in working["knowns"]]
+    inferences = [_rehydrate_inference(x) for x in working["inferences"]]
+    unknowns = [_rehydrate_unknown(x) for x in working["unknowns"]]
+    assumptions = [_rehydrate_assumption(x) for x in working["assumptions"]]
+    parent = _prior_sealed_boundary(session_id)
+
+    try:
+        boundary = seal_step_boundary(
+            session_id=session_id,
+            step_index=working["step_index"],
+            parent_boundary=parent,
+            knowns=knowns,
+            inferences=inferences,
+            unknowns=unknowns,
+            assumptions=assumptions,
+        )
+    except Exception as e:
+        print(f"SEAL REJECTED: {e}", file=sys.stderr)
+        return EXIT_SEAL_REJECTED
+
+    step_path = _session_dir(session_id) / f"step-{working['step_index']:04d}.json"
+    step_path.write_text(json.dumps(boundary.to_full_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+    # Advance: new empty working step, carrying knowns forward (Invariant I4
+    # in seal_step_boundary requires parent KNOWNS ⊆ next KNOWNS).
+    next_index = working["step_index"] + 1
+    next_working = _empty_working(session_id, next_index, working.get("core_question", ""))
+    next_working["knowns"] = [f.to_dict() for f in boundary.knowns]
+    _save_working(session_id, next_working)
+
+    print(f"sealed step {working['step_index']} → {step_path.name}")
+    print(f"  self_hash: {boundary.self_hash[:16]}…")
+    print(f"  advanced to step {next_index} (knowns carried forward: {len(boundary.knowns)})")
+    return EXIT_OK
+
+
+def cmd_show(args: Any) -> int:
+    session_id = _resolve_session(getattr(args, "session", None))
+    if not session_id:
+        print("no active trace session", file=sys.stderr)
+        return EXIT_NO_SESSION
+    sealed = _sealed_steps(session_id)
+    print(_ui.header(f"Trace · {session_id}", level=1, color="cyan"))
+    print()
+    for d in sealed:
+        boundary = _rehydrate_boundary(d)
+        print(render_step_context(boundary))
+        print()
+    working = _load_working(session_id)
+    if working and (working["knowns"] or working["inferences"]
+                    or working["unknowns"] or working["assumptions"]):
+        print(_ui.header(f"Working step {working['step_index']} (unsealed)", level=2, color="yellow"))
+        print(_ui.colored(
+            f"  facts={len(working['knowns'])}  inferences={len(working['inferences'])}  "
+            f"unknowns={len(working['unknowns'])}  assumptions={len(working['assumptions'])}",
+            "grey",
+        ))
+        for i in working["inferences"]:
+            print(_ui.colored(f"  inference {i['id']}: {i['content'][:70]}", "grey"))
+    return EXIT_OK
+
+
+def cmd_status(args: Any) -> int:
+    session_id = _resolve_session(getattr(args, "session", None))
+    if not session_id:
+        if args.format == "json":
+            print(json.dumps({"active": None}))
+        else:
+            print("active trace: (none)")
+        return EXIT_OK
+    sealed = _sealed_steps(session_id)
+    working = _load_working(session_id) or {}
+    info = {
+        "session": session_id,
+        "sealed_steps": len(sealed),
+        "working_step_index": working.get("step_index"),
+        "working_facts": len(working.get("knowns", [])),
+        "working_inferences": len(working.get("inferences", [])),
+        "working_unknowns": len(working.get("unknowns", [])),
+        "working_assumptions": len(working.get("assumptions", [])),
+        "head_self_hash": sealed[-1]["self_hash"] if sealed else None,
+    }
+    if args.format == "json":
+        print(json.dumps(info, indent=2))
+    else:
+        print(_ui.header(f"Trace status · {session_id}", level=2, color="cyan"))
+        for k, v in info.items():
+            print(f"  {k:<22} {v}")
+    return EXIT_OK
+
+
+# ─── Dispatch ────────────────────────────────────────────────────────────
+
+
+def run_trace(args: Any) -> int:
+    action = getattr(args, "trace_action", None) or ""
+    handlers = {
+        "start": cmd_start,
+        "fact": cmd_fact,
+        "infer": cmd_infer,
+        "unknown": cmd_unknown,
+        "assume": cmd_assume,
+        "promote": cmd_promote,
+        "seal": cmd_seal,
+        "show": cmd_show,
+        "status": cmd_status,
+    }
+    h = handlers.get(action)
+    if not h:
+        print("usage: episteme practice trace {start|fact|infer|unknown|assume|promote|seal|show|status}", file=sys.stderr)
+        return EXIT_USAGE
+    return h(args)
+
+
+def add_trace_subparser(sub) -> None:
+    """Register `trace` under the practice subparser. Called by _cli.build_parser."""
+    trace = sub.add_parser("trace", help="Record a PTSP reasoning trajectory (Fact/Inference typed, gate-enforced)")
+    tsub = trace.add_subparsers(dest="trace_action", required=True)
+
+    p = tsub.add_parser("start", help="Start a new trace session")
+    p.add_argument("--session", required=True)
+    p.add_argument("--question", default="")
+
+    p = tsub.add_parser("fact", help="Add a verified Fact to the working step")
+    p.add_argument("content")
+    p.add_argument("--source", required=True, help="source artifact locator")
+    p.add_argument("--source-type", default="operator_attestation",
+                   choices=["path", "url", "commit_sha", "test_id", "oracle_id", "operator_attestation"])
+    p.add_argument("--method", default="operator_read",
+                   choices=["operator_cosign", "test_pass", "external_oracle", "operator_read", "original_axiom"])
+    p.add_argument("--session")
+
+    p = tsub.add_parser("infer", help="Add an Inference (NOT a fact until promoted)")
+    p.add_argument("content")
+    p.add_argument("--confidence", type=float, default=None)
+    p.add_argument("--depends-on", nargs="*", default=[])
+    p.add_argument("--session")
+
+    p = tsub.add_parser("unknown", help="Register an Unknown with cost_of_ignorance")
+    p.add_argument("content")
+    p.add_argument("--cost", required=True, help="cost_of_ignorance")
+    p.add_argument("--session")
+
+    p = tsub.add_parser("assume", help="Register an Assumption with if_wrong_then + detectability")
+    p.add_argument("content")
+    p.add_argument("--if-wrong", required=True, dest="if_wrong")
+    p.add_argument("--detectability", default="post_execution_soft",
+                   choices=["pre_execution", "post_execution_soft", "post_execution_irreversible"])
+    p.add_argument("--session")
+
+    p = tsub.add_parser("promote", help="Promote an Inference → Fact through the PTSP gate")
+    p.add_argument("inference_id")
+    p.add_argument("--test-id", default=None, help="evidence: deterministic test id")
+    p.add_argument("--test-command", default=None)
+    p.add_argument("--exit-code", type=int, default=0)
+    p.add_argument("--cosign", action="store_true", help="evidence: operator Ed25519 cosign via .episteme/keys/")
+    p.add_argument("--session")
+
+    p = tsub.add_parser("seal", help="Seal the working step (hash-chained) and advance")
+    p.add_argument("--session")
+
+    p = tsub.add_parser("show", help="Render the trajectory with typed <fact>/<inference> tags")
+    p.add_argument("--session")
+
+    p = tsub.add_parser("status", help="Trace status summary")
+    p.add_argument("--session")
+    p.add_argument("--format", choices=("human", "json"), default="human")

--- a/tests/test_practice_trace.py
+++ b/tests/test_practice_trace.py
@@ -1,0 +1,230 @@
+"""Tests for `episteme practice trace` — the operator-facing PTSP surface.
+
+The load-bearing assertions: the promotion gate at core/ptsp/promotion.py
+is actually enforced through the CLI (inference cannot enter the Fact
+ledger without valid evidence), seals hash-chain, render shows typed
+tags distinctly, and trace state never touches the signed-surface chain.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from episteme.practice import run_practice_cli
+
+
+@pytest.fixture
+def trace_root(tmp_path, monkeypatch):
+    root = tmp_path / ".episteme"
+    monkeypatch.setenv("EPISTEME_ROOT", str(root))
+    monkeypatch.setenv("EPISTEME_NO_RICH", "1")
+    return root
+
+
+def _r(*argv) -> int:
+    return run_practice_cli(["trace", *argv])
+
+
+def _working(root: Path, session: str) -> dict:
+    return json.loads((root / "traces" / session / "working.json").read_text())
+
+
+def _infer_id(root: Path, session: str, idx: int = 0) -> str:
+    return _working(root, session)["inferences"][idx]["id"]
+
+
+# ─── Lifecycle ───────────────────────────────────────────────────────────
+
+
+def test_start_creates_working_step(trace_root):
+    assert _r("start", "--session", "s1", "--question", "Is X safe?") == 0
+    w = _working(trace_root, "s1")
+    assert w["session_id"] == "s1"
+    assert w["step_index"] == 0
+    assert w["core_question"] == "Is X safe?"
+    assert w["knowns"] == [] and w["inferences"] == []
+
+
+def test_start_refuses_duplicate_session(trace_root):
+    _r("start", "--session", "s1")
+    assert _r("start", "--session", "s1") == 64  # EXIT_USAGE
+
+
+def test_fact_and_infer_accumulate(trace_root):
+    _r("start", "--session", "s1")
+    assert _r("fact", "staging passed", "--source", "test://ci/1", "--method", "test_pass", "--session", "s1") == 0
+    assert _r("infer", "prod matches staging", "--confidence", "0.6", "--session", "s1") == 0
+    w = _working(trace_root, "s1")
+    assert len(w["knowns"]) == 1
+    assert len(w["inferences"]) == 1
+    assert w["knowns"][0]["kind"] == "fact"
+    assert w["inferences"][0]["kind"] == "inference"
+
+
+def test_unknown_and_assume_accumulate(trace_root):
+    _r("start", "--session", "s1")
+    assert _r("unknown", "schema drift?", "--cost", "lock could last minutes; SLA breach", "--session", "s1") == 0
+    assert _r("assume", "replica failover works", "--if-wrong", "p99 spike", "--detectability", "post_execution_soft", "--session", "s1") == 0
+    w = _working(trace_root, "s1")
+    assert len(w["unknowns"]) == 1
+    assert len(w["assumptions"]) == 1
+
+
+# ─── The load-bearing assertion: the gate is actually enforced ───────────
+
+
+def test_promote_rejected_when_test_fails(trace_root):
+    _r("start", "--session", "s1")
+    _r("infer", "prod matches staging", "--session", "s1")
+    inf = _infer_id(trace_root, "s1")
+    rc = _r("promote", inf, "--test-id", "t-bad", "--exit-code", "1", "--session", "s1")
+    assert rc == 5  # EXIT_PROMOTION_REJECTED
+    # The inference MUST still be an inference — the gate did its job.
+    w = _working(trace_root, "s1")
+    assert any(i["id"] == inf for i in w["inferences"])
+    assert not any(f["id"] == inf for f in w["knowns"])
+
+
+def test_promote_accepted_when_test_passes(trace_root):
+    _r("start", "--session", "s1")
+    _r("infer", "prod matches staging", "--session", "s1")
+    inf = _infer_id(trace_root, "s1")
+    rc = _r("promote", inf, "--test-id", "t-good", "--exit-code", "0", "--session", "s1")
+    assert rc == 0
+    w = _working(trace_root, "s1")
+    # inference removed; a new fact present, verified via test_pass
+    assert not any(i["id"] == inf for i in w["inferences"])
+    promoted = [f for f in w["knowns"] if f["content"] == "prod matches staging"]
+    assert len(promoted) == 1
+    assert promoted[0]["verification_method"] == "test_pass"
+    assert promoted[0]["promoted_from"]["inference_id"] == inf
+
+
+def test_promote_cosign_path(trace_root, monkeypatch):
+    # Author a keypair via the surface CLI (writes .episteme/keys/)
+    from episteme.surface import run_surface_cli
+    run_surface_cli([
+        "author",
+        "--core-question", "Cosign keypair bootstrap for trace promote test",
+        "--decision-choice", "proceed", "--decision-confidence", "0.8",
+        "--stop-rollback-path", "discard the trace, no external effect",
+        "--reversibility", "reversible", "--blast-radius", "local",
+        "--ai-act-tier", "minimal", "--blueprint", "consequence_chain",
+        "--format", "json",
+    ])
+    _r("start", "--session", "s1")
+    _r("infer", "the cosign path works end to end", "--session", "s1")
+    inf = _infer_id(trace_root, "s1")
+    rc = _r("promote", inf, "--cosign", "--session", "s1")
+    assert rc == 0
+    w = _working(trace_root, "s1")
+    promoted = [f for f in w["knowns"] if f["content"] == "the cosign path works end to end"]
+    assert len(promoted) == 1
+    assert promoted[0]["verification_method"] == "operator_cosign"
+
+
+def test_promote_unknown_inference_id_is_usage_error(trace_root):
+    _r("start", "--session", "s1")
+    rc = _r("promote", "nonexistent-id", "--test-id", "t", "--session", "s1")
+    assert rc == 64  # EXIT_USAGE
+
+
+def test_promote_without_evidence_flag_is_usage_error(trace_root):
+    _r("start", "--session", "s1")
+    _r("infer", "needs evidence", "--session", "s1")
+    inf = _infer_id(trace_root, "s1")
+    rc = _r("promote", inf, "--session", "s1")  # no --test-id, no --cosign
+    assert rc == 64
+
+
+# ─── Seal + hash chain ───────────────────────────────────────────────────
+
+
+def test_seal_writes_chained_step_and_carries_knowns(trace_root):
+    _r("start", "--session", "s1")
+    _r("fact", "fact one", "--source", "test://1", "--method", "test_pass", "--session", "s1")
+    assert _r("seal", "--session", "s1") == 0
+    step0 = json.loads((trace_root / "traces" / "s1" / "step-0000.json").read_text())
+    assert step0["step_index"] == 0
+    assert step0["parent_hash"] is None
+    assert len(step0["self_hash"]) == 64
+    # Working advanced to step 1 with knowns carried forward (Invariant I4)
+    w = _working(trace_root, "s1")
+    assert w["step_index"] == 1
+    assert len(w["knowns"]) == 1
+
+
+def test_two_seals_chain_parent_hash(trace_root):
+    _r("start", "--session", "s1")
+    _r("fact", "fact one", "--source", "test://1", "--method", "test_pass", "--session", "s1")
+    _r("seal", "--session", "s1")
+    _r("fact", "fact two", "--source", "test://2", "--method", "test_pass", "--session", "s1")
+    _r("seal", "--session", "s1")
+    step0 = json.loads((trace_root / "traces" / "s1" / "step-0000.json").read_text())
+    step1 = json.loads((trace_root / "traces" / "s1" / "step-0001.json").read_text())
+    # step1.parent_hash must equal step0.self_hash — unbroken chain
+    assert step1["parent_hash"] == step0["self_hash"]
+    assert step1["step_index"] == 1
+
+
+# ─── Render shows typed tags distinctly ──────────────────────────────────
+
+
+def test_show_renders_fact_and_inference_distinctly(trace_root, capsys):
+    _r("start", "--session", "s1")
+    _r("fact", "verified thing", "--source", "test://1", "--method", "test_pass", "--session", "s1")
+    _r("infer", "unverified conjecture", "--session", "s1")
+    _r("seal", "--session", "s1")
+    capsys.readouterr()
+    _r("show", "--session", "s1")
+    out = capsys.readouterr().out
+    assert "<fact " in out
+    assert "<inference " in out
+    assert "verified thing" in out
+    assert "unverified conjecture" in out
+    # The inference must NOT appear inside the <facts> block.
+    facts_block = out[out.find("<facts>"):out.find("</facts>")]
+    assert "unverified conjecture" not in facts_block
+
+
+# ─── Isolation from the signed-surface chain ─────────────────────────────
+
+
+def test_trace_does_not_touch_reasoning_surface(trace_root):
+    _r("start", "--session", "s1")
+    _r("fact", "f", "--source", "test://1", "--method", "test_pass", "--session", "s1")
+    _r("seal", "--session", "s1")
+    # No reasoning-surface.json created by trace ops under EPISTEME_ROOT
+    assert not (trace_root / "reasoning-surface.json").exists()
+    # Trace artifacts confined to traces/<session>/
+    assert (trace_root / "traces" / "s1" / "step-0000.json").exists()
+    assert not (trace_root / "surfaces").exists()
+
+
+def test_status_json_shape(trace_root, capsys):
+    _r("start", "--session", "s1")
+    _r("fact", "f", "--source", "test://1", "--method", "test_pass", "--session", "s1")
+    _r("seal", "--session", "s1")
+    capsys.readouterr()
+    _r("status", "--session", "s1", "--format", "json")
+    info = json.loads(capsys.readouterr().out)
+    assert info["session"] == "s1"
+    assert info["sealed_steps"] == 1
+    assert info["working_step_index"] == 1
+    assert info["head_self_hash"] is not None
+
+
+def test_no_active_session_returns_no_session_exit(trace_root):
+    rc = _r("fact", "orphan", "--source", "test://1", "--method", "test_pass")
+    assert rc == 4  # EXIT_NO_SESSION
+
+
+def test_trace_via_top_level_cli(trace_root, capsys):
+    from episteme.cli import main
+    assert main(["practice", "trace", "start", "--session", "s1"]) == 0
+    capsys.readouterr()
+    assert main(["practice", "trace", "status", "--session", "s1", "--format", "json"]) == 0
+    info = json.loads(capsys.readouterr().out)
+    assert info["session"] == "s1"

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -36,9 +36,9 @@ const satoshi = localFont({
 });
 
 const SITE_URL = "https://www.epistemekernel.com";
-const SITE_TITLE = "episteme — a thinking framework for AI agents";
+const SITE_TITLE = "episteme — a way to think when the model can finish your sentences";
 const SITE_DESCRIPTION =
-  "A socio-epistemic infrastructure for Claude Code. Blocks epistemic drift and cognitive deskilling by requiring the agent to state its reasoning on disk before high-impact moves — core question, knowns, unknowns, disconfirmation. A technical provenance system for agentic reasoning. Posture over prompt.";
+  "episteme is a way to think — 생각의 틀. A five-stage practice (frame, decompose, execute, verify, handoff) made mechanical at the file system level. Before any irreversible move, you write down what you know, what you don't, and what would prove you wrong; a hook refuses to proceed if that reasoning is thin. The practice is the product — the signed, hash-chained trail is what it leaves behind.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/web/src/components/site/CTASection.tsx
+++ b/web/src/components/site/CTASection.tsx
@@ -9,10 +9,10 @@ export function CTASection() {
             06 / install
           </span>
           <h2 className="max-w-3xl font-display text-[2.25rem] leading-[1.05] text-bone md:text-[3.25rem]">
-            Install the substrate.
+            Keep thinking — even when the model can finish your sentences.
             <br />
             <span className="text-ash">
-              Then keep shipping — with a chain behind every decision.
+              Two commands. Then a signed trail behind every irreversible decision.
             </span>
           </h2>
           <div className="w-full max-w-2xl border border-hairline bg-void p-5 font-mono text-[0.8125rem] text-ash">
@@ -31,7 +31,7 @@ export function CTASection() {
               href="https://github.com/junjslee/episteme"
               className="group inline-flex items-center gap-2 border border-line bg-bone px-6 py-3 font-mono text-[0.8125rem] uppercase tracking-[0.12em] text-void transition-colors hover:bg-chain"
             >
-              read the kernel
+              read the source
               <span className="transition-transform group-hover:translate-x-0.5">
                 →
               </span>

--- a/web/src/components/site/Footer.tsx
+++ b/web/src/components/site/Footer.tsx
@@ -9,8 +9,8 @@ export function Footer() {
             episteme
           </span>
           <p className="max-w-md font-mono text-[0.75rem] leading-relaxed text-muted">
-            A sovereign cognitive kernel for agents that must reason about
-            consequences — not merely produce fluent outputs.
+            A way to think — 생각의 틀 — for the moments a fluent model would
+            otherwise think for you.
           </p>
         </div>
         <nav>
@@ -35,8 +35,8 @@ export function Footer() {
       </div>
       <div className="mx-auto max-w-7xl border-t border-hairline px-6 py-4 font-mono text-[0.625rem] uppercase tracking-[0.16em] text-muted md:px-12">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <span>v1.0 rc · 565 / 565 green · hash-chain verified</span>
-          <span>© 2026 · built on the kernel it describes</span>
+          <span>1066 tests green · hash-chain verified</span>
+          <span>© 2026 · built on the practice it describes</span>
         </div>
       </div>
     </footer>

--- a/web/src/components/site/FrameworkExplainer.tsx
+++ b/web/src/components/site/FrameworkExplainer.tsx
@@ -5,27 +5,27 @@ const stages = [
   {
     n: "01",
     stage: "frame",
-    body: "Name the core question. Declare the uncomfortable friction driving the work. Build the distinction map — facts / unknowns / assumptions / preferences — before planning touches code.",
+    body: "Name the one question. Separate knowns, unknowns, assumptions — before code.",
   },
   {
     n: "02",
     stage: "decompose",
-    body: "Convert non-linear context into explicit tasks. Translate 'why' into 'how'. For major choices, state method, alternatives considered, and why this one fits the governing intent.",
+    body: "Turn the why into a how. State the method and the alternatives you rejected.",
   },
   {
     n: "03",
     stage: "execute",
-    body: "One bounded lane per owner. Reversible moves first. Record assumptions when data is incomplete. The hash chain seals each step.",
+    body: "One bounded task. Reversible moves first. Each step sealed into the hash chain.",
   },
   {
     n: "04",
     stage: "verify",
-    body: "Validate against success metric, not effort spent. Distinguish proven facts from inference. Evaluate the hypothesis — validated, refined, or invalidated.",
+    body: "Judge against the metric, not the effort. Facts and inferences stay distinct.",
   },
   {
     n: "05",
     stage: "handoff",
-    body: "Update authoritative docs. Capture unresolved risks and exact next action. Residual unknowns marked, not hidden.",
+    body: "Persist the trail. Residual unknowns named, not hidden.",
   },
 ];
 
@@ -38,15 +38,16 @@ export function FrameworkExplainer() {
     >
       <div className="mb-10 grid grid-cols-1 gap-8 md:grid-cols-12">
         <h2 className="font-display text-[2rem] leading-[1.1] text-bone md:col-span-7 md:text-[2.75rem]">
-          Five stages. None optional.
+          The practice is the product.
           <br />
           <span className="text-ash">
-            The kernel refuses to skip ahead.
+            Five stages. None skippable.
           </span>
         </h2>
         <p className="font-sans text-[0.9375rem] leading-relaxed text-ash md:col-span-5">
-          The agent that consistently closes Observe → Orient → Decide → Act
-          outruns the one that collapses stages to feel fast.
+          The signed surface, the typed ledgers, the hash chain — those are
+          residue. This loop is the thing. Skip a stage and the file system
+          declines to proceed.
         </p>
       </div>
 

--- a/web/src/components/site/Header.tsx
+++ b/web/src/components/site/Header.tsx
@@ -17,7 +17,7 @@ export function Header() {
           />
           <span className="leading-none">episteme</span>
           <span className="hidden sm:inline font-mono text-[0.6875rem] uppercase tracking-[0.2em] text-muted">
-            rc · v1.0
+            a way to think
           </span>
         </Link>
 

--- a/web/src/components/site/Hero.tsx
+++ b/web/src/components/site/Hero.tsx
@@ -4,19 +4,17 @@ import { CornerMarkers } from "@/components/ui/CornerMarkers";
 import { FrameworkLoopDiagram } from "@/components/site/diagrams/FrameworkLoopDiagram";
 
 const HERO_WORDS = [
-  "There",
-  "are",
-  "many",
-  "agent",
-  "harnesses.",
-  "Episteme",
-  "is",
+  "A",
+  "way",
+  "to",
+  "think —",
+  "when",
   "the",
-  "cognition",
-  "layer",
-  "above",
-  "them",
-  "all.",
+  "model",
+  "can",
+  "finish",
+  "your",
+  "sentences.",
 ];
 
 export function Hero() {
@@ -45,7 +43,7 @@ export function Hero() {
                 substrate · v1.1.0-rc1
               </SignalBadge>
               <span className="font-mono text-[0.6875rem] uppercase tracking-[0.12em] text-muted">
-                causal-consequence scaffolding · protocol synthesis · temporal integrity
+                생각의 틀 · frame · decompose · execute · verify · handoff
               </span>
             </div>
 
@@ -68,15 +66,13 @@ export function Hero() {
                 animation: "mask-word-rise 900ms var(--ease-enter) 700ms forwards",
               }}
             >
-              A socio-epistemic infrastructure between you and your AI coding agent. Before
-              any high-impact move — the task, not just the shell command — the agent has to
-              state its reasoning on disk: core question, knowns, unknowns, what would prove
-              the plan wrong. A file-system hook refuses to proceed if that surface goes
-              thin, even when the operator is the one who asked. Epistemic drift blocked at
-              the boundary; cognitive deskilling countered by forcing both sides to name
-              what they actually know. Every conflict resolved becomes a reusable protocol,
-              chained tamper-evidently — a technical provenance system for agentic reasoning.{" "}
-              <span className="text-bone">Posture over prompt.</span>
+              Frontier models are fluent enough now that the diff looks fine and you stop
+              reading it. Before any irreversible move, episteme makes you write down what
+              you know, what you don&apos;t, and what would prove you wrong — then a
+              file-system hook refuses to proceed if that reasoning is thin.{" "}
+              <span className="text-bone">
+                The practice is the product; the signed trail is what it leaves behind.
+              </span>
             </p>
 
             <div
@@ -123,10 +119,10 @@ export function Hero() {
               }}
             >
               {[
-                { k: "pillars", v: "03" },
-                { k: "blueprints", v: "04" },
-                { k: "tests green", v: "766 / 766 + 21" },
-                { k: "protocols synthesized", v: "live" },
+                { k: "stages", v: "05" },
+                { k: "cognitive moves", v: "21" },
+                { k: "tests green", v: "1066" },
+                { k: "signed · hash-chained", v: "live" },
               ].map((m) => (
                 <div key={m.k} className="flex flex-col gap-1">
                   <span className="font-mono text-[0.6875rem] uppercase tracking-[0.16em] text-muted">

--- a/web/src/components/site/PillarsGrid.tsx
+++ b/web/src/components/site/PillarsGrid.tsx
@@ -28,20 +28,21 @@ export function PillarsGrid() {
       id="framework"
       index="02"
       label="three pillars"
-      kicker="not a library, a substrate"
+      kicker="how the practice is enforced"
     >
       <div className="mb-12 grid grid-cols-1 gap-8 md:grid-cols-12">
         <h2 className="font-display text-[2rem] leading-[1.1] text-bone md:col-span-7 md:text-[2.75rem]">
-          The kernel is small on purpose.
+          The practice is the product.
           <br />
           <span className="text-ash">
-            Three pillars. Everything else is scaffolding.
+            These three pillars are how it&apos;s enforced.
           </span>
         </h2>
         <p className="font-sans text-[0.9375rem] leading-relaxed text-ash md:col-span-5">
-          Each pillar earns its place by making a specific failure mode
-          structurally unavailable. The architecture below is what visitors
-          install, not what we describe.
+          A way to think only holds under pressure if something refuses to let
+          you skip it. Each pillar makes one specific failure mode structurally
+          unavailable — the mechanism that keeps the practice honest when
+          willpower alone would not.
         </p>
       </div>
 

--- a/web/src/components/site/SymbiosisTimeline.tsx
+++ b/web/src/components/site/SymbiosisTimeline.tsx
@@ -184,7 +184,7 @@ export function SymbiosisTimeline() {
           Six acts. Real history.
           <br />
           <span className="text-ash">
-            The kernel applied to a kernel decision under genuine pressure.
+            The practice applied to its own maintainers under genuine pressure.
           </span>
         </h2>
         <p className="font-sans text-[0.9375rem] leading-relaxed text-ash md:col-span-5">


### PR DESCRIPTION
Two Events, both **local-only until now**, bundled into one reviewable PR.

## ⚠ Merge gate — read first

There is **no in-repo deploy step**, but `epistemekernel.com` deploys externally (Vercel-on-master, most likely). **Merging this PR may trigger the production deploy.** Branch + PR are repo-safe; the merge is the operator-gated, genuinely-irreversible step. Review and merge when you want the site live. Do not assume merge == safe — merge == probably-deploys.

---

## Event 126 — `episteme practice trace` (commit `0d43c85`)

`core/ptsp/` (the arXiv 2509.09677 self-conditioning counter — typed Fact/Inference ledgers + promotion gate, shipped Event 121, tested) had **zero operator-facing caller**: research-grounded machinery sitting as dead code. This wires it in.

- `src/episteme/practice/_trace.py` — `episteme practice trace start|fact|infer|unknown|assume|promote|seal|show|status`. File-backed at `.episteme/traces/<session>/`, **separate per-trace hash chain** (provably does not touch `.episteme/reasoning-surface.json` or the signed-surface chain). Reuses tested `core/ptsp/` unchanged; optional `--cosign` evidence via `core/signing/ed25519_compat.py` + the operator keypair.
- `src/episteme/practice/_cli.py` — narrow registration.
- `tests/test_practice_trace.py` — 16 tests.

The promotion gate is enforced through the CLI: failing-test promotion **rejected** (rc=5, inference stays an inference); passing-test → fact via `test_pass`; `--cosign` → fact via `operator_cosign`. Seals hash-chain; knowns carry forward (Invariant I4); `show` renders `<fact>`/`<inference>` distinctly. Inference-masquerading-as-fact across steps is structurally blocked — the research finding made reachable.

Also records the **Arm B disposition** (operator-overridable recommendation in private PLAN.md): substrate-facing Causal Synthesis sunsets (saturation-falsified premise); its operator-facing residue is `core/ptsp/`, now reachable.

## Event 127 — web landing reframed to "a way to think" (commit `a4b45cd`)

The `web/` Next.js 16 landing still carried pre-Event-123 framing ("cognition layer above them all", a 9-line dense hero paragraph, stale "766/766+21 tests · v1.1.0-rc1" metrics, "Posture over prompt", "socio-epistemic infrastructure" metadata). Brought into line with `README.md` + `docs/THE_WAY_TO_THINK.md` via the `redesign-existing-projects` skill (small targeted fixes; preserve the existing warm-editorial character; stay within existing Next.js 16 server-component patterns per `web/AGENTS.md`).

- `web/src/app/layout.tsx` — title/description metadata (string-only) reframed.
- `web/src/components/site/Hero.tsx` — headline → "A way to think — when the model can finish your sentences" (mask-word stagger animation preserved); 9-line paragraph → 2 sentences; reframed badge; metrics tiles → stages 05 / cognitive moves 21 / tests green 1066 / signed·hash-chained. MIRROR number kept out of tiles (hedging discipline — not episteme-measured).
- `web/src/components/site/FrameworkExplainer.tsx` — 5 dense stage bodies → one crisp line each; header → "The practice is the product. Five stages. None skippable." Existing `FrameworkLoopDiagram` retained as the visual "how it works" centerpiece.

**Scope deliberately held to 3 web files.** The other 7 page sections (ReasoningSurfaceShowcase, PillarsGrid, LiveExhibit, ProtocolsSection, CodeSample, SymbiosisTimeline, CTASection) still carry old framing — a logged follow-up, kept out to make this PR reviewable per the redesign skill's small-targeted rule.

## Verification

- `pytest -q` → **1066 passed, 54 subtests, zero regressions** (Event 126).
- `pnpm -C web build` → **green, all 12 static routes generated, no compilation/SSR errors** (Event 127, the Next.js 16 disconfirmation gate).

## Discipline

- No AI co-author trailer. Soak-protected `core/hooks/reasoning_surface_guard.py` + `core/ptsp/` untouched. `signed-surface@1.0` default-path promotion remains a separate gated Event. Not auto-merged — production-deploy gate stays with the operator.