### PR TITLE
fix(ci): machine-independent drift oracle + fresh-user journey (master is red without this)

### DIFF
--- a/src/episteme/doc_references.py
+++ b/src/episteme/doc_references.py
@@ -353,10 +353,17 @@ def git_ignored(repo_root: Path, paths: Iterable[str]) -> Set[str]:
     items = [p for p in paths]
     if not items:
         return set()
+    # Query each path in both bare and trailing-slash form: a dir-only
+    # pattern (`archive/`) matches the bare spelling only while the
+    # directory exists on disk, so the bare form alone gives a different
+    # answer on a machine that has the local-only dir than on a fresh
+    # clone. The slash form pins the directory interpretation regardless
+    # of on-disk state, keeping the oracle machine-independent.
+    queries = [q for p in items for q in (p, p.rstrip("/") + "/")]
     try:
         proc = subprocess.run(
             ["git", "-C", str(repo_root), "check-ignore", "--stdin"],
-            input="\n".join(items),
+            input="\n".join(queries),
             capture_output=True,
             text=True,
         )
@@ -367,7 +374,8 @@ def git_ignored(repo_root: Path, paths: Iterable[str]) -> Set[str]:
     # case we exempt nothing (fail toward flagging rather than hiding drift).
     if proc.returncode not in (0, 1):
         return set()
-    return {p for p in proc.stdout.split("\n") if p}
+    matched = {p.rstrip("/") for p in proc.stdout.split("\n") if p}
+    return {p for p in items if p in matched or p.rstrip("/") in matched}
 
 
 def find_drift(

--- a/tests/test_doc_references.py
+++ b/tests/test_doc_references.py
@@ -199,6 +199,21 @@ class GitResolutionRobustness(unittest.TestCase):
             # fail toward flagging: exempt nothing rather than crash
             self.assertEqual(set(), dr.git_ignored(Path("/nowhere"), ["a/b.py"]))
 
+    def test_git_ignored_matches_dir_only_pattern_for_absent_path(self):
+        # A dir-only pattern (`/archive/`) matches a bare path (`archive`)
+        # only while that directory exists on disk — so an oracle that asks
+        # about the bare form answers differently on a machine that has the
+        # local-only dir (developer laptop) than on a fresh clone (CI).
+        # The oracle must be machine-independent: absent paths still exempt.
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            subprocess.run(["git", "-C", d, "init", "-q"], check=True)
+            (root / ".gitignore").write_text("/archive/\n", encoding="utf-8")
+            (root / "web").mkdir()
+            (root / "web" / ".gitignore").write_text("/.next/\n", encoding="utf-8")
+            ignored = dr.git_ignored(root, ["archive", "web/.next", "src/real.py"])
+            self.assertEqual({"archive", "web/.next"}, ignored)
+
 
 class ResolutionTests(unittest.TestCase):
     """resolve_exists is filesystem truth (follow symlinks); dir-kind must be a dir."""

--- a/tests/test_fresh_user_journey.py
+++ b/tests/test_fresh_user_journey.py
@@ -70,6 +70,16 @@ class FreshUserJourney(unittest.TestCase):
                 stale.unlink()  # dangling private-doc symlinks
         cls.home = root / "home"
         cls.home.mkdir()
+        # The fresh-user persona has Claude Code by definition (they arrive
+        # via the plugin), but the machine running this suite may not (CI
+        # runners don't). doctor treats `claude` as required, so the journey
+        # must not inherit that host accident: a stub on PATH keeps the
+        # verdict about episteme's own path, deterministic on every machine.
+        cls.stub_bin = root / "stub-bin"
+        cls.stub_bin.mkdir()
+        stub = cls.stub_bin / "claude"
+        stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        stub.chmod(0o755)
 
     @classmethod
     def tearDownClass(cls):
@@ -81,6 +91,7 @@ class FreshUserJourney(unittest.TestCase):
             "HOME": str(self.home),
             "EPISTEME_HOME": str(self.home / ".episteme"),
             "PYTHONPATH": str(self.sandbox / "src"),
+            "PATH": f"{self.stub_bin}{os.pathsep}{os.environ.get('PATH', '')}",
         }
         proc = subprocess.run(
             [


### PR DESCRIPTION
PR #97 auto-merged at its original tip before the CI-determinism fix (`c761bc2`) was pushed — branch protection has no required status checks, so `--auto` degenerated to an immediate merge. Master's push CI is currently red with the two machine-dependent failures this commit removes:

1. **Drift-oracle nondeterminism** — `git check-ignore` matches a dir-only pattern (`/archive/`, `/.next/`) against the bare spelling only while the directory exists on disk, so `archive/` and `web/.next/` were exempt locally but flagged on a fresh clone. `git_ignored` now queries bare + trailing-slash spellings; the answer is machine-independent. New test runs real git (the prior exemption test injected a fake checker, which is how the hole survived).
2. **Journey host-PATH dependence** — doctor's required-tool check on `claude` passed on the operator machine, failed on CI runners. The fresh-user persona has Claude Code by definition; a stub on a prepended PATH keeps the verdict about episteme's own path.

Verified in a detached-worktree CI rehearsal (tracked files only): full suite 1402 passed + 11 skipped + 72 subtests.