### PR TITLE
fix(engine): close the CP-FENCE-02 second-boundary straddle with a Post lookback window

### DIFF
--- a/core/hooks/_fence_synthesis.py
+++ b/core/hooks/_fence_synthesis.py
@@ -45,7 +45,7 @@ import os
 import re
 import sys
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -67,6 +67,20 @@ def _framework_path() -> Path:
 
 CP5_FORMAT_VERSION = "cp5-pre-chain"
 MARKER_TTL_SECONDS = 24 * 60 * 60
+
+# CP-FENCE-02 · Pre/Post second-boundary straddle race.
+# The h_ fallback correlation id hashes a SECOND-granularity wall-clock
+# bucket (`ts.split(".")[0]`). PreToolUse (reasoning_surface_guard) and
+# PostToolUse (fence_synthesis) each sample `datetime.now()`
+# independently, so the two hooks land in the same bucket ONLY when both
+# samples fall inside the same wall-clock second. When they straddle a
+# second boundary the ids diverge and the marker handoff breaks. On the
+# PostToolUse read side we widen the candidate set across adjacent second
+# buckets — `POST_LOOKBACK_SECONDS` earlier (the common case: Pre fired
+# first) and `POST_LOOKAHEAD_SECONDS` later (clock skew guard) — so a Pre
+# marker written up to POST_LOOKBACK_SECONDS ago still pairs.
+POST_LOOKBACK_SECONDS = 5
+POST_LOOKAHEAD_SECONDS = 1
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +129,26 @@ def correlation_id(payload: dict, cmd: str, ts: str) -> str:
     return "h_" + hashlib.sha1(seed).hexdigest()[:16]
 
 
-def candidate_correlation_ids(payload: dict, cmd: str, ts: str) -> list[str]:
+def _h_correlation_for_bucket(bucket: str, cwd: str, cmd: str) -> str:
+    """Hash one second-bucket into the h_ fallback correlation id.
+
+    Single code path shared by the current-second seed and the shifted
+    lookback/lookahead seeds so their string shape and hash stay
+    byte-identical — `f"{bucket}|{cwd}|{cmd}"` → sha1[:16] with the
+    `h_` prefix, matching `correlation_id()`.
+    """
+    seed = f"{bucket}|{cwd}|{cmd}".encode("utf-8", errors="replace")
+    return "h_" + hashlib.sha1(seed).hexdigest()[:16]
+
+
+def candidate_correlation_ids(
+    payload: dict,
+    cmd: str,
+    ts: str,
+    *,
+    lookback_seconds: int = 0,
+    lookahead_seconds: int = 0,
+) -> list[str]:
     """Return all candidate correlation ids for a tool call.
 
     Event 50 · CP-FENCE-02 fix. `correlation_id()` returns ONE id
@@ -129,28 +162,55 @@ def candidate_correlation_ids(payload: dict, cmd: str, ts: str) -> list[str]:
     all candidates on read — always finds the match regardless of
     which side had the richer payload.
 
-    Returned list is deduplicated, order-stable (explicit runtime ids
-    first, SHA-1 fallback second).
+    Straddle race (CP-FENCE-02, second pass). The h_ fallback bucket is
+    a second-granularity wall-clock stamp; Pre and Post sample the clock
+    independently, so their buckets diverge whenever the two hooks fall
+    on opposite sides of a second boundary. `lookback_seconds` /
+    `lookahead_seconds` (both default 0) widen the candidate set on the
+    PostToolUse read side across adjacent second buckets so a Pre marker
+    written up to `lookback_seconds` earlier still pairs. With both at 0
+    the function is byte-identical to the pre-widening behavior, keeping
+    every Pre-side call site (guard dual-write, cascade guard write)
+    unchanged.
+
+    Returned list is deduplicated, order-stable: explicit runtime ids
+    first, then the current-second h_ seed (so a fresh marker wins over
+    a stale sibling), then lookback buckets nearest-first, then
+    lookahead buckets nearest-first.
     """
     out: list[str] = []
     seen: set[str] = set()
+
+    def _add(cid: str) -> None:
+        if cid and cid not in seen:
+            out.append(cid)
+            seen.add(cid)
+
     rid = (
         payload.get("tool_use_id")
         or payload.get("toolUseId")
         or payload.get("request_id")
     )
     if isinstance(rid, str) and rid.strip():
