### PR TITLE
feat(kernel): episteme kernel compact-protocols — one-time cascade-synthesis ledger compaction

### DIFF
--- a/core/hooks/_framework.py
+++ b/core/hooks/_framework.py
@@ -66,6 +66,7 @@ from _chain import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     GENESIS_PREV_HASH,
     ChainError,
     ChainVerdict,
+    _locked as _chain_locked,
     append as _chain_append,
     atomic_replace_file as _atomic_replace,
     compute_entry_hash,
@@ -1032,3 +1033,345 @@ def compact_deferred_discoveries(
             f"Backup: {backup}"
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# One-time cascade-synthesis compaction (protocols)
+# ---------------------------------------------------------------------------
+
+CASCADE_BLUEPRINT = "architectural_cascade"
+
+
+def _cascade_content_key(payload: dict) -> str | None:
+    """Content-identity key for a cascade-synthesis protocol — the dedup
+    axis for ``compact_protocols``. Returns None for every record it
+    cannot positively identify as a cascade duplicate (always kept).
+
+    Scope: ONLY ``type == "protocol"`` AND
+    ``blueprint == "architectural_cascade"``. A non-cascade protocol or
+    a foreign type is out of scope → None.
+
+    Key: the STORED ``cascade_hash`` when present as a str (modern
+    records, emitted since commit 1c01f9d). The ~457-record Event-143
+    spam predates that field, so for a legacy cascade record the key is
+    RECOMPUTED from the payload's own ``source_fields`` / ``op_outcome``
+    via the kernel's own ``_cascade_synthesis.cascade_hash`` — the same
+    function the emit path uses, so a recomputed legacy key collides
+    exactly with the stored key of a modern record describing the same
+    resolution (proven in the ×22 cluster: 21 legacy recomputations
+    collide with 1 stored key).
+
+    FAIL-OPEN ON KEEPING: any exception during recomputation returns
+    None (record kept). Dropping a legitimate protocol is the
+    irreversible cost; keeping a duplicate is cheap and self-corrects on
+    the next modern re-emission. The caller distinguishes an in-scope
+    None (derivation failure — counted + surfaced) from an out-of-scope
+    None (ordinary keep).
+    """
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("type") != PROTOCOL_TYPE:
+        return None
+    if payload.get("blueprint") != CASCADE_BLUEPRINT:
+        return None
+    stored = payload.get("cascade_hash")
+    if isinstance(stored, str):
+        return stored
+    try:
+        # Lazy import: the compaction path is the only _framework caller
+        # that needs the synthesis arm, and importing it eagerly at module
+        # load would couple the whole framework substrate to the T13 arm.
+        import _cascade_synthesis  # type: ignore  # pyright: ignore[reportMissingImports]
+
+        sf = payload.get("source_fields") or {}
+        oo = payload.get("op_outcome") or {}
+        flaw = str(sf["flaw_classification"])
+        posture = str(sf["posture_selected"])
+        needs_update = [str(x) for x in (sf.get("blast_radius_surfaces") or [])]
+        observable = str(sf.get("observable", ""))
+        project = Path(str(oo.get("cwd") or ".")).resolve().name or "unknown_project"
+        subsystem = _cascade_synthesis._subsystem(needs_update)
+        return _cascade_synthesis.cascade_hash(
+            project, subsystem, flaw, posture, needs_update, observable
+        )
+    except Exception:
+        return None
+
+
+def compact_protocols(
+    *,
+    path: Path | None = None,
+    dry_run: bool = False,
+) -> CompactResult:
+    """One-time in-place compaction of the framework protocols chain.
+
+    Event 143's cascade-synthesis arm chained hundreds of identical
+    resolution protocols before content-hash dedup shipped (commit
+    1c01f9d): a session surface carrying ``flaw_classification`` made the
+    self-escalation trigger classify every tool call as a cascade, and
+    per-command ``op_class`` variation defeated the signature-based
+    supersede. This is the complementary one-shot cleanup of the ledger
+    that bloated *before* the ``cascade_hash`` gate landed.
+
+    Algorithm (modelled on ``compact_deferred_discoveries`` — the
+    sanctioned in-place atomic-rewrite + recompute-from-GENESIS pattern):
+
+    1. Read + parse every JSONL line. Any non-JSON / non-dict line aborts
+       with ``ChainError`` BEFORE any write — no partial rewrite.
+    2. INPUT chain pre-verify: refuse a non-intact input (a GENESIS
+       rebuild would silently launder the break into a self-consistent
+       chain and promote quarantined records — the post-rebuild verify
+       passes by construction and can never catch it). Fires for the
+       dry-run path too.
+    3. Walk in file order. For each record derive
+       ``_cascade_content_key(payload)``. Records with key None (every
+       non-cascade payload, plus in-scope cascade records whose key could
+       not be derived) are ALWAYS kept. Among cascade records with a key,
+       KEEP the FIRST per key and drop later duplicates. Payloads stay
+       VERBATIM (no ``cascade_hash`` backfill — audit purity; see the
+       blind-spot note below for the bounded cost).
+    4. ``removed == 0`` → ``noop`` without a backup.
+    5. Rebuild from GENESIS preserving each kept record's ORIGINAL
+       envelope ``ts`` (byte-stable re-run). Two remap maps carry
+       ``supersedes`` across the rewrite:
+       - ``drop_to_rep``: a DROPPED duplicate's OLD entry_hash → the kept
+         representative's OLD entry_hash.
+       - ``hash_remap``: a KEPT record's OLD entry_hash → its NEW one.
+       For each kept payload whose ``supersedes`` points backward:
+       redirect a reference to a dropped duplicate onto its
+       representative (``drop_to_rep``), then rewrite to the new hash
+       (``hash_remap``); leave verbatim if unresolved by both maps.
+       ``supersedes`` always points backward in file order, so both maps
+       are populated by the time a referrer is rebuilt.
+    6. Backup the original bytes to ``<name>.compact-<ts>.bak``,
+       ``atomic_replace_file``, then post-verify (``ChainError`` naming
+       the preserved backup on failure).
+
+    Concurrency: the ENTIRE read → pre-verify → keep-walk → backup →
+    rebuild → replace → post-verify span runs under ``_locked(target)``.
+    The live ledger is append-hot (hooks write during sessions); the
+    sibling holds no lock — this is a deliberate improvement. The rebuild
+    computes hashes via ``compute_entry_hash`` directly (never
+    ``_chain.append``, which would take a second same-process flock on
+    the held file and deadlock).
+
+    ``dry_run=True`` returns the would-be counts after the keep-walk with
+    ``backup_path`` / ``head_hash`` None; no backup, no rewrite.
+
+    Idempotent: a second run finds no duplicates and returns ``noop``.
+
+    Bounded blind spot: kept payloads are verbatim, so a kept LEGACY
+    representative still lacks ``cascade_hash``. The write-time dedup walk
+    keys on the stored field, so it will not recognise the kept legacy
+    rep until ONE modern re-emission of the same resolution lands (that
+    modern record carries the field and collapses onto the rep on the
+    NEXT compaction). Cost is ≤1 future re-emission per legacy-kept
+    cluster — accepted against audit purity.
+    """
+    target = path if path is not None else _protocols_path()
+
+    if not target.is_file():
+        return CompactResult(
+            status="missing",
+            total_before=0,
+            total_after=0,
+            removed=0,
+            backup_path=None,
+            head_hash=None,
+            message=f"{target} does not exist — nothing to compact",
+        )
+
+    # Whole-window lock (see docstring § Concurrency). The missing check
+    # is deliberately BEFORE the lock so _locked's ``a+`` open does not
+    # materialise an empty file for a truly-absent target.
+    with _chain_locked(target):
+        try:
+            text = target.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ChainError(f"compact_protocols read: {exc}") from exc
+
+        lines = [ln for ln in text.splitlines() if ln.strip()]
+        if not lines:
+            return CompactResult(
+                status="empty",
+                total_before=0,
+                total_after=0,
+                removed=0,
+                backup_path=None,
+                head_hash=None,
+                message=f"{target} is empty — nothing to compact",
+            )
+
+        # Parse every line first — a single bad line aborts before any
+        # write (matches the sibling; no partial rewrite).
+        parsed: list[dict] = []
+        for idx, line in enumerate(lines):
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ChainError(
+                    f"{target}:line {idx + 1}: not valid JSON ({exc})"
+                ) from exc
+            if not isinstance(rec, dict):
+                raise ChainError(f"{target}:line {idx + 1}: not a JSON object")
+            parsed.append(rec)
+
+        total_before = len(parsed)
+
+        # INPUT chain pre-verify (laundering guard; fires for dry-run too).
+        input_verdict = _chain_verify(target)
+        if not input_verdict.intact:
+            raise ChainError(
+                f"{target}: input chain not intact ({input_verdict.reason}) — "
+                f"refusing to compact. A GENESIS rebuild would launder the "
+                f"break into a verified chain and promote quarantined records. "
+                f"Operator must resolve the break manually (archive + re-play "
+                f"from backup) before compaction."
+            )
+
+        # Keep-walk: first-wins per content key; record dropped-duplicate
+        # -> representative so a later supersedes ref can be re-pointed.
+        seen: dict[str, str] = {}  # content key -> kept rep OLD entry_hash
+        drop_to_rep: dict[str, str] = {}  # dropped OLD hash -> rep OLD hash
+        kept: list[dict] = []
+        deriv_failures = 0
+        for rec in parsed:
+            payload = rec.get("payload")
+            key = _cascade_content_key(payload) if isinstance(payload, dict) else None
+            in_scope = (
+                isinstance(payload, dict)
+                and payload.get("type") == PROTOCOL_TYPE
+                and payload.get("blueprint") == CASCADE_BLUEPRINT
+            )
+            if key is None:
+                # In-scope + None means the key could not be derived —
+                # counted + surfaced (fail-open on keeping). Out-of-scope
+                # None is an ordinary keep.
+                if in_scope:
+                    deriv_failures += 1
+                kept.append(rec)
+                continue
+            old = str(rec.get("entry_hash") or "")
+            rep = seen.get(key)
+            if rep is not None:
+                if old:
+                    drop_to_rep[old] = rep
+                continue  # later duplicate — drop
+            seen[key] = old
+            kept.append(rec)
+
+        total_after = len(kept)
+        removed = total_before - total_after
+
+        deriv_note = (
+            f" ({deriv_failures} in-scope cascade record(s) kept — "
+            f"content key underivable)"
+            if deriv_failures
+            else ""
+        )
+
+        if removed == 0:
+            return CompactResult(
+                status="noop",
+                total_before=total_before,
+                total_after=total_after,
+                removed=0,
+                backup_path=None,
+                head_hash=input_verdict.head_hash,
+                message=(
+                    f"{target}: no cascade duplicates among {total_before} "
+                    f"records — nothing to compact{deriv_note}"
+                ),
+            )
+
+        # Rebuild from GENESIS, preserving each kept record's ORIGINAL ts
+        # (byte-stable) and remapping supersedes old->new (incl. re-pointing
+        # a reference to a dropped duplicate onto its representative).
+        new_lines: list[str] = []
+        expected_prev = GENESIS_PREV_HASH
+        head_hash = expected_prev
+        hash_remap: dict[str, str] = {}  # kept OLD entry_hash -> NEW
+        for rec in kept:
+            payload = rec.get("payload")
+            ts = rec.get("ts")
+            if not isinstance(payload, dict) or not isinstance(ts, str):
+                raise ChainError(
+                    f"{target}: kept record missing payload / ts during rebuild "
+                    f"(payload={type(payload).__name__}, ts={type(ts).__name__})"
+                )
+            sup = payload.get("supersedes")
+            if isinstance(sup, str) and sup.startswith("sha256:"):
+                tgt = sup
+                if tgt in drop_to_rep:
+                    tgt = drop_to_rep[tgt]
+                if tgt in hash_remap:
+                    payload = {**payload, "supersedes": hash_remap[tgt]}
+                # else: unresolved by both maps — leave verbatim.
+            old_entry_hash = str(rec.get("entry_hash") or "")
+            entry_hash = compute_entry_hash(expected_prev, ts, payload)
+            if old_entry_hash:
+                hash_remap[old_entry_hash] = entry_hash
+            envelope = {
+                "schema_version": UPGRADED_FORMAT_MARKER,
+                "ts": ts,
+                "prev_hash": expected_prev,
+                "payload": payload,
+                "entry_hash": entry_hash,
+            }
+            new_lines.append(json.dumps(envelope, ensure_ascii=False))
+            expected_prev = entry_hash
+            head_hash = entry_hash
+
+        if dry_run:
+            return CompactResult(
+                status="compacted",
+                total_before=total_before,
+                total_after=total_after,
+                removed=removed,
+                backup_path=None,
+                head_hash=None,
+                message=(
+                    f"{target}: DRY RUN — would remove {removed} cascade "
+                    f"duplicate(s), leaving {total_after} of {total_before} "
+                    f"records{deriv_note}"
+                ),
+            )
+
+        # Backup the original bytes before any rewrite.
+        from datetime import datetime, timezone
+
+        backup_ts = (
+            datetime.now(timezone.utc).isoformat().replace(":", "").replace(".", "-")
+        )
+        backup = target.with_suffix(f".compact-{backup_ts}.bak")
+        try:
+            backup.write_bytes(target.read_bytes())
+        except OSError as exc:
+            raise ChainError(f"compact_protocols backup: {exc}") from exc
+
+        new_contents = ("\n".join(new_lines) + "\n").encode("utf-8")
+        try:
+            _atomic_replace(target, new_contents)
+        except OSError as exc:
+            raise ChainError(f"compact_protocols atomic replace: {exc}") from exc
+
+        post_verdict = _chain_verify(target)
+        if not post_verdict.intact:
+            raise ChainError(
+                f"{target}: compaction wrote file but post-verify failed "
+                f"({post_verdict.reason}). Backup preserved at {backup}."
+            )
+
+        return CompactResult(
+            status="compacted",
+            total_before=total_before,
+            total_after=total_after,
+            removed=removed,
+            backup_path=backup,
+            head_hash=post_verdict.head_hash,
+            message=(
+                f"{target}: compacted {total_before} → {total_after} records "
+                f"({removed} cascade duplicate(s) removed); chain intact. "
+                f"Backup: {backup}{deriv_note}"
+            ),
+        )

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -4527,6 +4527,87 @@ def _kernel_update() -> int:
     return 0
 
 
+def _kernel_compact_protocols(args) -> int:
+    """`episteme kernel compact-protocols` — one-time compaction of the
+    framework protocols ledger (collapse Event-143 cascade-synthesis
+    duplicates; keep-first, chain rebuilt, audit trail preserved).
+
+    Mirrors the `chain compact` gate: a non-dry-run in-place rewrite
+    requires --confirm (operator action per the loss-averse posture).
+    After the run it prints the protocols-chain verify verdict —
+    `verify.intact=true` is the operator's visible success criterion.
+    """
+    import sys as _sys
+
+    hooks_dir = REPO_ROOT / "core" / "hooks"
+    if str(hooks_dir) not in _sys.path:
+        _sys.path.insert(0, str(hooks_dir))
+
+    try:
+        import _framework  # type: ignore  # pyright: ignore[reportMissingImports]
+    except ImportError as exc:
+        print(
+            f"[episteme kernel compact-protocols] error loading framework "
+            f"module: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    dry_run = bool(getattr(args, "dry_run", False))
+    json_out = bool(getattr(args, "json", False))
+
+    # Gate: refuse a non-dry-run rewrite without --confirm.
+    if not dry_run and not getattr(args, "confirm", False):
+        print(
+            "[episteme kernel compact-protocols] refusing to rewrite the "
+            "protocols ledger without --confirm (or pass --dry-run to preview)",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        result = _framework.compact_protocols(dry_run=dry_run)
+    except _framework.ChainError as exc:
+        print(f"[episteme kernel compact-protocols] {exc}", file=sys.stderr)
+        return 1
+
+    # The operator's visible success criterion: the protocols chain
+    # verifies intact after the run (dry-run leaves it untouched).
+    verify = _framework.verify_chains()["protocols"]
+    intact = bool(verify.intact)
+
+    if json_out:
+        print(
+            json.dumps(
+                {
+                    "status": result.status,
+                    "total_before": result.total_before,
+                    "total_after": result.total_after,
+                    "removed": result.removed,
+                    "backup_path": (
+                        str(result.backup_path) if result.backup_path else None
+                    ),
+                    "head_hash": result.head_hash,
+                    "message": result.message,
+                    "intact": intact,
+                }
+            )
+        )
+        return 0
+
+    print(f"[episteme kernel compact-protocols] status={result.status}")
+    print(f"  total_before={result.total_before}")
+    print(f"  total_after={result.total_after}")
+    print(f"  removed={result.removed}")
+    if result.backup_path:
+        print(f"  backup_path={result.backup_path}")
+    if result.head_hash:
+        print(f"  head_hash={result.head_hash}")
+    print(f"  {result.message}")
+    print(f"  verify.intact={'true' if intact else 'false'}")
+    return 0
+
+
 def _inject(target: Path = Path("."), strict: bool = True) -> int:
     cwd = target.resolve()
     if not cwd.exists():
@@ -5574,10 +5655,29 @@ def build_parser() -> argparse.ArgumentParser:
     audit = sub.add_parser("audit", help="Reasoning check: verify the current project session has addressed cognitive unknowns")
     audit.add_argument("--fix", action="store_true", help="Append stub Reasoning Surface blocks to files that are missing them")
 
-    kernel = sub.add_parser("kernel", help="Kernel integrity manifest operations")
+    kernel = sub.add_parser("kernel", help="Kernel integrity manifest + ledger maintenance operations")
     kernel_sub = kernel.add_subparsers(dest="kernel_action", required=True)
     kernel_sub.add_parser("verify", help="Verify managed kernel files match the manifest")
     kernel_sub.add_parser("update", help="Regenerate kernel/MANIFEST.sha256 from current files")
+    k_compact = kernel_sub.add_parser(
+        "compact-protocols",
+        help="One-time compaction of the framework protocols ledger (collapse cascade-synthesis duplicates; keep-first, chain rebuilt, audit trail preserved)",
+    )
+    k_compact.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be removed without backing up or rewriting",
+    )
+    k_compact.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a single JSON object of the result fields including `intact`",
+    )
+    k_compact.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Required to actually rewrite the ledger when not --dry-run (in-place rewrite + backup)",
+    )
 
     worktree = sub.add_parser("worktree", help="Create a git worktree for a bounded task")
     worktree.add_argument("task_type")
