### PR TITLE
chore: gitignore .claude/worktrees/ to stop chkpt gitlink pollution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,13 @@ dist/
 # Local iteration state for the ralph-loop plugin; never commit.
 .claude/ralph-loop.local.md
 
+# ─── Nested agent git-worktrees ───────────────────────────────────────────────
+# The orchestrator creates isolated worktrees at .claude/worktrees/agent-<id>.
+# Without this rule, checkpoint.py's `git add -A` sweeps them into master as
+# mode-160000 gitlinks (embedded-repo entries with no .gitmodules), polluting
+# the tree for every clone. Event 146.
+.claude/worktrees/
+
 # ─── Playwright MCP session artifacts (snapshots/screenshots) ─────────────────
 .playwright-mcp/
 


### PR DESCRIPTION
Nested agent worktrees at `.claude/worktrees/agent-<id>` were being swept into master by checkpoint.py's unscoped staging as mode-160000 gitlinks (local commits e354923, 23d3261 — both discarded after verification that the gitlink was their only content). Excluding the directory blocks the pollution class at its entry point.

Event 146 urgent action, operator-commissioned. Companion lanes (guard argv[0] classification, marker GC reaper, release versioning escape path) follow in separate PRs.