### PR TITLE
feat(loop-hygiene): §3 pairing ladder + §4 rewrite mutex/inode + §5 healing/namespace

### DIFF
--- a/core/hooks/_cascade_synthesis.py
+++ b/core/hooks/_cascade_synthesis.py
@@ -322,6 +322,7 @@ def finalize_on_success_with_fallback(
         try:
             from _framework import (  # type: ignore  # pyright: ignore[reportMissingImports]
                 ChainError as _ChainError,
+                _cascade_content_key,
                 _chain_iter,
                 _protocols_path,
                 write_protocol as _write_protocol,
@@ -337,13 +338,21 @@ def finalize_on_success_with_fallback(
         # verify_chains' job; dedup's job is seeing every record. And the
         # gate FAILS CLOSED — if uniqueness cannot be proven, skipping
         # one legitimate protocol costs less than re-spamming the ledger.
-        h = payload.get("cascade_hash")
+        #
+        # §5.1 read-side healing: key on `_cascade_content_key` (the
+        # shared stored-else-recomputed helper) rather than the raw
+        # `cascade_hash` field. A legacy record with NO stored field then
+        # RECOMPUTES the same content key and participates in dedup with
+        # zero payload mutation (audit purity — Event 144's verbatim
+        # rule). The ≤1-re-emission-per-cluster blind spot closes for
+        # every legacy record, forever, not just ones a compaction visited.
+        key = _cascade_content_key(payload)
         try:
             target = _protocols_path()
-            if target.is_file():
+            if key is not None and target.is_file():
                 for env in _chain_iter(target, verify=False):
                     p = env.get("payload") if isinstance(env, dict) else None
-                    if isinstance(p, dict) and p.get("cascade_hash") == h:
+                    if isinstance(p, dict) and _cascade_content_key(p) == key:
                         return None
         except (OSError, _ChainError):
             return None

--- a/core/hooks/_chain.py
+++ b/core/hooks/_chain.py
@@ -163,27 +163,112 @@ def _now_ts() -> str:
 
 
 @contextmanager
-def _locked(path: Path) -> Iterator[None]:
+def rewrite_lock(lock_dir: Path) -> Iterator[None]:
+    """Cross-stream, cross-session rewrite mutex (§4.1).
+
+    A single ``<lock_dir>/.lock`` guards ALL chain-rewrite operations —
+    ``compact_protocols`` / ``compact_deferred_discoveries`` /
+    ``upgrade_cp5_prechain`` / ``reset_stream``. Because both framework
+    streams share one directory, rewrite-vs-rewrite across streams AND
+    across sessions serialize on this one lock.
+
+    **Lock-order law (deadlock prevention): ``rewrite_lock`` →
+    ``_locked(file)``, never the reverse.** Appenders take ONLY
+    ``_locked(file)`` (the hot path is unchanged), so append-vs-rewrite
+    still serializes on the per-file lock exactly as before. No-op
+    fallback on Windows (per CP4)."""
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / ".lock"
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        if _fcntl is not None:
+            _fcntl.flock(fd, _fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if _fcntl is not None:
+                _fcntl.flock(fd, _fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def _verify_and_reacquire(lock_fd, path: Path, *, _after_flock=None, max_attempts: int = 5):
+    """§4.2 — orphaned-inode guard. After an exclusive flock on
+    ``lock_fd``, confirm the descriptor still points at the LIVE
+    ``path`` inode; a concurrent compactor may have ``os.replace``d the
+    path to a new inode while we blocked on the lock, orphaning our fd
+    (an append into an unlinked file is silently lost, and the flock no
+    longer excludes a new appender on the live inode).
+
+    On an ``(st_dev, st_ino)`` mismatch — or ``FileNotFoundError`` on the
+    path — release, reopen ``path``, re-flock, and re-check, up to
+    ``max_attempts`` before raising ``ChainError``. Returns the
+    (possibly reopened) flocked fd on the live inode. No-op when fcntl is
+    unavailable (Windows). ``_after_flock`` is a test seam invoked after
+    each flock acquisition, before the inode check."""
+    if _fcntl is None:
+        return lock_fd
+    for _attempt in range(max_attempts):
+        if _after_flock is not None:
+            _after_flock()
+        try:
+            st_fd = os.fstat(lock_fd.fileno())
+            st_path = os.stat(path)
+            if (st_fd.st_dev, st_fd.st_ino) == (st_path.st_dev, st_path.st_ino):
+                return lock_fd
+        except FileNotFoundError:
+            pass  # path vanished under us → treat as mismatch, reopen
+        # Orphaned inode: drop this fd, reopen the live path, re-flock.
+        try:
+            _fcntl.flock(lock_fd.fileno(), _fcntl.LOCK_UN)
+        except OSError:
+            pass
+        lock_fd.close()
+        lock_fd = open(path, "a+", encoding="utf-8")
+        _fcntl.flock(lock_fd.fileno(), _fcntl.LOCK_EX)
+    try:
+        lock_fd.close()
+    except OSError:
+        pass
+    raise ChainError(
+        f"_locked({path}): inode kept diverging after {max_attempts} reopen "
+        f"attempts (concurrent rewrite storm?)"
+    )
+
+
+@contextmanager
+def _locked(path: Path, *, _after_first_flock=None) -> Iterator[None]:
     """Acquire an exclusive lock on the chain file during append +
     verify. No-op fallback on Windows with a stderr hint; documented
     degradation per CP4 pattern.
 
     The lock file is the target file itself — opening with ``a+`` so
-    we can hold the descriptor even on an empty / missing file.
-    """
+    we can hold the descriptor even on an empty / missing file. After
+    the flock is granted the inode is re-verified (§4.2) so a
+    concurrent ``os.replace`` by a compactor cannot leave us writing
+    into an orphaned file. ``_after_first_flock`` is a test seam
+    forwarded to ``_verify_and_reacquire``."""
     path.parent.mkdir(parents=True, exist_ok=True)
     # ``a+`` creates the file if absent and leaves the position at end.
     lock_fd = open(path, "a+", encoding="utf-8")
     try:
         if _fcntl is not None:
             _fcntl.flock(lock_fd.fileno(), _fcntl.LOCK_EX)
+            lock_fd = _verify_and_reacquire(
+                lock_fd, path, _after_flock=_after_first_flock
+            )
         yield
     finally:
         try:
-            if _fcntl is not None:
+            if _fcntl is not None and not lock_fd.closed:
                 _fcntl.flock(lock_fd.fileno(), _fcntl.LOCK_UN)
+        except (OSError, ValueError):
+            pass
         finally:
-            lock_fd.close()
+            try:
+                lock_fd.close()
+            except OSError:
+                pass
 
 
 def atomic_replace_file(path: Path, new_contents: bytes) -> None:
@@ -447,27 +532,33 @@ def reset_stream(
             "(typically the operator types 'I ACKNOWLEDGE CHAIN RESET' or similar)"
         )
 
-    archived: Path | None = None
-    if path.is_file():
-        ts_slug = _now_ts().replace(":", "").replace(".", "-")
-        archived = path.with_suffix(f".broken-{ts_slug}.jsonl")
-        path.rename(archived)
+    # §4.1 — a reset is a chain-rewrite op: hold the shared rewrite mutex
+    # across the archive-rename + genesis-append so it serializes against
+    # concurrent compactions/upgrades on the same stream directory. The
+    # inner ``append`` still takes ``_locked(path)`` (lock-order preserved:
+    # rewrite_lock → _locked).
+    with rewrite_lock(path.parent):
+        archived: Path | None = None
+        if path.is_file():
+            ts_slug = _now_ts().replace(":", "").replace(".", "-")
+            archived = path.with_suffix(f".broken-{ts_slug}.jsonl")
+            path.rename(archived)
 
-    # Start fresh chain with a chain_reset genesis carrying the
-    # recovery-attestation envelope payload (Event 80 / CP-CHAIN-
-    # RECOVERY-PROTOCOL-01). Schema documented in
-    # kernel/CHAIN_RECOVERY_PROTOCOL.md § Common payload fields.
-    genesis_payload = {
-        "type": "chain_reset",
-        "mode": mode,
-        "reason": reason.strip(),
-        "operator_confirmation": operator_confirmation.strip(),
-        "previous_head": previous_head,
-        "recovered_at": _now_ts(),
-        "archived_from": str(archived) if archived else None,
-        "what_was_lost": what_was_lost.strip() if what_was_lost else None,
-    }
-    envelope = append(path, genesis_payload)
+        # Start fresh chain with a chain_reset genesis carrying the
+        # recovery-attestation envelope payload (Event 80 / CP-CHAIN-
+        # RECOVERY-PROTOCOL-01). Schema documented in
+        # kernel/CHAIN_RECOVERY_PROTOCOL.md § Common payload fields.
+        genesis_payload = {
+            "type": "chain_reset",
+            "mode": mode,
+            "reason": reason.strip(),
+            "operator_confirmation": operator_confirmation.strip(),
+            "previous_head": previous_head,
+            "recovered_at": _now_ts(),
+            "archived_from": str(archived) if archived else None,
+            "what_was_lost": what_was_lost.strip() if what_was_lost else None,
+        }
+        envelope = append(path, genesis_payload)
     return ResetResult(
         status="archived_and_reset" if archived else "reset",
         archived_path=archived,

--- a/core/hooks/_fence_synthesis.py
+++ b/core/hooks/_fence_synthesis.py
@@ -215,6 +215,64 @@ def candidate_correlation_ids(
 
 
 # ---------------------------------------------------------------------------
+# Pair-signature fallback ladder — v1.9 loop-hygiene §3.1
+#
+# The h_ bucket ladder (candidate_correlation_ids) only spans a few
+# seconds, so a >5s no-tool_use_id op cannot pair. The pair signature is
+# a wall-clock-INDEPENDENT key over (session_scope | cwd | normalize(cmd))
+# — PostToolUse's tier-3 fallback (see finalize_on_success_with_fallback)
+# scans pending markers by this signature, oldest-first, delete-on-use.
+# ---------------------------------------------------------------------------
+
+_PAIR_SIG_CMD_CAP_BYTES = 4096
+
+
+def normalize(cmd: str) -> str:
+    """Canonicalize a command for signature pairing: collapse internal
+    whitespace runs to single spaces, expand ``~`` → ``$HOME``, cap at
+    ``_PAIR_SIG_CMD_CAP_BYTES`` bytes. Deterministic: Pre and Post apply
+    the same transform so the signature is identical on both sides."""
+    if not cmd:
+        return ""
+    text = " ".join(cmd.split())
+    home = os.environ.get("HOME") or str(Path.home())
+    text = text.replace("~", home)
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) > _PAIR_SIG_CMD_CAP_BYTES:
+        text = encoded[:_PAIR_SIG_CMD_CAP_BYTES].decode("utf-8", errors="ignore")
+    return text
+
+
+def pair_signature(session_scope: str, cwd: str, cmd: str) -> str:
+    """Timestamp-independent Pre/Post pairing key.
+
+    ``s_`` + sha1(``session_scope | cwd | normalize(cmd)``)[:16].
+    ``session_scope`` is the payload ``session_id`` when the runtime
+    carries it (probe §6.2 step 0: present on both Pre and Post), else
+    empty — the signature then degrades to (cwd | cmd), which still pairs
+    an op with itself as long as nothing else in the same second-window
+    shares the identical command."""
+    seed = f"{session_scope}|{cwd}|{normalize(cmd)}".encode("utf-8", errors="replace")
+    return "s_" + hashlib.sha1(seed).hexdigest()[:16]
+
+
+def _session_scope(payload: dict) -> str:
+    """Session scope for the pair signature. Probe §6.2 step 0 confirmed
+    Claude Code hook payloads carry ``session_id`` on both Pre and Post,
+    so it is the scope source; absent, this returns empty and the
+    signature degrades to (cwd | cmd)."""
+    return str(payload.get("session_id") or "")
+
+
+def pair_signature_for_payload(payload: dict, cmd: str) -> str:
+    """Compute the pair signature from a hook payload (Post side). The cwd
+    is normalized through ``Path`` so it matches the Pre-side marker,
+    which stores ``str(Path(payload['cwd']))``."""
+    cwd = str(Path(str(payload.get("cwd") or os.getcwd())))
+    return pair_signature(_session_scope(payload), cwd, cmd)
+
+
+# ---------------------------------------------------------------------------
 # Context signature — CP5 minimal inline computation
 #
 # The canonical version lives in CP7's `_context_signature.py` and
@@ -263,20 +321,30 @@ def write_pending_marker(
     correlation: str,
     cwd: Path,
     cmd: str,
+    *,
+    session_scope: str = "",
 ) -> Path | None:
     """Persist the Fence-admitted surface so PostToolUse can finalize.
 
     Returns the marker path on success, None on graceful-degrade
     failure. Never raises — the PreToolUse path must not break on
     synthesis bookkeeping failure.
+
+    Marker schema v2 (§3.1, additive; readers tolerate absence): the
+    marker gains ``pair_signature`` (the timestamp-independent tier-3
+    key) and ``ppid`` (this Pre-process's parent PID — a tier-3
+    discriminator; probe §6.2 step 0 confirmed Pre/Post share it). Old v1
+    markers simply never signature-match.
     """
     try:
         marker = {
-            "version": 1,
+            "version": 2,
             "correlation_id": correlation,
             "written_at": datetime.now(timezone.utc).isoformat(),
             "cwd": str(cwd),
             "command_redacted": _redact(cmd),
+            "pair_signature": pair_signature(session_scope, str(cwd), cmd),
+            "ppid": os.getppid(),
             "surface": {
                 "constraint_identified": str(surface.get("constraint_identified", "")),
                 "origin_evidence": str(surface.get("origin_evidence", "")),
@@ -432,9 +500,59 @@ def finalize_on_success(correlation: str, exit_code: int | None) -> dict | None:
         delete_pending_marker(correlation)
 
 
+def _signature_scan(
+    pair_sig: str, post_ppid: int | None
+) -> tuple[Path | None, dict | None]:
+    """Tier 3 of the pairing ladder (§3.1). Scan the pending dir for a
+    marker whose ``pair_signature`` equals ``pair_sig``, TTL-filtered,
+    oldest-first (FIFO: the earliest unfinalized identical op pairs
+    first). Returns ``(path, marker)`` or ``(None, None)``.
+
+    ``post_ppid`` is a SOFT discriminator: markers whose ``ppid`` matches
+    are preferred (probe §6.2 step 0: Pre/Post share PPID), but if none
+    match, the FIFO order over all signature matches still pairs — a
+    differing spawn model degrades to pure FIFO rather than failing a
+    legitimate pair closed. Old v1 markers (no ``pair_signature``) never
+    match. Never raises."""
+    pending = _pending_dir()
+    if not pending.is_dir():
+        return None, None
+    now = datetime.now(timezone.utc)
+    matches: list[tuple[datetime, bool, Path, dict]] = []
+    for path in pending.glob("*.json"):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict) or data.get("pair_signature") != pair_sig:
+            continue
+        written = data.get("written_at")
+        written_dt = now
+        if isinstance(written, str):
+            try:
+                written_dt = datetime.fromisoformat(written.replace("Z", "+00:00"))
+            except ValueError:
+                written_dt = now
+            else:
+                if (now - written_dt).total_seconds() > MARKER_TTL_SECONDS:
+                    continue
+        ppid_match = post_ppid is not None and data.get("ppid") == post_ppid
+        matches.append((written_dt, ppid_match, path, data))
+    if not matches:
+        return None, None
+    preferred = [m for m in matches if m[1]] or matches
+    preferred.sort(key=lambda m: m[0])  # oldest-first FIFO
+    _, _, path, data = preferred[0]
+    return path, data
+
+
 def finalize_on_success_with_fallback(
     candidates: list[str],
     exit_code: int | None,
+    *,
+    pair_sig: str | None = None,
+    post_ppid: int | None = None,
 ) -> dict | None:
     """Event 50 · CP-FENCE-02 — try multiple correlation candidates.
 
@@ -444,12 +562,20 @@ def finalize_on_success_with_fallback(
     under a different id than the PostToolUse-computed correlation
     (the Claude Code PreToolUse-lacks-tool_use_id case).
 
+    Pairing ladder (§3.1, strictly ordered, first hit wins):
+      1+2. ``candidates`` — explicit runtime ids then the bucket window
+           (current + lookback/lookahead second-buckets).
+      3. ``pair_sig`` signature scan — a timestamp-independent fallback
+         for a >5s no-tool_use_id op whose Pre marker's second-bucket is
+         beyond the candidate window. Skipped when ``pair_sig`` is None
+         (backward-compatible: existing callers behave exactly as before).
+
     Behavior:
-      - Walk candidates in order, read the first marker that exists.
-      - If exit_code == 0, synthesize + write protocol (same as
-        ``finalize_on_success``).
-      - Regardless of synthesis outcome, delete ALL candidate markers
-        so stale siblings don't pile up.
+      - Walk candidates in order, read the first marker that exists; else
+        run the tier-3 signature scan.
+      - If exit_code == 0, synthesize + write protocol.
+      - Delete ALL candidate markers (stale siblings), plus the tier-3
+        marker on use (delete-on-use), regardless of synthesis outcome.
       - Returns the envelope on synthesis write, else None.
     """
     found_marker: dict | None = None
@@ -458,6 +584,9 @@ def finalize_on_success_with_fallback(
         if candidate_marker is not None:
             found_marker = candidate_marker
             break
+    tier3_path: Path | None = None
+    if found_marker is None and pair_sig:
+        tier3_path, found_marker = _signature_scan(pair_sig, post_ppid)
     try:
         if found_marker is None:
             return None
@@ -480,6 +609,11 @@ def finalize_on_success_with_fallback(
     finally:
         for cid in candidates:
             delete_pending_marker(cid)
+        if tier3_path is not None:
+            try:
+                tier3_path.unlink()
+            except OSError:
+                pass
 
 
 # ---------------------------------------------------------------------------

--- a/core/hooks/_framework.py
+++ b/core/hooks/_framework.py
@@ -71,6 +71,7 @@ from _chain import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     atomic_replace_file as _atomic_replace,
     compute_entry_hash,
     iter_records as _chain_iter,
+    rewrite_lock as _rewrite_lock,
     verify_chain as _chain_verify,
 )
 
@@ -644,130 +645,134 @@ def upgrade_cp5_prechain(
             message=f"{target} does not exist — nothing to upgrade",
         )
 
-    try:
-        text = target.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise UpgradeError(f"upgrade_cp5_prechain read: {exc}") from exc
-
-    lines = [ln for ln in text.splitlines() if ln.strip()]
-    if not lines:
-        return UpgradeResult(
-            status="empty",
-            entries_processed=0,
-            backup_path=None,
-            message=f"{target} is empty — nothing to upgrade",
-        )
-
-    parsed: list[dict] = []
-    for idx, line in enumerate(lines):
+    # §4.1 — a chain-rewrite op: shared rewrite mutex FIRST, then the
+    # per-file lock (lock-order law). The rewrite uses atomic_replace_file
+    # directly, so no second same-process flock is taken.
+    with _rewrite_lock(target.parent), _chain_locked(target):
         try:
-            rec = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise UpgradeError(
-                f"{target}:line {idx + 1}: not valid JSON ({exc})"
-            ) from exc
-        if not isinstance(rec, dict):
-            raise UpgradeError(
-                f"{target}:line {idx + 1}: not a JSON object"
-            )
-        parsed.append(rec)
+            text = target.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise UpgradeError(f"upgrade_cp5_prechain read: {exc}") from exc
 
-    # Idempotent fast path — already upgraded?
-    if all(_looks_already_upgraded(r) for r in parsed):
-        verdict = _chain_verify(target)
-        if verdict.intact:
+        lines = [ln for ln in text.splitlines() if ln.strip()]
+        if not lines:
             return UpgradeResult(
-                status="already_upgraded",
-                entries_processed=len(parsed),
+                status="empty",
+                entries_processed=0,
                 backup_path=None,
-                message=(
-                    f"{target}: {len(parsed)} records already in "
-                    f"cp7-chained-v1 envelope; chain intact"
-                ),
+                message=f"{target} is empty — nothing to upgrade",
             )
-        raise UpgradeError(
-            f"{target}: appears upgraded but chain verification failed "
-            f"({verdict.reason}). Operator must resolve manually."
-        )
 
-    # Mixed state — partial upgrade detected.
-    if any(_looks_already_upgraded(r) for r in parsed) and any(
-        _looks_cp5_prechain(r) for r in parsed
-    ):
-        raise UpgradeError(
-            f"{target}: file contains both cp5-pre-chain AND cp7-chained-v1 "
-            f"records. Partial upgrade detected; operator must resolve "
-            f"manually (archive then re-play from backup)."
-        )
+        parsed: list[dict] = []
+        for idx, line in enumerate(lines):
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise UpgradeError(
+                    f"{target}:line {idx + 1}: not valid JSON ({exc})"
+                ) from exc
+            if not isinstance(rec, dict):
+                raise UpgradeError(
+                    f"{target}:line {idx + 1}: not a JSON object"
+                )
+            parsed.append(rec)
 
-    # Every record must look cp5-pre-chain at this point.
-    for idx, rec in enumerate(parsed):
-        if not _looks_cp5_prechain(rec):
+        # Idempotent fast path — already upgraded?
+        if all(_looks_already_upgraded(r) for r in parsed):
+            verdict = _chain_verify(target)
+            if verdict.intact:
+                return UpgradeResult(
+                    status="already_upgraded",
+                    entries_processed=len(parsed),
+                    backup_path=None,
+                    message=(
+                        f"{target}: {len(parsed)} records already in "
+                        f"cp7-chained-v1 envelope; chain intact"
+                    ),
+                )
             raise UpgradeError(
-                f"{target}:line {idx + 1}: expected cp5-pre-chain shape "
-                f"(format_version={CP5_FORMAT_VERSION!r}, null chain fields); "
-                f"got format_version={rec.get('format_version')!r}"
+                f"{target}: appears upgraded but chain verification failed "
+                f"({verdict.reason}). Operator must resolve manually."
             )
-        if not isinstance(rec.get("written_at"), str):
+
+        # Mixed state — partial upgrade detected.
+        if any(_looks_already_upgraded(r) for r in parsed) and any(
+            _looks_cp5_prechain(r) for r in parsed
+        ):
             raise UpgradeError(
-                f"{target}:line {idx + 1}: missing required "
-                f"`written_at` string field"
+                f"{target}: file contains both cp5-pre-chain AND cp7-chained-v1 "
+                f"records. Partial upgrade detected; operator must resolve "
+                f"manually (archive then re-play from backup)."
             )
 
-    # Backup the original file.
-    backup_ts = lines[-1] if False else ""  # placeholder; real ts below
-    from datetime import datetime, timezone
+        # Every record must look cp5-pre-chain at this point.
+        for idx, rec in enumerate(parsed):
+            if not _looks_cp5_prechain(rec):
+                raise UpgradeError(
+                    f"{target}:line {idx + 1}: expected cp5-pre-chain shape "
+                    f"(format_version={CP5_FORMAT_VERSION!r}, null chain fields); "
+                    f"got format_version={rec.get('format_version')!r}"
+                )
+            if not isinstance(rec.get("written_at"), str):
+                raise UpgradeError(
+                    f"{target}:line {idx + 1}: missing required "
+                    f"`written_at` string field"
+                )
 
-    backup_ts = (
-        datetime.now(timezone.utc).isoformat().replace(":", "").replace(".", "-")
-    )
-    backup = target.with_suffix(f".upgrade-{backup_ts}.bak")
-    try:
-        backup.write_bytes(target.read_bytes())
-    except OSError as exc:
-        raise UpgradeError(f"upgrade_cp5_prechain backup: {exc}") from exc
+        # Backup the original file.
+        backup_ts = lines[-1] if False else ""  # placeholder; real ts below
+        from datetime import datetime, timezone
 
-    # Walk + rechain. Write to a new file then atomic-replace.
-    new_lines: list[str] = []
-    expected_prev = GENESIS_PREV_HASH
-    for rec in parsed:
-        payload = _cp5_payload_from_legacy(rec)
-        ts = str(rec["written_at"])
-        entry_hash = compute_entry_hash(expected_prev, ts, payload)
-        envelope = {
-            "schema_version": UPGRADED_FORMAT_MARKER,
-            "ts": ts,
-            "prev_hash": expected_prev,
-            "payload": payload,
-            "entry_hash": entry_hash,
-        }
-        new_lines.append(json.dumps(envelope, ensure_ascii=False))
-        expected_prev = entry_hash
-
-    new_contents = ("\n".join(new_lines) + "\n").encode("utf-8")
-    try:
-        _atomic_replace(target, new_contents)
-    except OSError as exc:
-        raise UpgradeError(f"upgrade_cp5_prechain atomic replace: {exc}") from exc
-
-    # Post-upgrade verify — the walker's output must re-verify.
-    post_verdict = _chain_verify(target)
-    if not post_verdict.intact:
-        raise UpgradeError(
-            f"{target}: upgrade wrote file but post-verify failed "
-            f"({post_verdict.reason}). Backup preserved at {backup}."
+        backup_ts = (
+            datetime.now(timezone.utc).isoformat().replace(":", "").replace(".", "-")
         )
+        backup = target.with_suffix(f".upgrade-{backup_ts}.bak")
+        try:
+            backup.write_bytes(target.read_bytes())
+        except OSError as exc:
+            raise UpgradeError(f"upgrade_cp5_prechain backup: {exc}") from exc
 
-    return UpgradeResult(
-        status="upgraded",
-        entries_processed=len(parsed),
-        backup_path=backup,
-        message=(
-            f"{target}: upgraded {len(parsed)} records from "
-            f"cp5-pre-chain to cp7-chained-v1; chain intact. "
-            f"Backup: {backup}"
-        ),
-    )
+        # Walk + rechain. Write to a new file then atomic-replace.
+        new_lines: list[str] = []
+        expected_prev = GENESIS_PREV_HASH
+        for rec in parsed:
+            payload = _cp5_payload_from_legacy(rec)
+            ts = str(rec["written_at"])
+            entry_hash = compute_entry_hash(expected_prev, ts, payload)
+            envelope = {
+                "schema_version": UPGRADED_FORMAT_MARKER,
+                "ts": ts,
+                "prev_hash": expected_prev,
+                "payload": payload,
+                "entry_hash": entry_hash,
+            }
+            new_lines.append(json.dumps(envelope, ensure_ascii=False))
+            expected_prev = entry_hash
+
+        new_contents = ("\n".join(new_lines) + "\n").encode("utf-8")
+        try:
+            _atomic_replace(target, new_contents)
+        except OSError as exc:
+            raise UpgradeError(f"upgrade_cp5_prechain atomic replace: {exc}") from exc
+
+        # Post-upgrade verify — the walker's output must re-verify.
+        post_verdict = _chain_verify(target)
+        if not post_verdict.intact:
+            raise UpgradeError(
+                f"{target}: upgrade wrote file but post-verify failed "
+                f"({post_verdict.reason}). Backup preserved at {backup}."
+            )
+
+        return UpgradeResult(
+            status="upgraded",
+            entries_processed=len(parsed),
+            backup_path=backup,
+            message=(
+                f"{target}: upgraded {len(parsed)} records from "
+                f"cp5-pre-chain to cp7-chained-v1; chain intact. "
+                f"Backup: {backup}"
+            ),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -833,206 +838,212 @@ def compact_deferred_discoveries(
             message=f"{target} does not exist — nothing to compact",
         )
 
-    try:
-        text = target.read_text(encoding="utf-8")
-    except OSError as exc:
-        raise ChainError(f"compact_deferred_discoveries read: {exc}") from exc
-
-    lines = [ln for ln in text.splitlines() if ln.strip()]
-    if not lines:
-        return CompactResult(
-            status="empty",
-            total_before=0,
-            total_after=0,
-            removed=0,
-            backup_path=None,
-            head_hash=None,
-            message=f"{target} is empty — nothing to compact",
-        )
-
-    # Parse every line first. A single bad line aborts the whole run so
-    # we never produce a partial rewrite (matches upgrade_cp5_prechain).
-    parsed: list[dict] = []
-    for idx, line in enumerate(lines):
+    # §4.1 retrofit — the whole-window lock this op previously lacked.
+    # Lock-order law: shared rewrite mutex FIRST, then the per-file
+    # lock (matching the sibling compact_protocols). The rebuild uses
+    # compute_entry_hash + atomic_replace_file directly (never
+    # _chain.append), so no second same-process flock is taken.
+    with _rewrite_lock(target.parent), _chain_locked(target):
         try:
-            rec = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise ChainError(
-                f"{target}:line {idx + 1}: not valid JSON ({exc})"
-            ) from exc
-        if not isinstance(rec, dict):
-            raise ChainError(f"{target}:line {idx + 1}: not a JSON object")
-        parsed.append(rec)
+            text = target.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ChainError(f"compact_deferred_discoveries read: {exc}") from exc
 
-    total_before = len(parsed)
-
-    # INPUT chain pre-verify (Event 136 review must-fix). The rebuild below
-    # recomputes prev_hash/entry_hash from GENESIS, so a pre-existing break
-    # or tamper in the input would be SILENTLY "healed" into a self-consistent
-    # chain — laundering a quarantined/tampered record into a verified state,
-    # and the post-rebuild verify passes by construction so it can never catch
-    # this. Refuse to compact a non-intact input (mirrors the sibling
-    # upgrade_cp5_prechain guard). The operator must resolve the break
-    # manually (archive + re-play from backup) before compaction. This fires
-    # for the dry-run path too — you cannot safely preview a compaction whose
-    # rebuild would erase tamper evidence.
-    input_verdict = _chain_verify(target)
-    if not input_verdict.intact:
-        raise ChainError(
-            f"{target}: input chain not intact ({input_verdict.reason}) — "
-            f"refusing to compact. A GENESIS rebuild would launder the break "
-            f"into a verified chain and promote quarantined records. Operator "
-            f"must resolve the break manually (archive + re-play from backup) "
-            f"before compaction."
-        )
-
-    # Verdicts couple to discoveries by entry_hash (see § Resolution
-    # layer). A GENESIS rebuild recomputes every entry_hash, so any
-    # verdict ref would dangle and a resolved discovery would re-open —
-    # unless we (1) never drop a verdicted discovery as a duplicate, and
-    # (2) remap verdict refs old->new during the rebuild. Collect the
-    # referenced hashes first.
-    verdict_refs: set[str] = set()
-    for rec in parsed:
-        payload = rec.get("payload")
-        if isinstance(payload, dict) and payload.get("type") == DISCOVERY_VERDICT_TYPE:
-            ref = payload.get("ref")
-            if isinstance(ref, str) and ref:
-                verdict_refs.add(ref)
-
-    # Walk in file order; keep the first open deferred_discovery per
-    # dedup key, drop later open UNVERDICTED duplicates, keep everything
-    # else. A verdicted discovery is never dropped (its verdict refs it)
-    # but its key is still recorded as seen — otherwise a later
-    # unverdicted duplicate of a resolved finding would survive as
-    # "first" and keep re-firing the banner (adversarial finding
-    # 2026-07-03: verdicting the first member must not defeat dedup of
-    # the rest).
-    seen_keys: set[tuple[str, str]] = set()
-    kept: list[dict] = []
-    for rec in parsed:
-        payload = rec.get("payload")
-        if (
-            isinstance(payload, dict)
-            and payload.get("type") == DEFERRED_DISCOVERY_TYPE
-            and str(payload.get("status", "pending")) in OPEN_STATUSES
-        ):
-            key = _dedup_key(payload, dedup_desc_prefix)
-            verdicted = str(rec.get("entry_hash") or "") in verdict_refs
-            if key in seen_keys and not verdicted:
-                continue  # later open, unverdicted duplicate — drop
-            seen_keys.add(key)
-        kept.append(rec)
-
-    total_after = len(kept)
-    removed = total_before - total_after
-
-    if removed == 0:
-        return CompactResult(
-            status="noop",
-            total_before=total_before,
-            total_after=total_after,
-            removed=0,
-            backup_path=None,
-            head_hash=_chain_verify(target).head_hash,
-            message=(
-                f"{target}: no open duplicates among {total_before} records "
-                f"— nothing to compact"
-            ),
-        )
-
-    # Rebuild the chain from GENESIS, preserving each kept record's
-    # ORIGINAL envelope ts (byte-stable: re-running on already-compacted
-    # input is a noop because the hashes reproduce exactly).
-    new_lines: list[str] = []
-    expected_prev = GENESIS_PREV_HASH
-    head_hash = expected_prev
-    # old entry_hash -> new entry_hash, so a verdict's `ref` (which
-    # points at a discovery's OLD hash) can be rewritten to the new one.
-    # A discovery always precedes its verdict in append order, so the
-    # map entry exists by the time the verdict is rebuilt.
-    hash_remap: dict[str, str] = {}
-    for rec in kept:
-        payload = rec.get("payload")
-        ts = rec.get("ts")
-        if not isinstance(payload, dict) or not isinstance(ts, str):
-            raise ChainError(
-                f"{target}: kept record missing payload / ts during rebuild "
-                f"(payload={type(payload).__name__}, ts={type(ts).__name__})"
+        lines = [ln for ln in text.splitlines() if ln.strip()]
+        if not lines:
+            return CompactResult(
+                status="empty",
+                total_before=0,
+                total_after=0,
+                removed=0,
+                backup_path=None,
+                head_hash=None,
+                message=f"{target} is empty — nothing to compact",
             )
-        if payload.get("type") == DISCOVERY_VERDICT_TYPE:
-            old_ref = payload.get("ref")
-            if isinstance(old_ref, str) and old_ref in hash_remap:
-                payload = {**payload, "ref": hash_remap[old_ref]}
-        old_entry_hash = str(rec.get("entry_hash") or "")
-        entry_hash = compute_entry_hash(expected_prev, ts, payload)
-        if old_entry_hash:
-            hash_remap[old_entry_hash] = entry_hash
-        envelope = {
-            "schema_version": UPGRADED_FORMAT_MARKER,
-            "ts": ts,
-            "prev_hash": expected_prev,
-            "payload": payload,
-            "entry_hash": entry_hash,
-        }
-        new_lines.append(json.dumps(envelope, ensure_ascii=False))
-        expected_prev = entry_hash
-        head_hash = entry_hash
 
-    if dry_run:
+        # Parse every line first. A single bad line aborts the whole run so
+        # we never produce a partial rewrite (matches upgrade_cp5_prechain).
+        parsed: list[dict] = []
+        for idx, line in enumerate(lines):
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ChainError(
+                    f"{target}:line {idx + 1}: not valid JSON ({exc})"
+                ) from exc
+            if not isinstance(rec, dict):
+                raise ChainError(f"{target}:line {idx + 1}: not a JSON object")
+            parsed.append(rec)
+
+        total_before = len(parsed)
+
+        # INPUT chain pre-verify (Event 136 review must-fix). The rebuild below
+        # recomputes prev_hash/entry_hash from GENESIS, so a pre-existing break
+        # or tamper in the input would be SILENTLY "healed" into a self-consistent
+        # chain — laundering a quarantined/tampered record into a verified state,
+        # and the post-rebuild verify passes by construction so it can never catch
+        # this. Refuse to compact a non-intact input (mirrors the sibling
+        # upgrade_cp5_prechain guard). The operator must resolve the break
+        # manually (archive + re-play from backup) before compaction. This fires
+        # for the dry-run path too — you cannot safely preview a compaction whose
+        # rebuild would erase tamper evidence.
+        input_verdict = _chain_verify(target)
+        if not input_verdict.intact:
+            raise ChainError(
+                f"{target}: input chain not intact ({input_verdict.reason}) — "
+                f"refusing to compact. A GENESIS rebuild would launder the break "
+                f"into a verified chain and promote quarantined records. Operator "
+                f"must resolve the break manually (archive + re-play from backup) "
+                f"before compaction."
+            )
+
+        # Verdicts couple to discoveries by entry_hash (see § Resolution
+        # layer). A GENESIS rebuild recomputes every entry_hash, so any
+        # verdict ref would dangle and a resolved discovery would re-open —
+        # unless we (1) never drop a verdicted discovery as a duplicate, and
+        # (2) remap verdict refs old->new during the rebuild. Collect the
+        # referenced hashes first.
+        verdict_refs: set[str] = set()
+        for rec in parsed:
+            payload = rec.get("payload")
+            if isinstance(payload, dict) and payload.get("type") == DISCOVERY_VERDICT_TYPE:
+                ref = payload.get("ref")
+                if isinstance(ref, str) and ref:
+                    verdict_refs.add(ref)
+
+        # Walk in file order; keep the first open deferred_discovery per
+        # dedup key, drop later open UNVERDICTED duplicates, keep everything
+        # else. A verdicted discovery is never dropped (its verdict refs it)
+        # but its key is still recorded as seen — otherwise a later
+        # unverdicted duplicate of a resolved finding would survive as
+        # "first" and keep re-firing the banner (adversarial finding
+        # 2026-07-03: verdicting the first member must not defeat dedup of
+        # the rest).
+        seen_keys: set[tuple[str, str]] = set()
+        kept: list[dict] = []
+        for rec in parsed:
+            payload = rec.get("payload")
+            if (
+                isinstance(payload, dict)
+                and payload.get("type") == DEFERRED_DISCOVERY_TYPE
+                and str(payload.get("status", "pending")) in OPEN_STATUSES
+            ):
+                key = _dedup_key(payload, dedup_desc_prefix)
+                verdicted = str(rec.get("entry_hash") or "") in verdict_refs
+                if key in seen_keys and not verdicted:
+                    continue  # later open, unverdicted duplicate — drop
+                seen_keys.add(key)
+            kept.append(rec)
+
+        total_after = len(kept)
+        removed = total_before - total_after
+
+        if removed == 0:
+            return CompactResult(
+                status="noop",
+                total_before=total_before,
+                total_after=total_after,
+                removed=0,
+                backup_path=None,
+                head_hash=_chain_verify(target).head_hash,
+                message=(
+                    f"{target}: no open duplicates among {total_before} records "
+                    f"— nothing to compact"
+                ),
+            )
+
+        # Rebuild the chain from GENESIS, preserving each kept record's
+        # ORIGINAL envelope ts (byte-stable: re-running on already-compacted
+        # input is a noop because the hashes reproduce exactly).
+        new_lines: list[str] = []
+        expected_prev = GENESIS_PREV_HASH
+        head_hash = expected_prev
+        # old entry_hash -> new entry_hash, so a verdict's `ref` (which
+        # points at a discovery's OLD hash) can be rewritten to the new one.
+        # A discovery always precedes its verdict in append order, so the
+        # map entry exists by the time the verdict is rebuilt.
+        hash_remap: dict[str, str] = {}
+        for rec in kept:
+            payload = rec.get("payload")
+            ts = rec.get("ts")
+            if not isinstance(payload, dict) or not isinstance(ts, str):
+                raise ChainError(
+                    f"{target}: kept record missing payload / ts during rebuild "
+                    f"(payload={type(payload).__name__}, ts={type(ts).__name__})"
+                )
+            if payload.get("type") == DISCOVERY_VERDICT_TYPE:
+                old_ref = payload.get("ref")
+                if isinstance(old_ref, str) and old_ref in hash_remap:
+                    payload = {**payload, "ref": hash_remap[old_ref]}
+            old_entry_hash = str(rec.get("entry_hash") or "")
+            entry_hash = compute_entry_hash(expected_prev, ts, payload)
+            if old_entry_hash:
+                hash_remap[old_entry_hash] = entry_hash
+            envelope = {
+                "schema_version": UPGRADED_FORMAT_MARKER,
+                "ts": ts,
+                "prev_hash": expected_prev,
+                "payload": payload,
+                "entry_hash": entry_hash,
+            }
+            new_lines.append(json.dumps(envelope, ensure_ascii=False))
+            expected_prev = entry_hash
+            head_hash = entry_hash
+
+        if dry_run:
+            return CompactResult(
+                status="compacted",
+                total_before=total_before,
+                total_after=total_after,
+                removed=removed,
+                backup_path=None,
+                head_hash=None,
+                message=(
+                    f"{target}: DRY RUN — would remove {removed} open duplicate(s), "
+                    f"leaving {total_after} of {total_before} records"
+                ),
+            )
+
+        # Backup the original bytes before any rewrite.
+        from datetime import datetime, timezone
+
+        backup_ts = (
+            datetime.now(timezone.utc).isoformat().replace(":", "").replace(".", "-")
+        )
+        backup = target.with_suffix(f".compact-{backup_ts}.bak")
+        try:
+            backup.write_bytes(target.read_bytes())
+        except OSError as exc:
+            raise ChainError(f"compact_deferred_discoveries backup: {exc}") from exc
+
+        new_contents = ("\n".join(new_lines) + "\n").encode("utf-8")
+        try:
+            _atomic_replace(target, new_contents)
+        except OSError as exc:
+            raise ChainError(
+                f"compact_deferred_discoveries atomic replace: {exc}"
+            ) from exc
+
+        post_verdict = _chain_verify(target)
+        if not post_verdict.intact:
+            raise ChainError(
+                f"{target}: compaction wrote file but post-verify failed "
+                f"({post_verdict.reason}). Backup preserved at {backup}."
+            )
+
         return CompactResult(
             status="compacted",
             total_before=total_before,
             total_after=total_after,
             removed=removed,
-            backup_path=None,
-            head_hash=None,
+            backup_path=backup,
+            head_hash=post_verdict.head_hash,
             message=(
-                f"{target}: DRY RUN — would remove {removed} open duplicate(s), "
-                f"leaving {total_after} of {total_before} records"
+                f"{target}: compacted {total_before} → {total_after} records "
+                f"({removed} open duplicate(s) removed); chain intact. "
+                f"Backup: {backup}"
             ),
         )
-
-    # Backup the original bytes before any rewrite.
-    from datetime import datetime, timezone
-
-    backup_ts = (
-        datetime.now(timezone.utc).isoformat().replace(":", "").replace(".", "-")
-    )
-    backup = target.with_suffix(f".compact-{backup_ts}.bak")
-    try:
-        backup.write_bytes(target.read_bytes())
-    except OSError as exc:
-        raise ChainError(f"compact_deferred_discoveries backup: {exc}") from exc
-
-    new_contents = ("\n".join(new_lines) + "\n").encode("utf-8")
-    try:
-        _atomic_replace(target, new_contents)
-    except OSError as exc:
-        raise ChainError(
-            f"compact_deferred_discoveries atomic replace: {exc}"
-        ) from exc
-
-    post_verdict = _chain_verify(target)
-    if not post_verdict.intact:
-        raise ChainError(
-            f"{target}: compaction wrote file but post-verify failed "
-            f"({post_verdict.reason}). Backup preserved at {backup}."
-        )
-
-    return CompactResult(
-        status="compacted",
-        total_before=total_before,
-        total_after=total_after,
-        removed=removed,
-        backup_path=backup,
-        head_hash=post_verdict.head_hash,
-        message=(
-            f"{target}: compacted {total_before} → {total_after} records "
-            f"({removed} open duplicate(s) removed); chain intact. "
-            f"Backup: {backup}"
-        ),
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -1181,10 +1192,12 @@ def compact_protocols(
             message=f"{target} does not exist — nothing to compact",
         )
 
-    # Whole-window lock (see docstring § Concurrency). The missing check
-    # is deliberately BEFORE the lock so _locked's ``a+`` open does not
-    # materialise an empty file for a truly-absent target.
-    with _chain_locked(target):
+    # Whole-window lock (see docstring § Concurrency). §4.1 lock-order
+    # law: the shared rewrite mutex (cross-stream / cross-session) is
+    # acquired FIRST, then the per-file lock — never the reverse. The
+    # missing check is deliberately BEFORE the locks so _locked's ``a+``
+    # open does not materialise an empty file for a truly-absent target.
+    with _rewrite_lock(target.parent), _chain_locked(target):
         try:
             text = target.read_text(encoding="utf-8")
         except OSError as exc:

--- a/core/hooks/fence_synthesis.py
+++ b/core/hooks/fence_synthesis.py
@@ -24,6 +24,7 @@ them.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -37,6 +38,7 @@ from _fence_synthesis import (  # noqa: E402  # pyright: ignore[reportMissingImp
     candidate_correlation_ids as _candidate_correlation_ids,
     correlation_id as _correlation_id,
     finalize_on_success_with_fallback as _finalize_with_fallback,
+    pair_signature_for_payload as _pair_signature_for_payload,
     POST_LOOKBACK_SECONDS as _POST_LOOKBACK_SECONDS,
     POST_LOOKAHEAD_SECONDS as _POST_LOOKAHEAD_SECONDS,
 )
@@ -149,6 +151,21 @@ def main() -> int:
     except (json.JSONDecodeError, OSError) as exc:
         _hook_log(f"invocation: payload parse failed — {type(exc).__name__}: {exc}")
         return 0
+    # §3.1 diagnostic (bounded logging, shipped). Records the live
+    # PostToolUse payload shape + this hook process's parent PID. Two
+    # loop-hygiene invariants read it: `session_id` presence selects the
+    # pair-signature `session_scope` source, and Pre/Post PPID sharing
+    # decides whether `ppid` is a tier-3 signature discriminator or stays
+    # diagnostic-only. One line per Post invocation; keys/PID only (no
+    # values) so it never leaks command content.
+    try:
+        _hook_log(
+            f"probe: keys={sorted(payload.keys())} "
+            f"ppid={os.getppid()} "
+            f"session_id={'present' if payload.get('session_id') else 'absent'}"
+        )
+    except Exception:
+        pass
     try:
         if _tool_name(payload) != "Bash":
             _hook_log(f"skipped: tool={_tool_name(payload)!r}")
@@ -177,11 +194,19 @@ def main() -> int:
             lookback_seconds=_POST_LOOKBACK_SECONDS,
             lookahead_seconds=_POST_LOOKAHEAD_SECONDS,
         )
+        # §3.1 tier-3 inputs — the timestamp-independent pair signature +
+        # this Post-process's parent PID (soft discriminator; probe §6.2
+        # step 0: Pre/Post share PPID). They let the finalizer pair a >5s
+        # no-tool_use_id op whose Pre marker's second-bucket falls outside
+        # the candidate window.
+        _pair_sig = _pair_signature_for_payload(payload, cmd)
+        _post_ppid = os.getppid()
         # Finalize synthesis first so we know whether a protocol was
         # produced. CP8: pass the synthesis signal into the spot-check
         # sampler; the multiplier lands before the sample roll.
         envelope = _finalize_with_fallback(
-            candidates, _extract_exit_code(payload)
+            candidates, _extract_exit_code(payload),
+            pair_sig=_pair_sig, post_ppid=_post_ppid,
         )
         if envelope is not None:
             _hook_log(f"synthesized protocol: correlation={correlation[:16]}")

--- a/core/hooks/reasoning_surface_guard.py
+++ b/core/hooks/reasoning_surface_guard.py
@@ -1443,6 +1443,15 @@ def main() -> int:
                 sys.stderr.write(f"[episteme advisory] {l2_detail}\n")
 
             if status == "ok":
+                # §3.2 · Single per-op wall-clock sample. ONE
+                # `datetime.now()` read for the whole admitted op, threaded
+                # to every correlation-id computation below (fence marker,
+                # cascade deferred-discovery cid, cascade marker). A per-op
+                # timestamp — NOT session-level (which would collapse every
+                # op in a session into one h_ bucket and structurally
+                # cross-pair Post events). Sampling once makes intra-op h_
+                # divergence impossible by construction.
+                op_ts = datetime.now(timezone.utc).isoformat()
                 try:
                     blueprint_name = _detect_scenario(
                         payload, surface_text=None, project_context={},
@@ -1550,24 +1559,27 @@ def main() -> int:
                                 _bash_command(payload)
                                 if tool_name == "Bash" else ""
                             )
-                            marker_ts = datetime.now(timezone.utc).isoformat()
                             # Event 50 · CP-FENCE-02 — write the marker
                             # under every candidate correlation id so
                             # PostToolUse pairs reliably even when
                             # PreToolUse and PostToolUse payloads
                             # disagree on which id is available
                             # (Claude Code's Pre payload typically
-                            # lacks tool_use_id).
+                            # lacks tool_use_id). §3.1: pass session_scope
+                            # so the marker carries the pair signature for
+                            # the tier-3 fallback.
+                            _fence_scope = str(payload.get("session_id") or "")
                             for correlation in _fence_synthesis.candidate_correlation_ids(
                                 payload,
                                 cmd_for_marker,
-                                marker_ts,
+                                op_ts,
                             ):
                                 _fence_synthesis.write_pending_marker(
                                     layer2_surface,
                                     correlation,
                                     cwd,
                                     cmd_for_marker,
+                                    session_scope=_fence_scope,
                                 )
                         except Exception:
                             # Synthesis bookkeeping failure must never
@@ -1615,8 +1627,7 @@ def main() -> int:
                                 if tool_name == "Bash" else ""
                             )
                             _cid = _correlation_id(
-                                payload, _cmd_for_cid,
-                                datetime.now(timezone.utc).isoformat(),
+                                payload, _cmd_for_cid, op_ts,
                             )
                             _write_cascade_deferred_discoveries(
                                 layer2_surface,
@@ -1639,11 +1650,11 @@ def main() -> int:
                                 _bash_command(payload)
                                 if tool_name == "Bash" else ""
                             )
-                            _marker_ts = datetime.now(
-                                timezone.utc
-                            ).isoformat()
+                            # §3.2: same per-op `op_ts` — NOT a second
+                            # `_marker_ts` sample (which straddled a second
+                            # boundary against the deferred-cid sample).
                             for _corr in _fence_synthesis.candidate_correlation_ids(
-                                payload, _cmd_for_marker, _marker_ts,
+                                payload, _cmd_for_marker, op_ts,
                             ):
                                 _cascade_synthesis.write_pending_marker(
                                     layer2_surface,

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -4527,12 +4527,15 @@ def _kernel_update() -> int:
     return 0
 
 
-def _kernel_compact_protocols(args) -> int:
-    """`episteme kernel compact-protocols` — one-time compaction of the
-    framework protocols ledger (collapse Event-143 cascade-synthesis
+def _run_protocols_compaction(args) -> int:
+    """Shared handler for BOTH protocols-compaction entry points (§5.2):
+    `episteme kernel compact-protocols` (operator-spec'd name) and
+    `episteme chain compact --stream protocols`. One-time compaction of
+    the framework protocols ledger (collapse Event-143 cascade-synthesis
     duplicates; keep-first, chain rebuilt, audit trail preserved).
 
-    Mirrors the `chain compact` gate: a non-dry-run in-place rewrite
+    Both entry points bind to this one handler → identical behavior,
+    drift impossible by construction. A non-dry-run in-place rewrite
     requires --confirm (operator action per the loss-averse posture).
     After the run it prints the protocols-chain verify verdict —
     `verify.intact=true` is the operator's visible success criterion.
@@ -4547,7 +4550,7 @@ def _kernel_compact_protocols(args) -> int:
         import _framework  # type: ignore  # pyright: ignore[reportMissingImports]
     except ImportError as exc:
         print(
-            f"[episteme kernel compact-protocols] error loading framework "
+            f"[episteme compact-protocols] error loading framework "
             f"module: {exc}",
             file=sys.stderr,
         )
@@ -4559,7 +4562,7 @@ def _kernel_compact_protocols(args) -> int:
     # Gate: refuse a non-dry-run rewrite without --confirm.
     if not dry_run and not getattr(args, "confirm", False):
         print(
-            "[episteme kernel compact-protocols] refusing to rewrite the "
+            "[episteme compact-protocols] refusing to rewrite the "
             "protocols ledger without --confirm (or pass --dry-run to preview)",
             file=sys.stderr,
         )
@@ -4568,7 +4571,7 @@ def _kernel_compact_protocols(args) -> int:
     try:
         result = _framework.compact_protocols(dry_run=dry_run)
     except _framework.ChainError as exc:
-        print(f"[episteme kernel compact-protocols] {exc}", file=sys.stderr)
+        print(f"[episteme compact-protocols] {exc}", file=sys.stderr)
         return 1
 
     # The operator's visible success criterion: the protocols chain
@@ -4595,7 +4598,7 @@ def _kernel_compact_protocols(args) -> int:
         )
         return 0
 
-    print(f"[episteme kernel compact-protocols] status={result.status}")
+    print(f"[episteme compact-protocols] status={result.status}")
     print(f"  total_before={result.total_before}")
     print(f"  total_after={result.total_after}")
     print(f"  removed={result.removed}")
@@ -4877,6 +4880,12 @@ def _chain_dispatch(args) -> int:
         return 0
 
     if action == "compact":
+        # §5.2 namespace symmetry — `--stream protocols` shares the one
+        # protocols-compaction handler with `episteme kernel
+        # compact-protocols` (drift impossible by construction; single
+        # handler binds both entry points).
+        if getattr(args, "stream", "deferred_discoveries") == "protocols":
+            return _run_protocols_compaction(args)
         # Event 136 CP-DEDUP-01 one-time compaction. Only deferred_discoveries
         # has the pre-Event-49 duplicate bloat. Non-dry-run rewrites the chain
         # in place (backup + atomic replace + post-verify), so gate it on
@@ -5661,7 +5670,7 @@ def build_parser() -> argparse.ArgumentParser:
     kernel_sub.add_parser("update", help="Regenerate kernel/MANIFEST.sha256 from current files")
     k_compact = kernel_sub.add_parser(
         "compact-protocols",
-        help="One-time compaction of the framework protocols ledger (collapse cascade-synthesis duplicates; keep-first, chain rebuilt, audit trail preserved)",
+        help="One-time compaction of the framework protocols ledger (collapse cascade-synthesis duplicates; keep-first, chain rebuilt, audit trail preserved). Alias of `episteme chain compact --stream protocols` (same handler)",
     )
     k_compact.add_argument(
         "--dry-run",
@@ -5760,18 +5769,23 @@ def build_parser() -> argparse.ArgumentParser:
     )
     c_compact = chain_sub.add_parser(
         "compact",
-        help="One-time CP-DEDUP-01 compaction of the deferred_discoveries chain (collapse pre-Event-49 open duplicates; first-wins, audit trail preserved)",
+        help="One-time compaction of a framework chain: `--stream deferred_discoveries` (CP-DEDUP-01 open duplicates) or `--stream protocols` (cascade-synthesis duplicates; shares the `kernel compact-protocols` handler)",
     )
     c_compact.add_argument(
         "--stream",
         default="deferred_discoveries",
-        choices=["deferred_discoveries"],
-        help="Stream to compact (only deferred_discoveries has CP-DEDUP-01 bloat)",
+        choices=["deferred_discoveries", "protocols"],
+        help="Stream to compact: deferred_discoveries (CP-DEDUP-01 bloat) or protocols (Event-143 cascade-synthesis duplicates; same handler as `episteme kernel compact-protocols`)",
     )
     c_compact.add_argument(
         "--dry-run",
         action="store_true",
         help="Report what would be removed without backing up or rewriting",
+    )
+    c_compact.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a single JSON object of the result fields (protocols stream; includes `intact`)",
     )
     c_compact.add_argument(
         "--confirm",
@@ -6710,7 +6724,7 @@ def main(argv: Iterable[str] | None = None) -> int:
         if args.kernel_action == "update":
             return _kernel_update()
         if args.kernel_action == "compact-protocols":
-            return _kernel_compact_protocols(args)
+            return _run_protocols_compaction(args)
         return 0
     if args.command == "check":
         return _check_dispatch(args)

--- a/tests/test_loop_hygiene.py
+++ b/tests/test_loop_hygiene.py
@@ -1,0 +1,662 @@
+"""Loop-hygiene — Event 145 §3/§4/§5 (FINAL_PRODUCTIZATION_BLUEPRINT).
+
+Lane B1 tests for the four loop-hygiene mechanisms:
+
+- §3.1 pair-signature fallback ladder: a >5s, no-tool_use_id op still
+  pairs Pre→Post via a timestamp-independent signature scan (tier 3),
+  oldest-first FIFO, TTL-filtered, delete-on-use; old v1 markers never
+  signature-match; ppid is a soft discriminator (probe: Pre/Post share
+  PPID) that never fails a legitimate pair closed.
+- §3.2 single per-op timestamp: the guard samples ONE wall-clock per
+  admitted op and threads it to every correlation-id write, so the
+  cascade marker carries the first sample's bucket (not a second
+  independent `_marker_ts`).
+- §4 concurrency: shared rewrite mutex + lock-order, inode re-verify in
+  `_locked` (orphaned-inode append race), retrofit whole-window lock
+  into `compact_deferred_discoveries`.
+- §5.1 read-side legacy healing: a legacy no-`cascade_hash` record
+  suppresses an identical modern emission via the shared
+  `_cascade_content_key`.
+- §5.2 namespace symmetry: `episteme chain compact --stream protocols`
+  and `episteme kernel compact-protocols` produce an identical result.
+"""
+from __future__ import annotations
+
+import fcntl
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from core.hooks import reasoning_surface_guard as guard
+from core.hooks import _scenario_detector as detector  # pyright: ignore[reportAttributeAccessIssue]
+from core.hooks import _fence_synthesis as fence_synth  # pyright: ignore[reportAttributeAccessIssue]
+from core.hooks import _cascade_synthesis as cascade_synth  # pyright: ignore[reportAttributeAccessIssue]
+from core.hooks import _chain  # pyright: ignore[reportAttributeAccessIssue]
+from core.hooks import _framework  # pyright: ignore[reportAttributeAccessIssue]
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# --------------------------------------------------------------------------
+# Shared fixtures (mirror the fence / cascade e2e harnesses)
+# --------------------------------------------------------------------------
+
+class _EphemeralEpistemeHome:
+    def __enter__(self):
+        self._home = tempfile.TemporaryDirectory()
+        self._prev = os.environ.get("EPISTEME_HOME")
+        os.environ["EPISTEME_HOME"] = self._home.name
+        detector._reset_trigger_cache_for_tests()
+        return Path(self._home.name)
+
+    def __exit__(self, *a):
+        if self._prev is None:
+            os.environ.pop("EPISTEME_HOME", None)
+        else:
+            os.environ["EPISTEME_HOME"] = self._prev
+        self._home.cleanup()
+        detector._reset_trigger_cache_for_tests()
+
+
+def _valid_fence_surface(constraint: str = "core/hooks/_grounding.py:32") -> dict:
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "core_question": "Is removing this constraint safe in this context?",
+        "knowns": ["CP3 landed 2026-04-21 with 340 tests green"],
+        "unknowns": ["if CI returns non-zero exit code, local parity was false"],
+        "assumptions": ["hook runner is Claude Code"],
+        "disconfirmation": "CI fails on main after push or tag verification rejects",
+        "constraint_identified": constraint,
+        "origin_evidence": "Commit e1f49c9 added this constraint to close CP3 gap #9.",
+        "removal_consequence_prediction": (
+            "if the deep-scan returns non-zero exit code after removal, "
+            "ungrounded entities slip past Layer 3"
+        ),
+        "reversibility_classification": "reversible",
+        "rollback_path": "git revert HEAD and rerun PYTHONPATH=. pytest -q tests/",
+    }
+
+
+def _valid_cascade_surface(**overrides) -> dict:
+    surface = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "core_question": "Does the cascade resolve coherently across its blast radius?",
+        "knowns": ["baseline suite green before the edit"],
+        "unknowns": ["if the cross-surface orphan-reference detector lands v1.0.1"],
+        "assumptions": ["hook runner is Claude Code"],
+        "disconfirmation": "CI fails or the test suite regresses below baseline",
+        "flaw_classification": "schema-implementation-drift",
+        "posture_selected": "refactor",
+        "patch_vs_refactor_evaluation": (
+            "Refactor required because the drift crosses hooks, schemas, "
+            "and the CLI; a patch would entangle module layers."
+        ),
+        "blast_radius_map": [
+            {"surface": "core/hooks/new_module.py", "status": "needs_update"},
+            {"surface": "tests/test_new.py", "status": "needs_update"},
+            {
+                "surface": "kernel/CONSTITUTION.md",
+                "status": "not-applicable",
+                "rationale": "philosophy unchanged",
+            },
+        ],
+        "sync_plan": [
+            {"surface": "core/hooks/new_module.py", "action": "Create module"},
+            {"surface": "tests/test_new.py", "action": "Add test suite"},
+        ],
+        "deferred_discoveries": [],
+    }
+    surface.update(overrides)
+    return surface
+
+
+def _run_guard(surface, cwd, command, tool_use_id="test-use-id"):
+    (cwd / ".episteme").mkdir(exist_ok=True)
+    (cwd / ".episteme" / "reasoning-surface.json").write_text(
+        json.dumps(surface), encoding="utf-8"
+    )
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": str(cwd),
+    }
+    if tool_use_id is not None:
+        payload["tool_use_id"] = tool_use_id
+    raw = json.dumps(payload)
+    with patch("sys.stdin", new=io.StringIO(raw)), \
+         patch("sys.stdout", new=io.StringIO()), \
+         patch("sys.stderr", new=io.StringIO()) as fake_err:
+        rc = guard.main()
+    return rc, "", fake_err.getvalue()
+
+
+_CASCADE_CMD = "python scripts/apply_cascade_edit.py"
+_FENCE_CMD = "rm .episteme/advisory-surface"
+
+
+def _make_fake_datetime(base: datetime):
+    """A stand-in for the guard module's `datetime` name whose `.now()`
+    returns a strictly increasing sequence (+2s per call) so successive
+    samples land in different second-buckets. Subclasses the real class
+    so inherited methods (fromisoformat, the constructor) still work; only
+    `now` is overridden. Only the guard module's reference is patched —
+    other modules keep the real class."""
+    counter = {"n": 0}
+
+    class _FakeDT(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            v = base + timedelta(seconds=2 * counter["n"])
+            counter["n"] += 1
+            return v
+
+    return _FakeDT
+
+
+# ==========================================================================
+# §3.1 — pair-signature fallback ladder
+# ==========================================================================
+
+class PairSignatureLadder(unittest.TestCase):
+    def test_normalize_collapses_ws_expands_tilde_and_caps(self):
+        self.assertEqual(fence_synth.normalize("  ls    -la   /x "), "ls -la /x")
+        home = os.environ.get("HOME") or str(Path.home())
+        self.assertEqual(fence_synth.normalize("cat ~/f"), f"cat {home}/f")
+        big = "x" * 9000
+        self.assertLessEqual(len(fence_synth.normalize(big).encode("utf-8")), 4096)
+
+    def test_pair_signature_is_timestamp_independent_and_deterministic(self):
+        a = fence_synth.pair_signature("sess", "/tmp/p", "ls   -la")
+        b = fence_synth.pair_signature("sess", "/tmp/p", "ls -la")
+        self.assertEqual(a, b)  # normalize collapses the whitespace diff
+        self.assertTrue(a.startswith("s_"))
+        self.assertNotEqual(
+            a, fence_synth.pair_signature("other", "/tmp/p", "ls -la")
+        )
+
+    def test_marker_carries_pair_signature_and_ppid(self):
+        with _EphemeralEpistemeHome() as home:
+            fence_synth.write_pending_marker(
+                _valid_fence_surface(), "h_x", Path("/tmp/p"), "ls -la",
+                session_scope="sess-1",
+            )
+            data = json.loads((home / "state" / "fence_pending" / "h_x.json").read_text())
+            self.assertEqual(
+                data["pair_signature"],
+                fence_synth.pair_signature("sess-1", "/tmp/p", "ls -la"),
+            )
+            self.assertIsInstance(data["ppid"], int)
+
+    def test_signature_scan_pairs_beyond_bucket_window(self):
+        """The headline >5s no-tool_use_id case: none of the Post candidate
+        ids reach the Pre marker's second-bucket, but the ts-independent
+        signature still pairs (tier 3)."""
+        with _EphemeralEpistemeHome() as home:
+            cwd = Path("/tmp/sig_scan_cwd")
+            cmd = _FENCE_CMD
+            scope = "sess-XYZ"
+            ts_pre = datetime(2026, 7, 6, 4, 30, 0, tzinfo=timezone.utc)
+            pre_cands = fence_synth.candidate_correlation_ids(
+                {"cwd": str(cwd)}, cmd, ts_pre.isoformat()
+            )
+            for c in pre_cands:
+                fence_synth.write_pending_marker(
+                    _valid_fence_surface(), c, cwd, cmd, session_scope=scope
+                )
+            ts_post = (ts_pre + timedelta(seconds=30)).isoformat()
+            post_payload = {"cwd": str(cwd), "tool_use_id": "toolu_LATE", "session_id": scope}
+            post_cands = fence_synth.candidate_correlation_ids(
+                post_payload, cmd, ts_post,
+                lookback_seconds=fence_synth.POST_LOOKBACK_SECONDS,
+                lookahead_seconds=fence_synth.POST_LOOKAHEAD_SECONDS,
+            )
+            self.assertFalse(set(post_cands) & set(pre_cands))  # tiers 1+2 miss
+            sig = fence_synth.pair_signature(scope, str(cwd), cmd)
+            env = fence_synth.finalize_on_success_with_fallback(
+                post_cands, 0, pair_sig=sig, post_ppid=os.getppid()
+            )
+            self.assertIsNotNone(env, "signature scan must pair across the >5s gap")
+            pending = home / "state" / "fence_pending"
+            remaining = list(pending.glob("*.json")) if pending.is_dir() else []
+            self.assertEqual(remaining, [], "used marker deleted on use")
+
+    def test_signature_scan_fifo_oldest_first(self):
+        with _EphemeralEpistemeHome() as home:
+            cwd = Path("/tmp/fifo_cwd")
+            cmd = _FENCE_CMD
+            scope = "s"
+            surface = {
+                "constraint_identified": "x", "origin_evidence": "e",
+                "removal_consequence_prediction": "c",
+                "reversibility_classification": "reversible", "rollback_path": "r",
+            }
+            now = datetime.now(timezone.utc)
+            older = {
+                "version": 1, "correlation_id": "h_old",
+                "written_at": (now - timedelta(seconds=120)).isoformat(),
+                "cwd": str(cwd), "command_redacted": cmd,
+                "pair_signature": fence_synth.pair_signature(scope, str(cwd), cmd),
+                "ppid": 111, "surface": surface,
+            }
+            newer = dict(older)
+            newer["correlation_id"] = "h_new"
+            newer["written_at"] = (now - timedelta(seconds=60)).isoformat()
+            pending = home / "state" / "fence_pending"
+            pending.mkdir(parents=True, exist_ok=True)
+            (pending / "h_old.json").write_text(json.dumps(older))
+            (pending / "h_new.json").write_text(json.dumps(newer))
+            sig = fence_synth.pair_signature(scope, str(cwd), cmd)
+            env = fence_synth.finalize_on_success_with_fallback(
+                [], 0, pair_sig=sig, post_ppid=111
+            )
+            self.assertIsNotNone(env)
+            # Oldest paired + deleted first; the newer marker survives.
+            remaining = sorted(p.stem for p in pending.glob("*.json"))
+            self.assertEqual(remaining, ["h_new"])
+
+    def test_signature_scan_ttl_expired_ignored(self):
+        with _EphemeralEpistemeHome() as home:
+            cwd = Path("/tmp/ttl_cwd")
+            cmd = _FENCE_CMD
+            scope = "s"
+            old_ts = (
+                datetime.now(timezone.utc)
+                - timedelta(seconds=fence_synth.MARKER_TTL_SECONDS + 60)
+            ).isoformat()
+            marker = {
+                "version": 1, "correlation_id": "h_stale", "written_at": old_ts,
+                "cwd": str(cwd), "command_redacted": cmd,
+                "pair_signature": fence_synth.pair_signature(scope, str(cwd), cmd),
+                "ppid": os.getppid(),
+                "surface": {
+                    "constraint_identified": "x", "origin_evidence": "e",
+                    "removal_consequence_prediction": "c",
+                    "reversibility_classification": "reversible", "rollback_path": "r",
+                },
+            }
+            pending = home / "state" / "fence_pending"
+            pending.mkdir(parents=True, exist_ok=True)
+            (pending / "h_stale.json").write_text(json.dumps(marker))
+            sig = fence_synth.pair_signature(scope, str(cwd), cmd)
+            env = fence_synth.finalize_on_success_with_fallback(
+                [], 0, pair_sig=sig, post_ppid=os.getppid()
+            )
+            self.assertIsNone(env, "TTL-expired marker must not pair")
+
+    def test_v1_marker_without_signature_never_matches(self):
+        with _EphemeralEpistemeHome() as home:
+            cwd = Path("/tmp/v1_cwd")
+            cmd = _FENCE_CMD
+            # A pre-schema-v2 marker (no pair_signature / ppid field).
+            marker = {
+                "version": 1, "correlation_id": "h_v1",
+                "written_at": datetime.now(timezone.utc).isoformat(),
+                "cwd": str(cwd), "command_redacted": cmd,
+                "surface": {
+                    "constraint_identified": "x", "origin_evidence": "e",
+                    "removal_consequence_prediction": "c",
+                    "reversibility_classification": "reversible", "rollback_path": "r",
+                },
+            }
+            pending = home / "state" / "fence_pending"
+            pending.mkdir(parents=True, exist_ok=True)
+            (pending / "h_v1.json").write_text(json.dumps(marker))
+            sig = fence_synth.pair_signature("s", str(cwd), cmd)
+            env = fence_synth.finalize_on_success_with_fallback(
+                [], 0, pair_sig=sig, post_ppid=os.getppid()
+            )
+            self.assertIsNone(env, "v1 markers must never signature-match")
+
+    def test_ppid_discriminator_prefers_match_but_soft_falls_back(self):
+        with _EphemeralEpistemeHome() as home:
+            cwd = Path("/tmp/ppid_cwd")
+            cmd = _FENCE_CMD
+            scope = "s"
+            sig = fence_synth.pair_signature(scope, str(cwd), cmd)
+            surface = {
+                "constraint_identified": "x", "origin_evidence": "e",
+                "removal_consequence_prediction": "c",
+                "reversibility_classification": "reversible", "rollback_path": "r",
+            }
+            base = datetime.now(timezone.utc)
+
+            def _write(stem, ppid, offset):
+                m = {
+                    "version": 1, "correlation_id": stem,
+                    "written_at": (base + timedelta(seconds=offset)).isoformat(),
+                    "cwd": str(cwd), "command_redacted": cmd,
+                    "pair_signature": sig, "ppid": ppid, "surface": surface,
+                }
+                pending = home / "state" / "fence_pending"
+                pending.mkdir(parents=True, exist_ok=True)
+                (pending / f"{stem}.json").write_text(json.dumps(m))
+
+            # mismatch is OLDER; match is NEWER. ppid preference beats FIFO.
+            _write("h_mismatch", 999, 0)
+            _write("h_match", 45319, 60)
+            env = fence_synth.finalize_on_success_with_fallback(
+                [], 0, pair_sig=sig, post_ppid=45319
+            )
+            self.assertIsNotNone(env)
+            pending = home / "state" / "fence_pending"
+            remaining = sorted(p.stem for p in pending.glob("*.json"))
+            self.assertEqual(remaining, ["h_mismatch"], "ppid-match preferred over FIFO")
+
+            # Soft fallback: only a mismatched-ppid marker → still pairs.
+            env2 = fence_synth.finalize_on_success_with_fallback(
+                [], 0, pair_sig=sig, post_ppid=7777
+            )
+            self.assertIsNotNone(env2, "no ppid match → soft-fall back to FIFO, still pairs")
+
+
+# ==========================================================================
+# §4 — concurrency & filesystem hygiene
+# ==========================================================================
+
+def _seed_deferred_dup(home_unused=None):
+    """Seed the deferred chain with 2 open duplicates (dedup bypassed) so a
+    compaction has something to remove and must take the rewrite path."""
+    for obs in ("first occurrence", "second — later duplicate"):
+        _framework.write_deferred_discovery(
+            {
+                "flaw_classification": "config-gap",
+                "description": "cascade fires on kernel state file edits",
+                "observable": obs,
+            },
+            dedup=False,
+        )
+
+
+class RewriteMutexAndInode(unittest.TestCase):
+    def test_verify_and_reacquire_lands_on_new_inode(self):
+        """§4.2 — after a concurrent os.replace orphans the locked fd, the
+        re-verify reopens onto the live inode."""
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "c.jsonl"
+            p.write_text("v1\n", encoding="utf-8")
+            fd = open(p, "a+", encoding="utf-8")
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+            orphan_ino = os.fstat(fd.fileno()).st_ino
+            swapped = {"done": False}
+
+            def swap():
+                if not swapped["done"]:
+                    _chain.atomic_replace_file(p, b"v2\n")  # new inode
+                    swapped["done"] = True
+
+            newfd = _chain._verify_and_reacquire(fd, p, _after_flock=swap)
+            try:
+                self.assertEqual(
+                    os.fstat(newfd.fileno()).st_ino, os.stat(p).st_ino
+                )
+                self.assertNotEqual(os.fstat(newfd.fileno()).st_ino, orphan_ino)
+            finally:
+                try:
+                    fcntl.flock(newfd.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
+                if not newfd.closed:
+                    newfd.close()
+
+    def test_verify_and_reacquire_gives_up_after_max_attempts(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "c.jsonl"
+            p.write_text("v1\n", encoding="utf-8")
+            fd = open(p, "a+", encoding="utf-8")
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+            n = {"i": 0}
+
+            def always_swap():
+                n["i"] += 1
+                _chain.atomic_replace_file(p, f"v{n['i']}\n".encode("utf-8"))
+
+            with self.assertRaises(_chain.ChainError):
+                _chain._verify_and_reacquire(
+                    fd, p, _after_flock=always_swap, max_attempts=3
+                )
+
+    def test_locked_reacquires_under_staged_swap(self):
+        """The `_locked` contextmanager threads the seam and completes; an
+        append inside the block lands in the live (swapped) file and the
+        chain stays intact."""
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "c.jsonl"
+            _chain.append(p, {"type": "protocol", "n": 0})
+            swapped = {"done": False}
+
+            def swap():
+                if not swapped["done"]:
+                    # Replace with a fresh single-record chain (new inode).
+                    tmp = Path(d) / "seed.jsonl"
+                    _chain.append(tmp, {"type": "protocol", "n": 99})
+                    _chain.atomic_replace_file(p, tmp.read_bytes())
+                    swapped["done"] = True
+
+            with _chain._locked(p, _after_first_flock=swap):
+                pass  # re-verify happens on flock acquisition
+            self.assertTrue(_chain.verify_chain(p).intact)
+
+    def test_rewrite_lock_is_exclusive(self):
+        with tempfile.TemporaryDirectory() as d:
+            lock_dir = Path(d)
+            with _chain.rewrite_lock(lock_dir):
+                probe = os.open(str(lock_dir / ".lock"), os.O_CREAT | os.O_RDWR)
+                try:
+                    with self.assertRaises(BlockingIOError):
+                        fcntl.flock(probe, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                finally:
+                    os.close(probe)
+            # After release the same lock acquires cleanly.
+            probe2 = os.open(str(lock_dir / ".lock"), os.O_CREAT | os.O_RDWR)
+            try:
+                fcntl.flock(probe2, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.flock(probe2, fcntl.LOCK_UN)
+            finally:
+                os.close(probe2)
+
+    def _lock_order_spy(self, compaction_call):
+        order: list[str] = []
+        real_rw = _chain.rewrite_lock
+        real_lk = _chain._locked
+
+        @contextmanager
+        def spy_rw(lock_dir):
+            order.append("rewrite")
+            with real_rw(lock_dir):
+                yield
+
+        @contextmanager
+        def spy_lk(path, **kw):
+            order.append("locked")
+            with real_lk(path, **kw):
+                yield
+
+        with patch.object(_framework, "_rewrite_lock", spy_rw), \
+             patch.object(_framework, "_chain_locked", spy_lk):
+            result = compaction_call()
+        return order, result
+
+    def test_compact_deferred_takes_rewrite_lock_then_file_lock(self):
+        with _EphemeralEpistemeHome():
+            _seed_deferred_dup()
+            order, result = self._lock_order_spy(
+                _framework.compact_deferred_discoveries
+            )
+            self.assertEqual(result.status, "compacted")
+            # Lock-order law: rewrite mutex acquired BEFORE the per-file lock.
+            self.assertEqual(order[:2], ["rewrite", "locked"])
+
+    def test_compact_protocols_takes_rewrite_lock_then_file_lock(self):
+        with _EphemeralEpistemeHome():
+            # Two identical legacy cascade records (no cascade_hash) collapse.
+            for _ in range(2):
+                _framework.write_protocol({
+                    "type": "protocol", "blueprint": "architectural_cascade",
+                    "source_fields": {
+                        "flaw_classification": "config-gap",
+                        "posture_selected": "patch",
+                        "blast_radius_surfaces": ["core/hooks/a.py"],
+                        "observable": "exit_code == 0 held",
+                    },
+                    "op_outcome": {"exit_code": 0, "cwd": "/tmp/proj", "command_redacted": "x"},
+                    "synthesized_protocol": "p",
+                })
+            order, result = self._lock_order_spy(_framework.compact_protocols)
+            self.assertEqual(result.status, "compacted")
+            self.assertEqual(order[:2], ["rewrite", "locked"])
+
+
+# ==========================================================================
+# §3.2 — single per-op timestamp
+# ==========================================================================
+
+class SinglePerOpTimestamp(unittest.TestCase):
+    def test_cascade_marker_uses_single_first_op_ts(self):
+        """The guard samples ONE wall-clock per admitted op and threads it
+        to every correlation-id write. With now() mocked to increment +2s
+        per call, the cascade pending marker must carry the FIRST sample's
+        second-bucket (op_ts). Pre-fix the marker used a second independent
+        `_marker_ts` (a later now() call) → a different bucket whenever the
+        two samples straddle a second boundary."""
+        base = datetime(2026, 7, 6, 4, 30, 0, tzinfo=timezone.utc)
+        surface = _valid_cascade_surface()
+        with _EphemeralEpistemeHome() as home, tempfile.TemporaryDirectory() as d:
+            cwd = Path(d)
+            cmd = _CASCADE_CMD
+            with patch.object(guard, "datetime", _make_fake_datetime(base)):
+                rc, _, err = _run_guard(surface, cwd, cmd, tool_use_id=None)
+            self.assertEqual(rc, 0, err)
+            markers = sorted(
+                p.stem for p in (home / "state" / "cascade_pending").glob("*.json")
+            )
+            self.assertEqual(len(markers), 1, markers)
+            expected = fence_synth._h_correlation_for_bucket(
+                base.isoformat().split(".")[0], str(cwd), cmd
+            )
+            self.assertEqual(
+                markers[0], expected,
+                "cascade marker must derive from the first (single) op_ts sample",
+            )
+
+
+# ==========================================================================
+# §5.1 — read-side legacy healing (no payload mutation)
+# ==========================================================================
+
+class ReadSideLegacyHealing(unittest.TestCase):
+    def test_legacy_no_field_record_suppresses_modern_emission(self):
+        """A legacy cascade record with NO stored `cascade_hash` must
+        suppress an identical modern emission — via the shared
+        `_cascade_content_key` (recompute-on-absence), with zero payload
+        mutation. Pre-fix the emit dedup keyed on the raw `cascade_hash`
+        field, so the legacy record (field absent) never matched and the
+        duplicate re-emitted."""
+        with _EphemeralEpistemeHome():
+            marker = {
+                "version": 1,
+                "correlation_id": "h_heal",
+                "written_at": datetime.now(timezone.utc).isoformat(),
+                "cwd": "/tmp/heal_proj",
+                "command_redacted": "make test",
+                "surface": {
+                    "flaw_classification": "config-gap",
+                    "posture_selected": "patch",
+                    "core_question": "does the flaw recur across surfaces?",
+                    "needs_update_surfaces": ["core/hooks/a.py", "core/hooks/b.py"],
+                    "observable": "exit_code == 0 held",
+                },
+            }
+            # The exact payload the emit path would write (carries cascade_hash).
+            modern = cascade_synth.build_protocol_for_tests(marker, 0)
+            self.assertIn("cascade_hash", modern)
+            # Seed a LEGACY twin: identical content, cascade_hash field absent.
+            legacy = {k: v for k, v in modern.items() if k != "cascade_hash"}
+            _framework.write_protocol(legacy)
+            self.assertEqual(len(_read_protocol_lines()), 1)
+
+            # Stage the pending marker + finalize on success.
+            pd = cascade_synth.pending_dir_for_tests()
+            pd.mkdir(parents=True, exist_ok=True)
+            (pd / "h_heal.json").write_text(json.dumps(marker), encoding="utf-8")
+            env = cascade_synth.finalize_on_success_with_fallback(["h_heal"], 0)
+
+            self.assertIsNone(
+                env, "identical modern emission must be suppressed by the legacy twin"
+            )
+            self.assertEqual(
+                len(_read_protocol_lines()), 1,
+                "no duplicate appended — read-side healing keyed on content",
+            )
+
+
+def _read_protocol_lines():
+    p = _framework._protocols_path()
+    if not p.is_file():
+        return []
+    return [ln for ln in p.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+# ==========================================================================
+# §5.2 — namespace symmetry (both compaction entry points)
+# ==========================================================================
+
+class NamespaceSymmetry(unittest.TestCase):
+    def _run_cli(self, home: Path, *args: str) -> subprocess.CompletedProcess:
+        env = {
+            **os.environ,
+            "EPISTEME_HOME": str(home),
+            "PYTHONPATH": str(_REPO_ROOT / "src"),
+        }
+        return subprocess.run(
+            [sys.executable, "-m", "episteme.cli", *args],
+            env=env, cwd=str(_REPO_ROOT), capture_output=True, text=True,
+        )
+
+    def _seed(self):
+        for i in range(4):
+            _framework.write_protocol({
+                "type": "protocol", "blueprint": "architectural_cascade",
+                "correlation_id": f"c-{i}",
+                "source_fields": {
+                    "flaw_classification": "config-gap",
+                    "posture_selected": "patch",
+                    "blast_radius_surfaces": ["core/hooks/a.py"],
+                    "observable": "one cli resolution",
+                },
+                "op_outcome": {"exit_code": 0, "cwd": "/tmp/proj", "command_redacted": "x"},
+                "synthesized_protocol": "p",
+            })
+
+    def test_both_entry_points_produce_identical_result(self):
+        with _EphemeralEpistemeHome() as home:
+            self._seed()
+            k = self._run_cli(home, "kernel", "compact-protocols", "--dry-run", "--json")
+            self.assertEqual(k.returncode, 0, k.stderr)
+            c = self._run_cli(home, "chain", "compact", "--stream", "protocols",
+                              "--dry-run", "--json")
+            self.assertEqual(c.returncode, 0, c.stderr)
+            kobj, cobj = json.loads(k.stdout), json.loads(c.stdout)
+            for field in ("status", "total_before", "total_after", "removed"):
+                self.assertEqual(kobj[field], cobj[field], field)
+            self.assertEqual(cobj["status"], "compacted")
+            self.assertEqual(cobj["removed"], 3)
+
+    def test_chain_compact_default_stream_unchanged(self):
+        """`chain compact` with no --stream still targets deferred_discoveries."""
+        with _EphemeralEpistemeHome() as home:
+            _seed_deferred_dup()
+            c = self._run_cli(home, "chain", "compact", "--dry-run")
+            self.assertEqual(c.returncode, 0, c.stderr)
+            self.assertIn("total_before=2", c.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Lane B1 — executes the FROZEN `FINAL_PRODUCTIZATION_BLUEPRINT.md` §3 (pair-signature fallback ladder + single per-op timestamp), §4 (shared rewrite mutex + inode re-verify), §5 (read-side legacy healing + namespace symmetry). TDD red-first per item. **Do not merge until integrator review.**

## §6.2 step-0 probe results (live Claude Code runtime, real op)

Captured via a diagnostic line in the PostToolUse hook + a temporary Pre-side line (removed), one real Bash op:

- **(a) session_id availability** — PRESENT on BOTH Pre (`reasoning_surface_guard`) and Post (`fence_synthesis`) payloads (value non-empty). Payload keys: `agent_id, agent_type, cwd, [duration_ms], effort, hook_event_name, permission_mode, prompt_id, session_id, tool_input, tool_name, [tool_response], tool_use_id, transcript_path`. `tool_use_id` is present on both sides too.
  → **Variant selected:** `session_scope` = payload `session_id` (non-degraded). The h_ fallback + signature scan remain defensive (tier-1 explicit id already pairs in this runtime).
- **(b) PPID stability** — Within one agent context, Pre and Post hook processes SHARE the same PPID (`45319 == 45319`), stable across multiple ops; a different agent context showed a different PPID (`6040`). Not per-spawn-random shells.
  → **Variant selected:** `ppid` qualifies as a tier-3 discriminator (design rule: "discriminator only if Pre/Post share it"). Implemented as a **soft** preference/tie-breaker (ppid-match preferred, else pure oldest-first FIFO) so a differing spawn model degrades gracefully rather than failing a legitimate pair closed.

The diagnostic line in `fence_synthesis.py` is kept as a shipped, bounded feature (keys + PID only, no values).

## Red → green proof (one line per item)

- §3.1 signature ladder — RED: `AttributeError: module '_fence_synthesis' has no attribute 'pair_signature'` → GREEN: 8/8 `PairSignatureLadder`.
- §3.2 single op_ts — RED: `AssertionError: 'h_147f60556385383a' != 'h_b797636cadf8bece'` (cascade marker used a later sample) → GREEN: `SinglePerOpTimestamp`.
- §4 mutex + inode — RED: `AttributeError: module '_chain' has no attribute '_verify_and_reacquire'` (6 failing) → GREEN: 6/6 `RewriteMutexAndInode`.
- §5.1 read-side healing — RED: legacy no-field record did NOT suppress the modern emission → GREEN: `ReadSideLegacyHealing`.
- §5.2 namespace symmetry — RED: `chain compact --stream protocols` rejected by argparse → GREEN: `NamespaceSymmetry` (identical CompactResult across both entry points).

## git diff --stat

```
 core/hooks/_cascade_synthesis.py      |  15 +-
 core/hooks/_chain.py                  | 143 ++++++--
 core/hooks/_fence_synthesis.py        | 146 +++++++-
 core/hooks/_framework.py              | 603 ++++++++++++++++---------------
 core/hooks/fence_synthesis.py         |  27 +-
 core/hooks/reasoning_surface_guard.py |  29 +-
 src/episteme/cli.py                   |  40 +-
 tests/test_loop_hygiene.py            | 662 ++++++++++++++++++++++++++++++++++
 8 files changed, 1312 insertions(+), 353 deletions(-)
```

(`_framework.py`'s large line count is the mechanical re-indent from wrapping `compact_deferred_discoveries` + `upgrade_cp5_prechain` under the whole-window lock; no logic change beyond the lock retrofit.)

## Green proof — full suite (baseline 1449 + 72 subtests; delta = +18 new tests only)

```
1467 passed, 72 subtests passed in 19.66s
```

Zero regressions. +18 = 8 (§3.1) + 1 (§3.2) + 6 (§4) + 1 (§5.1) + 2 (§5.2).

## Binding-correction compliance

- §3.2: one per-op `op_ts` sampled once in `guard.main()` (top of the admitted-op region), threaded to the fence marker, the cascade deferred-discovery id, and the cascade marker — NOT a session-level timestamp. Deleted the local `_marker_ts` sample.
- §4 lock-order law: `rewrite_lock` → `_locked(file)` (never reverse); appenders take only `_locked(file)`. `compact_deferred_discoveries` retrofitted with the whole-window per-file lock.
- §5.1: read-side healing only — no payload backfill, no `--heal` flag. `_cascade_content_key` is the single key function for emit-dedup and compaction.

## Deviations

1. **§3.2 op_ts also threaded to the cascade deferred-discovery id (line ~1617), not only the two marker writes named in the runbook.** Strong cause: the binding constraint is "single timestamp sampled once in guard.main()". Leaving that third correlation computation on its own `datetime.now()` would keep two samples in `main()`, contradicting "sampled once" and the stated invariant "intra-op divergence impossible by construction." Threading the single `op_ts` to all three correlation-id sites is the faithful superset.
2. **ppid tier-3 discriminator implemented as a soft preference (falls back to pure FIFO when no ppid matches), not a hard gate.** Strong cause: the discriminator decision is baked from this runtime's probe, but the fallback tier runs in potentially other runtimes; a hard ppid gate could silently zero out the signature scan under a different spawn model. Soft preference adds precision without introducing new false-negatives — consistent with the fail-open hook posture.

**Not merging** — integrator gates per runbook §6.