-        c = rid.strip()
-        if c not in seen:
-            out.append(c)
-            seen.add(c)
+        _add(rid.strip())
     cwd = str(payload.get("cwd") or os.getcwd())
     bucket = ts.split(".")[0]
-    seed = f"{bucket}|{cwd}|{cmd}".encode("utf-8", errors="replace")
-    h = "h_" + hashlib.sha1(seed).hexdigest()[:16]
-    if h not in seen:
-        out.append(h)
-        seen.add(h)
+    _add(_h_correlation_for_bucket(bucket, cwd, cmd))
+
+    if lookback_seconds > 0 or lookahead_seconds > 0:
+        # Derive shifted buckets through the SAME string shape as the
+        # current-second seed. Graceful degrade: a malformed ts keeps
+        # the single-bucket behavior above (hook path must never raise).
+        try:
+            t = datetime.fromisoformat(ts)
+        except (ValueError, TypeError):
+            return out
+        offsets: list[int] = []
+        offsets.extend(range(-1, -lookback_seconds - 1, -1))
+        offsets.extend(range(1, lookahead_seconds + 1))
+        for off in offsets:
+            shifted = (t + timedelta(seconds=off)).isoformat().split(".")[0]
+            _add(_h_correlation_for_bucket(shifted, cwd, cmd))
     return out
 
 

--- a/core/hooks/fence_synthesis.py
+++ b/core/hooks/fence_synthesis.py
@@ -37,6 +37,8 @@ from _fence_synthesis import (  # noqa: E402  # pyright: ignore[reportMissingImp
     candidate_correlation_ids as _candidate_correlation_ids,
     correlation_id as _correlation_id,
     finalize_on_success_with_fallback as _finalize_with_fallback,
+    POST_LOOKBACK_SECONDS as _POST_LOOKBACK_SECONDS,
+    POST_LOOKAHEAD_SECONDS as _POST_LOOKAHEAD_SECONDS,
 )
 import _spot_check  # noqa: E402  # pyright: ignore[reportMissingImports]
 
@@ -162,7 +164,19 @@ def main() -> int:
         # not just the one computed for PostToolUse. PreToolUse may
         # have written the marker under a different id (Claude Code
         # PreToolUse lacks tool_use_id while PostToolUse has it).
-        candidates = _candidate_correlation_ids(payload, cmd, ts)
+        # Second pass: the h_ fallback bucket is a second-granularity
+        # wall-clock stamp, so a Pre/Post sample that straddles a second
+        # boundary diverges. Widen the candidate window (lookback +
+        # lookahead) to re-pair across the boundary. Both synthesis arms
+        # (fence + cascade) consume this list, so the widened window
+        # closes the straddle race for BOTH.
+        candidates = _candidate_correlation_ids(
+            payload,
+            cmd,
+            ts,
+            lookback_seconds=_POST_LOOKBACK_SECONDS,
+            lookahead_seconds=_POST_LOOKAHEAD_SECONDS,
+        )
         # Finalize synthesis first so we know whether a protocol was
         # produced. CP8: pass the synthesis signal into the spot-check
         # sampler; the multiplier lands before the sample roll.

--- a/tests/test_fence_reconstruction_end_to_end.py
+++ b/tests/test_fence_reconstruction_end_to_end.py
@@ -27,8 +27,9 @@ import io
 import json
 import os
 import tempfile
+import time
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -697,6 +698,133 @@ class TestCPFence02CorrelationMismatch(unittest.TestCase):
                     len(remaining), 0,
                     f"all candidate markers should be cleaned, got {remaining}"
                 )