@@ -6609,6 +6709,8 @@ def main(argv: Iterable[str] | None = None) -> int:
             return _kernel_verify()
         if args.kernel_action == "update":
             return _kernel_update()
+        if args.kernel_action == "compact-protocols":
+            return _kernel_compact_protocols(args)
         return 0
     if args.command == "check":
         return _check_dispatch(args)

--- a/tests/test_protocols_compaction.py
+++ b/tests/test_protocols_compaction.py
@@ -1,0 +1,457 @@
+"""Protocols-ledger compaction — `_framework.compact_protocols` +
+`episteme kernel compact-protocols`.
+
+The Pillar-3 protocols chain accumulated a cascade-synthesis spam burst
+(Event 143): identical resolution content chained hundreds of times
+because per-command op_class variation defeated the signature supersede
+before content-hash dedup shipped (commit 1c01f9d). Those legacy spam
+records predate the ``payload.cascade_hash`` field, so compaction dedups
+on the STORED cascade_hash when present, else the content hash
+RECOMPUTED from the payload's own source_fields / op_outcome via the
+kernel's own ``_cascade_synthesis.cascade_hash`` — the same function the
+emit path uses, so a recomputed legacy key collides exactly with the
+stored key of a modern record describing the same resolution.
+
+Mirrors the sanctioned sibling ``compact_deferred_discoveries``:
+parse-all-before-write, input chain pre-verify (refuse to launder a
+break), keep-first, backup + atomic replace + post-verify, dry_run,
+idempotent noop. Adds: whole-window flock (the ledger is append-hot),
+content-key dedup, and supersedes remap (incl. re-pointing a supersedes
+that referenced a dropped duplicate at the surviving representative).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from core.hooks import _cascade_synthesis  # pyright: ignore[reportAttributeAccessIssue]
+from core.hooks import _chain  # pyright: ignore[reportAttributeAccessIssue]
+from core.hooks import _framework  # pyright: ignore[reportAttributeAccessIssue]
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class EphemeralHome:
+    """Point EPISTEME_HOME at a tmp dir for the duration of a test."""
+
+    def __init__(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._orig = None
+
+    def __enter__(self) -> Path:
+        self._orig = os.environ.get("EPISTEME_HOME")
+        os.environ["EPISTEME_HOME"] = self._tmp.name
+        return Path(self._tmp.name)
+
+    def __exit__(self, *a):
+        if self._orig is None:
+            os.environ.pop("EPISTEME_HOME", None)
+        else:
+            os.environ["EPISTEME_HOME"] = self._orig
+        self._tmp.cleanup()
+
+
+def _cascade_payload(
+    *,
+    flaw: str = "config-gap",
+    posture: str = "patch",
+    surfaces: list[str] | None = None,
+    observable: str = "exit_code == 0 held",
+    cwd: str = "/tmp/example_project",
+    correlation_id: str = "cid",
+    with_hash: bool = False,
+    include_source_fields: bool = True,
+    supersedes: str | None = None,
+) -> dict:
+    """Build a cascade-synthesis protocol payload the way the emit path
+    (``_cascade_synthesis._build_protocol``) shapes it. ``with_hash``
+    stamps the STORED cascade_hash (modern record, post-1c01f9d);
+    without it the record is a legacy spam record whose key must be
+    RECOMPUTED. Both forms describing the same resolution collide."""
+    if surfaces is None:
+        surfaces = ["core/hooks/a.py", "core/hooks/b.py"]
+    payload: dict = {
+        "type": "protocol",
+        "version": 1,
+        "blueprint": "architectural_cascade",
+        "source": "cascade_resolution",
+        "correlation_id": correlation_id,
+        "synthesized_protocol": f"resolved without divergence because `{observable}`",
+        "op_outcome": {
+            "exit_code": 0,
+            "cwd": cwd,
+            "command_redacted": "make test",
+        },
+    }
+    if include_source_fields:
+        payload["source_fields"] = {
+            "flaw_classification": flaw,
+            "posture_selected": posture,
+            "blast_radius_surfaces": surfaces,
+            "blast_radius_count": len(surfaces),
+            "core_question": "does the flaw recur across surfaces?",
+            "observable": observable,
+        }
+    if with_hash:
+        subsystem = _cascade_synthesis._subsystem(surfaces)
+        project = Path(cwd).resolve().name or "unknown_project"
+        payload["cascade_hash"] = _cascade_synthesis.cascade_hash(
+            project, subsystem, flaw, posture, surfaces, observable
+        )
+    if supersedes is not None:
+        payload["supersedes"] = supersedes
+    return payload
+
+
+def _non_cascade_payload(*, correlation_id: str, supersedes: str | None = None) -> dict:
+    """A protocol that is NOT a cascade — must always be kept, never a
+    dedup candidate."""
+    payload: dict = {
+        "type": "protocol",
+        "version": 1,
+        "blueprint": "generic",
+        "correlation_id": correlation_id,
+        "synthesized_protocol": f"generic protocol {correlation_id}",
+    }
+    if supersedes is not None:
+        payload["supersedes"] = supersedes
+    return payload
+
+
+def _protocols_path() -> Path:
+    return _framework._protocols_path()
+
+
+def _read_payloads() -> list[dict]:
+    """Raw read of the protocols chain: list of {ts, entry_hash, payload}
+    envelopes in file order (no supersede/dedup filtering)."""
+    p = _protocols_path()
+    if not p.is_file():
+        return []
+    out = []
+    for ln in p.read_text(encoding="utf-8").splitlines():
+        if ln.strip():
+            out.append(json.loads(ln))
+    return out
+
+
+class CompactProtocolsCore(unittest.TestCase):
+    # 1. Operator's contract.
+    def test_operator_contract_collapses_legacy_spam_keep_first(self):
+        with EphemeralHome():
+            # 2 non-cascade protocols (always kept).
+            _framework.write_protocol(_non_cascade_payload(correlation_id="gen-0"))
+            _framework.write_protocol(_non_cascade_payload(correlation_id="gen-1"))
+            # 3 distinct legit cascade protocols (with stored cascade_hash).
+            for i in range(3):
+                _framework.write_protocol(
+                    _cascade_payload(
+                        flaw=f"distinct-flaw-{i}",
+                        observable=f"distinct observable {i}",
+                        correlation_id=f"legit-{i}",
+                        with_hash=True,
+                    )
+                )
+            # 100 identical-content LEGACY cascade records (NO cascade_hash).
+            for i in range(100):
+                _framework.write_protocol(
+                    _cascade_payload(
+                        flaw="spammy-flaw",
+                        observable="the spam resolution content",
+                        correlation_id=f"legacy-{i:03d}",
+                        with_hash=False,
+                    )
+                )
+
+            before = _read_payloads()
+            self.assertEqual(len(before), 105)
+
+            result = _framework.compact_protocols()
+            self.assertEqual(result.status, "compacted")
+            self.assertEqual(result.removed, 99)
+            self.assertEqual(result.total_before, 105)
+            self.assertEqual(result.total_after, 6)
+
+            self.assertTrue(_framework.verify_chains()["protocols"].intact)
+
+            after = _read_payloads()
+            self.assertEqual(len(after), 105 - 99)
+            # Keep-first: exactly one spam survivor, the FIRST (legacy-000).
+            spam = [
+                e for e in after
+                if e["payload"].get("source_fields", {}).get("observable")
+                == "the spam resolution content"
+            ]
+            self.assertEqual(len(spam), 1)
+            self.assertEqual(spam[0]["payload"]["correlation_id"], "legacy-000")
+
+    # 2. Mixed cluster: legacy (no field) + modern (with field), same content.
+    def test_mixed_cluster_legacy_and_modern_first_legacy_wins(self):
+        with EphemeralHome():
+            for i in range(5):
+                _framework.write_protocol(
+                    _cascade_payload(
+                        flaw="mixed",
+                        observable="one resolution",
+                        correlation_id=f"legacy-{i}",
+                        with_hash=False,
+                    )
+                )
+            _framework.write_protocol(
+                _cascade_payload(
+                    flaw="mixed",
+                    observable="one resolution",
+                    correlation_id="modern",
+                    with_hash=True,
+                )
+            )
+            result = _framework.compact_protocols()
+            self.assertEqual(result.status, "compacted")
+            self.assertEqual(result.removed, 5)
+            after = _read_payloads()
+            self.assertEqual(len(after), 1)
+            # First legacy record is the surviving representative.
+            self.assertEqual(after[0]["payload"]["correlation_id"], "legacy-0")
+
+    # 3. supersedes remap (incl. re-pointing a dropped-duplicate target).
+    def test_supersedes_remapped_through_dropped_duplicate(self):
+        with EphemeralHome():
+            # A: cascade key K, kept.
+            _framework.write_protocol(
+                _cascade_payload(
+                    flaw="remap", observable="same", correlation_id="A", with_hash=False
+                )
+            )
+            # B: duplicate of A (key K), dropped.
+            b_env = _framework.write_protocol(
+                _cascade_payload(
+                    flaw="remap", observable="same", correlation_id="B", with_hash=False
+                )
+            )
+            b_old = b_env["entry_hash"]
+            # C: a protocol whose supersedes points at B's OLD entry_hash.
+            _framework.write_protocol(
+                _non_cascade_payload(correlation_id="C", supersedes=b_old)
+            )
+
+            result = _framework.compact_protocols()
+            self.assertEqual(result.status, "compacted")
+            self.assertEqual(result.removed, 1)
+
+            after = _read_payloads()
+            new_hashes = {e["entry_hash"] for e in after}
+            a_new = next(
+                e["entry_hash"] for e in after
+                if e["payload"]["correlation_id"] == "A"
+            )
+            c = next(e for e in after if e["payload"]["correlation_id"] == "C")
+            # C's supersedes now points at A's NEW entry_hash (B collapsed
+            # into A, and A's hash was recomputed by the GENESIS rebuild).
+            self.assertEqual(c["payload"]["supersedes"], a_new)
+            # Every supersedes value is resolvable to a live hash, or was
+            # verbatim-unresolvable by construction (none such here).
+            for e in after:
+                sup = e["payload"].get("supersedes")
+                if isinstance(sup, str) and sup.startswith("sha256:"):
+                    self.assertIn(sup, new_hashes)
+
+    # 4. Derivation failure — cascade record with source_fields missing.
+    def test_derivation_failure_record_kept_and_counted(self):
+        with EphemeralHome():
+            # In-scope cascade record whose key cannot be derived
+            # (source_fields absent) — must be kept, never dropped.
+            _framework.write_protocol(
+                _cascade_payload(
+                    correlation_id="broken",
+                    with_hash=False,
+                    include_source_fields=False,
+                )
+            )
+            # Plus a removable duplicate pair so status == compacted and the
+            # derivation-failure count is surfaced in the message.
+            for i in range(3):
+                _framework.write_protocol(
+                    _cascade_payload(
+                        flaw="ok", observable="derivable",
+                        correlation_id=f"dup-{i}", with_hash=False,
+                    )
+                )
+
+            result = _framework.compact_protocols()
+            self.assertEqual(result.status, "compacted")
+            self.assertEqual(result.removed, 2)  # 2 of the 3 dups collapse
+            after = _read_payloads()
+            cids = {e["payload"]["correlation_id"] for e in after}
+            self.assertIn("broken", cids)  # derivation-failure survivor kept
+            # The result message surfaces the derivation-failure count.
+            self.assertIn("1", result.message)
+            self.assertIn("underivable", result.message.lower())
+
+    # 5. Tamper guard — flip one byte, refuse for BOTH dry_run values.
+    def test_tamper_refused_for_both_dry_run_and_real(self):
+        with EphemeralHome():
+            for i in range(3):
+                _framework.write_protocol(
+                    _cascade_payload(
+                        flaw=f"t-{i}",
+                        observable=f"OBS_MARKER_{i}",
+                        correlation_id=f"t-{i}",
+                        with_hash=True,
+                    )
+                )
+            p = _protocols_path()
+            text = p.read_text(encoding="utf-8")
+            # Flip one char inside a payload string value: JSON still parses,
+            # entry_hash no longer matches -> input chain not intact.
+            self.assertIn("OBS_MARKER_1", text)
+            p.write_text(text.replace("OBS_MARKER_1", "OBS_MARKER_X"), encoding="utf-8")
+
+            with self.assertRaises(_framework.ChainError):
+                _framework.compact_protocols(dry_run=True)
+            with self.assertRaises(_framework.ChainError):
+                _framework.compact_protocols(dry_run=False)
+
+    # 6. dry_run — no backup, bytes unchanged, counts correct.
+    def test_dry_run_no_write_no_backup(self):
+        with EphemeralHome():
+            for i in range(4):
+                _framework.write_protocol(
+                    _cascade_payload(
+                        flaw="dr", observable="same", correlation_id=f"d-{i}",
+                        with_hash=False,
+                    )
+                )
+            p = _protocols_path()
+            original = p.read_bytes()
+
+            result = _framework.compact_protocols(dry_run=True)
+            self.assertEqual(result.status, "compacted")
+            self.assertEqual(result.removed, 3)
+            self.assertIsNone(result.backup_path)
+            self.assertIsNone(result.head_hash)
+            self.assertEqual(p.read_bytes(), original)  # bytes unchanged
+            self.assertEqual(
+                sorted(p.parent.glob("*.compact-*.bak")), []
+            )
+
+    # 7. Idempotency — second real run is a noop with no second backup.
+    def test_idempotent_second_run_noop(self):
+        with EphemeralHome():
+            for i in range(3):
+                _framework.write_protocol(
+                    _cascade_payload(
+                        flaw="idem", observable="same", correlation_id=f"i-{i}",
+                        with_hash=False,
+                    )
+                )
+            r1 = _framework.compact_protocols()
+            self.assertEqual(r1.status, "compacted")
+            baks1 = sorted(_protocols_path().parent.glob("*.compact-*.bak"))
+            self.assertEqual(len(baks1), 1)
+
+            r2 = _framework.compact_protocols()
+            self.assertEqual(r2.status, "noop")
+            self.assertEqual(r2.removed, 0)
+            self.assertEqual(r2.total_before, r2.total_after)
+            self.assertIsNone(r2.backup_path)
+            baks2 = sorted(_protocols_path().parent.glob("*.compact-*.bak"))
+            self.assertEqual(len(baks2), 1)  # no second backup
+
+    # 8. Backup fidelity — backup bytes == original bytes.
+    def test_backup_bytes_match_original(self):
+        with EphemeralHome():
+            for i in range(3):
+                _framework.write_protocol(
+                    _cascade_payload(
+                        flaw="bak", observable="same", correlation_id=f"b-{i}",
+                        with_hash=False,
+                    )
+                )
+            original = _protocols_path().read_bytes()
+            result = _framework.compact_protocols()
+            self.assertIsNotNone(result.backup_path)
+            self.assertEqual(Path(result.backup_path).read_bytes(), original)
+
+    # noop path: no cascade duplicates at all -> untouched, no backup.
+    def test_noop_when_no_duplicates(self):
+        with EphemeralHome():
+            for i in range(3):
+                _framework.write_protocol(
+                    _cascade_payload(
+                        flaw=f"uniq-{i}", observable=f"uniq {i}",
+                        correlation_id=f"u-{i}", with_hash=True,
+                    )
+                )
+            result = _framework.compact_protocols()
+            self.assertEqual(result.status, "noop")
+            self.assertEqual(result.removed, 0)
+            self.assertIsNone(result.backup_path)
+
+
+class CompactProtocolsCLI(unittest.TestCase):
+    """9. CLI e2e via subprocess."""
+
+    def _seed(self, home: Path) -> None:
+        for i in range(6):
+            _framework.write_protocol(
+                _cascade_payload(
+                    flaw="cli", observable="one cli resolution",
+                    correlation_id=f"c-{i}", with_hash=False,
+                )
+            )
+
+    def _run(self, home: Path, *args: str) -> subprocess.CompletedProcess:
+        env = {
+            **os.environ,
+            "EPISTEME_HOME": str(home),
+            "PYTHONPATH": str(_REPO_ROOT / "src"),
+        }
+        return subprocess.run(
+            [sys.executable, "-m", "episteme.cli", "kernel", "compact-protocols", *args],
+            env=env,
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+        )
+
+    def test_non_dry_run_without_confirm_exits_2(self):
+        with EphemeralHome() as home:
+            self._seed(home)
+            proc = self._run(home)
+            self.assertEqual(proc.returncode, 2, proc.stderr)
+            self.assertIn("confirm", proc.stderr.lower())
+            # ledger untouched
+            self.assertEqual(len(_read_payloads()), 6)
+
+    def test_dry_run_works_without_confirm(self):
+        with EphemeralHome() as home:
+            self._seed(home)
+            proc = self._run(home, "--dry-run")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(len(_read_payloads()), 6)  # unchanged
+
+    def test_confirm_compacts(self):
+        with EphemeralHome() as home:
+            self._seed(home)
+            proc = self._run(home, "--confirm")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(len(_read_payloads()), 1)  # collapsed
+
+    def test_json_carries_intact_true(self):
+        with EphemeralHome() as home:
+            self._seed(home)
+            proc = self._run(home, "--confirm", "--json")
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            obj = json.loads(proc.stdout)
+            self.assertEqual(obj["intact"], True)
+            self.assertEqual(obj["removed"], 5)
+            self.assertEqual(obj["status"], "compacted")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `episteme kernel compact-protocols` + `_framework.compact_protocols(...)` — a one-time in-place compaction of the Pillar-3 protocols chain that collapses the Event-143 cascade-synthesis spam burst.

A session surface carrying `flaw_classification` made the self-escalation trigger classify every tool call as a cascade, and per-command `op_class` variation defeated the signature supersede before content-hash dedup shipped (commit 1c01f9d). The live ledger holds **~457 removable duplicates across 3 clusters (×238, ×200, ×22) out of 470 records**. This is the complementary one-shot cleanup of the ledger that bloated *before* the `cascade_hash` gate landed.

**Phase boundary:** this PR ships the code + tests + a READ-ONLY `--dry-run` preview against the live ledger. The real `--confirm` compaction on the live ledger is deliberately NOT run — the integrator reviews first.

## Design

Mirrors the sanctioned sibling `compact_deferred_discoveries` (parse-all-before-write, input chain pre-verify refusing to launder a break, keep-first, backup + atomic replace + post-verify, `dry_run`, idempotent noop, reuses `CompactResult`). Cascade-specific additions:

- **Content key** (`_cascade_content_key`): stored `payload.cascade_hash` when present as a str, else the content hash RECOMPUTED from the payload's own `source_fields` / `op_outcome` via the kernel's own `_cascade_synthesis.cascade_hash` — the same function the emit path uses, so a recomputed legacy key collides exactly with the stored key of a modern record describing the same resolution (proven in the ×22 cluster: 21 legacy recomputations collide with 1 stored key). Scope is strictly `type==protocol` AND `blueprint==architectural_cascade`; anything else keys None and is always kept.
- **Fail-open on keeping**: any exception during recomputation returns None (kept). Dropping a legitimate protocol is the irreversible cost; keeping a duplicate is cheap and self-corrects on the next modern re-emission. In-scope underivable records are counted and surfaced in the result message.
- **Keep-first** per content key; payloads stay verbatim (no `cascade_hash` backfill — audit purity).
- **`supersedes` remap** across the GENESIS rebuild: `drop_to_rep` re-points a `supersedes` that referenced a DROPPED duplicate onto its surviving representative, then `hash_remap` rewrites old→new; unresolved refs are left verbatim.
- **Whole-window flock**: the entire read → pre-verify → keep-walk → backup → rebuild → atomic_replace → post-verify span runs under `_chain._locked(target)`. The live ledger is append-hot; the sibling holds no lock — this is a deliberate improvement. The rebuild computes hashes via `compute_entry_hash` directly (never `_chain.append`, which would take a second same-process flock on the held file and deadlock).
- **Bounded blind spot**: kept payloads are verbatim, so a kept LEGACY representative still lacks `cascade_hash`. The write-time dedup walk keys on the stored field, so it will not recognise the kept legacy rep until ONE modern re-emission of the same resolution lands. Cost is ≤1 future re-emission per legacy-kept cluster.

## CLI

`episteme kernel compact-protocols [--dry-run] [--json] [--confirm]`. Mirrors the `chain compact` gate — a non-dry-run rewrite refuses without `--confirm` (exit 2). Prints the post-run `verify_chains()["protocols"]` verdict; `verify.intact=true` is the operator's visible success criterion. Exit 0 on success/noop/dry-run, 1 on ChainError.

## Tests — 13 new (`tests/test_protocols_compaction.py`)

Operator contract (100 legacy dupes collapse to 1, keep-first) · mixed legacy+modern cluster · supersedes remap through a dropped duplicate · derivation-failure kept + counted · tamper guard for both `dry_run` values · dry_run no-write · idempotency · backup fidelity · noop · CLI e2e via subprocess (confirm-gate rc 2 / dry-run / confirm / json intact:true).

**Full suite: `1449 passed + 72 subtests`** (baseline 1436 + these 13), zero regressions.

## Live READ-ONLY dry-run preview (no `--confirm`)

`episteme kernel compact-protocols --dry-run --json`:

```json
{"status": "compacted", "total_before": 470, "total_after": 13, "removed": 457, "backup_path": null, "head_hash": null, "message": "…/protocols.jsonl: DRY RUN — would remove 457 cascade duplicate(s), leaving 13 of 470 records", "intact": true}
```

## Independent census cross-check

Standalone script reimplementing the key derivation from scratch (imports neither the new code nor `_cascade_synthesis`) over the live ledger at the same moment:

| metric | value |
|---|---|
| total_records | 470 |
| out_of_scope (kept) | 2 |
| in_scope_cascade | 468 |
| — keyed via stored cascade_hash | 9 |
| — keyed via recompute | 459 |
| — derivation failures (kept) | 0 |
| distinct_cascade_keys | 11 |
| **removable (duplicates)** | **457** |
| **expected_after** | **13** |
| clusters | ×238, ×200, ×22 |

**Verdict: MATCH.** Dry-run `removed=457` == census `removable=457`; `after=13` == `expected_after=13`; clusters ×238/×200/×22 exactly as the design-time census. No live-emission drift between the two reads. Live ledger confirmed untouched (still 470 lines, no `protocols.compact-*.bak` written).

DO NOT MERGE — awaiting integrator go signal for the live `--confirm` run.