### PR TITLE
fix(cli): installed-CLI repo-root discovery for episteme tier1 / evaluate

### DIFF
--- a/src/episteme/_evaluate.py
+++ b/src/episteme/_evaluate.py
@@ -33,6 +33,16 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Editable-install + repo-checkout discoverability: see _tier1_audit.py
+# for the rationale on this sys.path injection. The evaluate CLI doesn't
+# import from core/ today, but the pattern lands here for symmetry +
+# future-proofing if Mode 4+ surfaces consume telemetry shapes that the
+# classifier owns.
+_REPO_ROOT_CANDIDATE = Path(__file__).resolve().parents[2]
+if (_REPO_ROOT_CANDIDATE / "core" / "practice").is_dir():
+    if str(_REPO_ROOT_CANDIDATE) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT_CANDIDATE))
+
 
 def run_evaluate_cli(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(

--- a/src/episteme/_tier1_audit.py
+++ b/src/episteme/_tier1_audit.py
@@ -26,6 +26,19 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+# Editable-install + repo-checkout discoverability: src/episteme/ is the
+# installed package, but the classifier lives at core/practice/ which is
+# outside the package tree. When invoked from an editable install (`pip
+# install -e .`), Path(__file__).parents[2] is the repo root which holds
+# both src/ and core/. Add it to sys.path so `from core.practice...`
+# resolves at CLI runtime. Non-editable wheel installs (rare today —
+# PyPI publish is disabled per release-please.yml) fall back to the
+# ImportError path in _audit().
+_REPO_ROOT_CANDIDATE = Path(__file__).resolve().parents[2]
+if (_REPO_ROOT_CANDIDATE / "core" / "practice").is_dir():
+    if str(_REPO_ROOT_CANDIDATE) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT_CANDIDATE))
+
 
 def run_tier1_cli(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #85. The Event 135 CLIs (`episteme tier1`, `episteme evaluate`) import from `core.practice.irreversible_tier`, which lives outside the `src/episteme/` package tree. Pytest resolves it via `pythonpath = ["src", "."]` in pyproject.toml, but the installed entry-point runs without that and crashes with `ModuleNotFoundError: No module named 'core'`.

Fix: 2-file edit adding `Path(__file__).parents[2]` to `sys.path` at module-import time when `core/practice/` exists alongside `src/`. Editable-install (`pip install -e .`) users get it automatically. No test changes needed.

Verified locally: `episteme tier1 audit` reports SOAK GATE CLOSED (correct empty-state); `episteme evaluate self-audit --json` produces a real `surface_authoring_rate` from existing telemetry.

## Test plan

- [x] Local smoke-test on system Python 3.11 install (`/Library/Frameworks/Python.framework/Versions/3.11/bin/episteme`)
- [ ] CI: pytest 3.10 / 3.11 / 3.12 green (no test changes but the sys.path injection should not regress collection)
- [ ] CI: Vercel + Vercel Preview Comments green