+
+    def test_pairing_survives_second_boundary_straddle(self):
+        """CP-FENCE-02 straddle race. Same handoff as the sibling test
+        but with a >1s wall-clock gap between guard and post hook so the
+        two hooks sample datetime.now() in DIFFERENT second-buckets. The
+        h_ fallback correlation id hashes a second-granularity bucket;
+        pre-fix the PostToolUse candidate list misses the Pre marker's
+        bucket → no protocol AND a lingering marker. Post-fix the widened
+        lookback window re-pairs across the boundary."""
+        with _EphemeralEpistemeHome() as home:
+            with tempfile.TemporaryDirectory() as td:
+                cwd = Path(td)
+                (cwd / "core" / "hooks").mkdir(parents=True, exist_ok=True)
+                (cwd / "core" / "hooks" / "_grounding.py").write_text(
+                    "# grounding\n", encoding="utf-8"
+                )
+                (cwd / "docs").mkdir(exist_ok=True)
+                (cwd / "docs" / "PLAN.md").write_text("# plan\n")
+                surface = _valid_fence_surface(
+                    constraint="core/hooks/_grounding.py:32",
+                )
+                # PreToolUse WITHOUT tool_use_id → SHA-1 fallback bucket.
+                rc, _out, _err = _run_guard(
+                    surface, cwd, "rm .episteme/advisory-surface",
+                    tool_use_id=None,
+                )
+                self.assertEqual(rc, 0, f"PreToolUse should admit: {_err}")
+                pending_dir = home / "state" / "fence_pending"
+                pending_files = list(pending_dir.glob("*.json"))
+                self.assertEqual(len(pending_files), 1)
+                self.assertTrue(pending_files[0].stem.startswith("h_"))
+
+                # Force the Pre/Post wall clocks across a second boundary.
+                time.sleep(1.05)
+
+                # PostToolUse WITH tool_use_id, one-plus second later.
+                rc_post, _out_p, _err_p = _run_post_hook(
+                    "rm .episteme/advisory-surface",
+                    exit_code=0,
+                    cwd=cwd,
+                    tool_use_id="toolu_01ABCDEFG",
+                )
+                self.assertEqual(rc_post, 0)
+                framework = home / "framework" / "protocols.jsonl"
+                self.assertTrue(
+                    framework.is_file(),
+                    "CP-FENCE-02 straddle: PostToolUse must pair across a "
+                    "second boundary via the lookback window"
+                )
+                lines = [
+                    ln for ln in framework.read_text(encoding="utf-8").splitlines()
+                    if ln.strip()
+                ]
+                self.assertEqual(len(lines), 1, "expected exactly 1 protocol")
+                remaining = (
+                    list(pending_dir.glob("*.json"))
+                    if pending_dir.is_dir() else []
+                )
+                self.assertEqual(
+                    len(remaining), 0,
+                    f"all candidate markers should be cleaned, got {remaining}"
+                )
+
+    def test_lookback_window_pairs_across_buckets_and_bounds_at_limit(self):
+        """Deterministic (no sleep) function-level bound check for the
+        widened candidate window. A Pre marker written at ts1 pairs when
+        PostToolUse computes candidates up to POST_LOOKBACK_SECONDS later
+        and stops pairing beyond that bound."""
+        surface = {
+            "constraint_identified": "core/hooks/_grounding.py:32",
+            "origin_evidence": "commit e1f49c9 added it",
+            "removal_consequence_prediction": "if removed, deep-scan fails",
+            "reversibility_classification": "reversible",
+            "rollback_path": "git revert HEAD",
+        }
+        cmd = "rm .episteme/advisory-surface"
+        cwd = Path("/tmp/probe_cwd_unit_cpfence02")
+        # .900000 microseconds so a +1.5s / +4.9s post lands cleanly in a
+        # later second-bucket (straddle), while +7.0s exceeds the window.
+        ts1 = datetime(2026, 7, 6, 4, 30, 0, 900000, tzinfo=timezone.utc)
+        pre_payload = {"cwd": str(cwd)}  # no tool_use_id → h_ fallback only
+        post_payload = {"cwd": str(cwd), "tool_use_id": "toolu_UNIT"}
+
+        def _run(offset_seconds):
+            with _EphemeralEpistemeHome() as home:
+                pre_cands = fence_synth.candidate_correlation_ids(
+                    pre_payload, cmd, ts1.isoformat()
+                )
+                for c in pre_cands:
+                    fence_synth.write_pending_marker(surface, c, cwd, cmd)
+                post_ts = (ts1 + timedelta(seconds=offset_seconds)).isoformat()
+                post_cands = fence_synth.candidate_correlation_ids(
+                    post_payload, cmd, post_ts,
+                    lookback_seconds=fence_synth.POST_LOOKBACK_SECONDS,
+                    lookahead_seconds=fence_synth.POST_LOOKAHEAD_SECONDS,
+                )
+                env = fence_synth.finalize_on_success_with_fallback(
+                    post_cands, 0
+                )
+                pending = home / "state" / "fence_pending"
+                remaining = (
+                    sorted(p.stem for p in pending.glob("*.json"))
+                    if pending.is_dir() else []
+                )
+                return env, remaining, pre_cands
+
+        # +1.5s → post bucket +2s ahead; pre bucket well within lookback.
+        env, remaining, _ = _run(1.5)
+        self.assertIsNotNone(
+            env, "1.5s straddle must still pair via the lookback window"
+        )
+        self.assertEqual(remaining, [], "candidate markers must be cleaned")
+
+        # +4.9s → post bucket +5s ahead; pre bucket at the lookback edge.
+        env, remaining, _ = _run(4.9)
+        self.assertIsNotNone(
+            env, "4.9s straddle must pair at the lookback window edge"
+        )
+        self.assertEqual(remaining, [])
+
+        # +7.0s → beyond the POST_LOOKBACK_SECONDS window → no pairing.
+        env, remaining, pre_cands = _run(7.0)
+        self.assertIsNone(
+            env, "beyond the lookback window, pairing must not occur"
+        )
+        # The unpaired Pre marker is left behind — documents the bound.
+        self.assertEqual(remaining, pre_cands)
 
     def test_pre_with_tool_use_id_writes_dual_markers(self):
         """When both candidates are distinct, PreToolUse writes 2 markers."""


### PR DESCRIPTION
## Root cause

The `h_*` fallback correlation id hashes a **second-granularity** wall-clock bucket — `bucket = ts.split(\".\")[0]` in `core/hooks/_fence_synthesis.py`. PreToolUse (`reasoning_surface_guard`) and PostToolUse (`fence_synthesis`) each sample `datetime.now()` independently, so the two hooks derive the same `h_` id **only when both samples land inside the same wall-clock second**. When they straddle a second boundary, PostToolUse's candidate list `[toolu_*, h_<post-bucket>]` misses the Pre marker `h_<pre-bucket>` → `finalize_on_success_with_fallback` returns `None` → no protocol written **and** the stale marker lingers.

This is the intermittent failure of `TestCPFence02CorrelationMismatch::test_pre_lacks_tool_use_id_post_has_it_still_synthesizes` observed during the PR #100 merge validation.

**Refuted initial hypothesis:** the Event 50 dual-candidate fix assumed the Pre/Post mismatch was purely a `tool_use_id`-presence problem and that the `h_` fallback would always agree across the pair. False — the fallback agrees only *within a single wall-clock second*; across a second boundary the second-bucket seed diverges even though both sides ran the identical fallback formula.

## Fix

- `candidate_correlation_ids` gains keyword-only `lookback_seconds` / `lookahead_seconds` (**both default 0 → byte-identical** for every Pre-side call site: guard dual-write, cascade guard write, and `test_candidate_correlation_ids_helper`).
- With windows > 0 it appends `h_` ids for `t-1s … t-lookback` and `t+1s … t+lookahead` second buckets, derived through the **same string seed shape**, nearest-first, after the explicit runtime ids and the current-second seed (a fresh marker still wins over a stale sibling). Malformed `ts` → graceful fall back to single-bucket (never raises on the hook path).
- `fence_synthesis` PostToolUse passes `POST_LOOKBACK_SECONDS=5` / `POST_LOOKAHEAD_SECONDS=1`. Both synthesis arms (fence + cascade) consume this list, so the widened window closes the straddle for **both**; the 7ba8482 cross-arm exclusion is untouched.

## Red → Green evidence

**RED (pre-fix):**
- `test_pairing_survives_second_boundary_straddle` → `AssertionError: False is not true : CP-FENCE-02 straddle: PostToolUse must pair across a second boundary via the lookback window`
- `test_lookback_window_pairs_across_buckets_and_bounds_at_limit` → `AttributeError: module 'core.hooks._fence_synthesis' has no attribute 'POST_LOOKBACK_SECONDS'`

**GREEN (post-fix):**
- Both new tests pass; `test_candidate_correlation_ids_helper` passes **unchanged**.
- **Stability loop: 25/25** consecutive green on the original intermittent test.
- Probe (forced 1.05s delay between guard and post hook): `protocol_written=True markers_after=[]` (was `None` + lingering marker).
- Full suite: **1436 passed** (1434 baseline + 2 new tests), 72 subtests passed, **zero regressions**.

## TDD tests added

- `test_pairing_survives_second_boundary_straddle` — E2E regression with a 1.05s sleep between guard and post hook.
- `test_lookback_window_pairs_across_buckets_and_bounds_at_limit` — deterministic function-level bound check: pairs at +1.5s / +4.9s, stops at +7.0s (documents the 5s window).