### PR TITLE
fix(hooks): TTL-reap orphaned pairing markers at SessionStart (Event 146)

### DIFF
--- a/core/hooks/_marker_reaper.py
+++ b/core/hooks/_marker_reaper.py
@@ -1,0 +1,223 @@
+"""Marker garbage-collection reaper — Event 146.
+
+TTL-based unlink of orphaned pairing markers in the two pending dirs
+(``state/cascade_pending`` + ``state/fence_pending``). Fixes the
+unbounded leak the audit named: ``MARKER_TTL_SECONDS`` (defined in
+``_fence_synthesis``) previously gated READS only —
+``read_pending_marker`` and ``_signature_scan`` skip a stale marker
+without unlinking it, so a Pre marker whose Post never pairs is orphaned
+forever, and ``_signature_scan`` globs + ``json.loads`` EVERY pending
+file on each admitted Post hook, so per-op latency grows with the leak.
+
+## Single-handler (Event 145 B1)
+
+This module is the ONE sweep implementation. Both the SessionStart hook
+(``session_context.py``) and the standalone tool
+(``tools/fence_marker_cleanup.py``) import ``reap_all`` from here — no
+duplicated loop, no duplicated TTL constant. The TTL is reused from
+``_fence_synthesis`` so there is a single source of truth for the age
+boundary; the two pending-dir paths are reused from the synthesis
+modules that own them (``_fence_synthesis._pending_dir`` /
+``_cascade_synthesis._pending_dir``).
+
+## Concurrency
+
+Marker files are per-correlation-id JSON written atomically via
+``tempfile`` + ``os.replace``; the fence/cascade synthesis docstrings
+state the marker dirs are OUTSIDE the rewrite-mutex scope (``fcntl.flock``
+is NOT required for them). A parallel session may unlink or pair a marker
+mid-sweep, so every ``glob -> stat -> read -> unlink`` step tolerates
+``FileNotFoundError`` (skip, never crash). The ledger rewrite mutex
+(``_chain.rewrite_lock``) is NOT taken: the lock-order law
+(``_chain.py`` § ``rewrite_lock`` docstring) governs chain-file rewrites
+under the framework dir, not these marker dirs. Per-file atomic unlink
+with exception tolerance is sufficient and cannot deadlock against
+appenders, which take only the per-file lock on the chain files.
+
+## Age semantics
+
+A well-formed marker's age is ``now - written_at`` (the payload field) —
+byte-identical to the existing TTL read-check (``read_pending_marker`` /
+``_signature_scan``), so a marker the reader already treats as
+stale/absent is exactly the marker the reaper unlinks. A malformed marker
+(unparseable JSON / read error) has no payload age, so the reaper falls
+back to file ``mtime``: it is reaped only when it has physically sat on
+disk longer than the TTL, which cannot catch a fresh in-flight marker.
+The same mtime fallback covers a valid-JSON marker missing or carrying an
+unparseable ``written_at`` (schema drift), for the same reason.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+_HOOKS_DIR = Path(__file__).resolve().parent
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+from _fence_synthesis import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    MARKER_TTL_SECONDS,
+    _pending_dir as _fence_pending_dir,
+)
+from _cascade_synthesis import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    _pending_dir as _cascade_pending_dir,
+)
+
+
+@dataclass
+class ReapResult:
+    """Per-directory sweep tally.
+
+    - ``reaped``       — markers unlinked because age > TTL.
+    - ``kept``         — markers left in place (fresh, or unassessable /
+                         unlink-failed and deliberately not force-removed).
+    - ``malformed_reaped`` — subset of ``reaped`` whose JSON did not parse
+                         (unparseable-JSON count, per requirement 4).
+    - ``vanished``     — markers that disappeared mid-sweep (a parallel
+                         session unlinked/paired them); skipped, not an error.
+    """
+
+    reaped: int = 0
+    kept: int = 0
+    malformed_reaped: int = 0
+    vanished: int = 0
+
+
+def _marker_age_seconds(path: Path, now: datetime) -> tuple[float | None, bool]:
+    """Return ``(age_seconds, malformed)`` for one marker, or
+    ``(None, _)`` when the file vanished (``FileNotFoundError`` at stat or
+    open) or cannot be assessed. ``malformed`` is True only when the JSON
+    itself was unparseable (or unreadable) — matching requirement 4's
+    "unparseable JSON" scope.
+
+    Age is ``now - written_at`` when the payload carries a parseable
+    ``written_at`` (matches the TTL read-check); otherwise it falls back
+    to file ``mtime`` (malformed JSON, non-dict payload, or missing /
+    unparseable ``written_at``). Never raises.
+    """
+    try:
+        mtime_ts = path.stat().st_mtime
+    except FileNotFoundError:
+        return None, False
+    except OSError:
+        # Unreadable stat (e.g. permissions) — cannot assess; leave it.
+        return None, False
+    mtime_age = (
+        now - datetime.fromtimestamp(mtime_ts, tz=timezone.utc)
+    ).total_seconds()
+
+    malformed = False
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return None, False
+    except (OSError, json.JSONDecodeError):
+        # Unparseable / unreadable content: age by mtime, flagged malformed.
+        return mtime_age, True
+
+    if isinstance(data, dict):
+        written = data.get("written_at")
+        if isinstance(written, str):
+            try:
+                wdt = datetime.fromisoformat(written.replace("Z", "+00:00"))
+                if wdt.tzinfo is None:
+                    wdt = wdt.replace(tzinfo=timezone.utc)
+                return (now - wdt).total_seconds(), False
+            except ValueError:
+                # Unparseable written_at — schema drift, not unparseable
+                # JSON. Age by mtime; do NOT flag as malformed.
+                return mtime_age, False
+    # Non-dict payload or missing written_at: age by mtime, not malformed.
+    return mtime_age, False
+
+
+def reap_dir(
+    pending_dir: Path,
+    now: datetime | None = None,
+    ttl_seconds: int = MARKER_TTL_SECONDS,
+) -> ReapResult:
+    """Sweep one pending-marker directory, unlinking every marker whose
+    age exceeds ``ttl_seconds``. Never raises past its boundary; tolerates
+    a missing directory (no-op) and any single file vanishing mid-sweep.
+    """
+    result = ReapResult()
+    if now is None:
+        now = datetime.now(timezone.utc)
+    if not pending_dir.is_dir():
+        return result
+    # Materialize the entry list up front so unlinking during iteration
+    # cannot perturb the scandir walk, and a directory that vanishes
+    # mid-scan degrades to an empty sweep rather than raising.
+    try:
+        entries = list(pending_dir.glob("*.json"))
+    except OSError:
+        return result
+    for path in entries:
+        age, malformed = _marker_age_seconds(path, now)
+        if age is None:
+            result.vanished += 1
+            continue
+        if age <= ttl_seconds:
+            result.kept += 1
+            continue
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            # Paired/reaped by a parallel session between read and unlink.
+            result.vanished += 1
+            continue
+        except OSError:
+            # Unlink failed for another reason — leave it, do not crash.
+            result.kept += 1
+            continue
+        result.reaped += 1
+        if malformed:
+            result.malformed_reaped += 1
+    return result
+
+
+def reap_all(
+    now: datetime | None = None,
+    ttl_seconds: int = MARKER_TTL_SECONDS,
+) -> dict[str, ReapResult]:
+    """Reap both marker directories. Returns ``{"cascade": ReapResult,
+    "fence": ReapResult}``. Never raises."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    return {
+        "cascade": reap_dir(_cascade_pending_dir(), now, ttl_seconds),
+        "fence": reap_dir(_fence_pending_dir(), now, ttl_seconds),
+    }
+
+
+def format_summary(results: dict[str, ReapResult]) -> str:
+    """One-line human summary shared by the hook banner and the CLI tool
+    so the "reaped N cascade + M fence" wording has a single source."""
+    cascade = results["cascade"]
+    fence = results["fence"]
+    malformed = cascade.malformed_reaped + fence.malformed_reaped
+    hours = MARKER_TTL_SECONDS // 3600
+    line = (
+        f"reaped {cascade.reaped} cascade + {fence.reaped} fence markers "
+        f"past {hours}h TTL"
+    )
+    if malformed:
+        line += f" ({malformed} malformed)"
+    return line
+
+
+# ---------------------------------------------------------------------------
+# Test helpers — expose the reused dir resolvers so tests do not have to
+# reach into two private modules.
+# ---------------------------------------------------------------------------
+
+def cascade_pending_dir_for_tests() -> Path:
+    return _cascade_pending_dir()
+
+
+def fence_pending_dir_for_tests() -> Path:
+    return _fence_pending_dir()

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -210,6 +210,40 @@ def _e1_line() -> str | None:
     )
 
 
+def _reaper_line() -> str | None:
+    """Event 146 · marker GC — TTL-reap orphaned pairing markers once per
+    session, off the per-op hot path.
+
+    The live failure this closes: pairing markers leaked unbounded
+    (``state/cascade_pending`` ~689 files, ``state/fence_pending`` 235,
+    oldest 75x past TTL) because ``MARKER_TTL_SECONDS`` gated marker READS
+    only — a Pre marker whose Post never pairs was orphaned forever, and
+    ``_signature_scan`` re-globbed + parsed every leaked file on each
+    admitted Post hook, so per-op latency grew with the leak. SessionStart
+    is the correct home: the sweep runs once per session, never on the hot
+    path.
+
+    Performs the sweep as a side effect (the load-bearing work) and
+    returns the one-line summary only when at least one marker was reaped,
+    so the banner stays silent on the common zero-reap session — matching
+    the silent-on-zero convention of the other producers here. Graceful
+    degrade to None on any import / IO failure: session open must not
+    break on GC bookkeeping.
+    """
+    _hooks_dir = Path(__file__).resolve().parent
+    if str(_hooks_dir) not in sys.path:
+        sys.path.insert(0, str(_hooks_dir))
+    try:
+        import _marker_reaper  # type: ignore  # pyright: ignore[reportMissingImports]
+        results = _marker_reaper.reap_all()
+    except Exception:
+        return None
+    total_reaped = results["cascade"].reaped + results["fence"].reaped
+    if total_reaped <= 0:
+        return None
+    return f"marker-gc: {_marker_reaper.format_summary(results)}"
+
+
 _NEXT_STEPS_MAX_CHARS = 8000
 
 
@@ -475,6 +509,13 @@ def main() -> int:
     e1_line = _e1_line()
     if e1_line:
         lines.append(e1_line)
+
+    # Event 146 · marker GC — TTL-reap orphaned pairing markers once per
+    # session, off the per-op hot path. Runs the sweep as a side effect;
+    # the line is silent unless at least one marker was reaped.
+    reaper_line = _reaper_line()
+    if reaper_line:
+        lines.append(reaper_line)
 
     # Phase A · v1.0.1 — noise-watch advisory derived from the operator
     # profile's cognitive.noise_signature axis. Silent when the knob is

--- a/tests/test_marker_reaper.py
+++ b/tests/test_marker_reaper.py
@@ -1,0 +1,327 @@
+"""Marker GC reaper — Event 146.
+
+Tests the TTL-based unlink of orphaned pairing markers in
+``state/cascade_pending`` + ``state/fence_pending``, and its SessionStart
+wiring. The live failure this guards against: pairing markers leaked
+unbounded (cascade_pending ~689 files, fence_pending 235, oldest 75x past
+TTL) because ``MARKER_TTL_SECONDS`` gated marker READS only — a Pre marker
+whose Post never pairs was orphaned forever, and ``_signature_scan``
+re-globbed + parsed every leaked file on each admitted Post hook.
+
+Single-handler (Event 145 B1): ``core/hooks/_marker_reaper.py`` is the one
+sweep implementation shared by the SessionStart hook
+(``session_context._reaper_line``) and the CLI tool
+(``tools/fence_marker_cleanup.py``). These tests exercise the shared
+implementation and the hook seam; the tool's entry-point wiring is
+covered by a subprocess smoke test.
+
+All state is written under a tmp ``EPISTEME_HOME`` — never ``~/.episteme``.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from core.hooks import _marker_reaper as reaper  # pyright: ignore[reportAttributeAccessIssue]
+from core.hooks import _fence_synthesis as fence_synth  # pyright: ignore[reportAttributeAccessIssue]
+from core.hooks import session_context as sc  # pyright: ignore[reportAttributeAccessIssue]
+
+_TTL = fence_synth.MARKER_TTL_SECONDS
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class _TmpHome:
+    """Point EPISTEME_HOME at a fresh tmp dir for the duration."""
+
+    def __enter__(self) -> Path:
+        self._td = tempfile.TemporaryDirectory()
+        self._prev = os.environ.get("EPISTEME_HOME")
+        os.environ["EPISTEME_HOME"] = self._td.name
+        return Path(self._td.name)
+
+    def __exit__(self, *a) -> None:
+        if self._prev is None:
+            os.environ.pop("EPISTEME_HOME", None)
+        else:
+            os.environ["EPISTEME_HOME"] = self._prev
+        self._td.cleanup()
+
+
+def _fence_dir() -> Path:
+    return reaper.fence_pending_dir_for_tests()
+
+
+def _cascade_dir() -> Path:
+    return reaper.cascade_pending_dir_for_tests()
+
+
+def _write_marker(d: Path, name: str, written_at: datetime) -> Path:
+    """Write a well-formed marker whose payload ``written_at`` sets its age."""
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{name}.json"
+    p.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "correlation_id": name,
+                "written_at": written_at.isoformat(),
+                "cwd": "/x",
+                "pair_signature": f"s_{name}",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return p
+
+
+def _write_malformed(d: Path, name: str, mtime_epoch: float) -> Path:
+    """Write an unparseable-JSON marker and stamp its mtime for age-by-mtime."""
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{name}.json"
+    p.write_text("{ this is not valid json", encoding="utf-8")
+    os.utime(p, (mtime_epoch, mtime_epoch))
+    return p
+
+
+# ---------------------------------------------------------------------------
+# TTL boundary (well-formed markers, age from written_at)
+# ---------------------------------------------------------------------------
+
+
+class TTLBoundary(unittest.TestCase):
+    def test_just_under_ttl_stays_just_over_reaped(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            d = _fence_dir()
+            under = _write_marker(d, "under", now - timedelta(seconds=_TTL - 1))
+            over = _write_marker(d, "over", now - timedelta(seconds=_TTL + 1))
+            res = reaper.reap_dir(d, now=now)
+            self.assertTrue(under.exists(), "marker just under TTL must survive")
+            self.assertFalse(over.exists(), "marker just over TTL must be unlinked")
+            self.assertEqual(res.reaped, 1)
+            self.assertEqual(res.kept, 1)
+            self.assertEqual(res.malformed_reaped, 0)
+
+
+# ---------------------------------------------------------------------------
+# Fresh + stale mix
+# ---------------------------------------------------------------------------
+
+
+class FreshStaleMix(unittest.TestCase):
+    def test_only_stale_reaped_fresh_untouched(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            d = _fence_dir()
+            fresh = _write_marker(d, "fresh", now - timedelta(minutes=5))
+            stale1 = _write_marker(d, "stale1", now - timedelta(days=3))
+            stale2 = _write_marker(d, "stale2", now - timedelta(days=75))
+            res = reaper.reap_dir(d, now=now)
+            self.assertTrue(fresh.exists(), "pairing-eligible fresh marker untouched")
+            self.assertFalse(stale1.exists())
+            self.assertFalse(stale2.exists())
+            self.assertEqual(res.reaped, 2)
+            self.assertEqual(res.kept, 1)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — vanishing file mid-sweep
+# ---------------------------------------------------------------------------
+
+
+class VanishingFile(unittest.TestCase):
+    def test_age_probe_on_missing_file_no_crash(self):
+        with _TmpHome():
+            d = _fence_dir()
+            d.mkdir(parents=True, exist_ok=True)
+            missing = d / "gone.json"
+            age, malformed = reaper._marker_age_seconds(
+                missing, datetime.now(timezone.utc)
+            )
+            self.assertIsNone(age)
+            self.assertFalse(malformed)
+
+    def test_delete_between_scan_and_unlink_no_exception(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            d = _fence_dir()
+            _write_marker(d, "racey", now - timedelta(days=2))
+
+            def _boom(self, *a, **k):  # a parallel session paired/removed it
+                raise FileNotFoundError(self)
+
+            with patch.object(Path, "unlink", _boom):
+                res = reaper.reap_dir(d, now=now)  # must not raise
+            self.assertEqual(res.reaped, 0)
+            self.assertGreaterEqual(res.vanished, 1)
+
+
+# ---------------------------------------------------------------------------
+# Malformed markers (unparseable JSON)
+# ---------------------------------------------------------------------------
+
+
+class MalformedMarkers(unittest.TestCase):
+    def test_malformed_old_by_mtime_reaped_and_counted(self):
+        with _TmpHome():
+            d = _fence_dir()
+            old_mtime = (
+                datetime.now(timezone.utc) - timedelta(seconds=_TTL + 3600)
+            ).timestamp()
+            p = _write_malformed(d, "bad", old_mtime)
+            res = reaper.reap_dir(d)
+            self.assertFalse(p.exists())
+            self.assertEqual(res.reaped, 1)
+            self.assertEqual(res.malformed_reaped, 1)
+
+    def test_malformed_fresh_by_mtime_kept(self):
+        # Refinement over the pre-Event-146 tool, which reaped malformed
+        # markers unconditionally: a malformed file younger than TTL by
+        # mtime is KEPT (loss-averse — do not unlink a recent artifact).
+        with _TmpHome():
+            d = _fence_dir()
+            fresh_mtime = (
+                datetime.now(timezone.utc) - timedelta(minutes=10)
+            ).timestamp()
+            p = _write_malformed(d, "bad_fresh", fresh_mtime)
+            res = reaper.reap_dir(d)
+            self.assertTrue(p.exists(), "fresh malformed marker must survive")
+            self.assertEqual(res.reaped, 0)
+            self.assertEqual(res.kept, 1)
+
+
+# ---------------------------------------------------------------------------
+# Empty / missing dirs
+# ---------------------------------------------------------------------------
+
+
+class EmptyAndMissing(unittest.TestCase):
+    def test_missing_dir_is_noop(self):
+        with _TmpHome():
+            d = _fence_dir()  # never created
+            self.assertFalse(d.exists())
+            res = reaper.reap_dir(d)
+            self.assertEqual((res.reaped, res.kept, res.vanished), (0, 0, 0))
+
+    def test_empty_dir_is_noop(self):
+        with _TmpHome():
+            d = _fence_dir()
+            d.mkdir(parents=True, exist_ok=True)
+            res = reaper.reap_dir(d)
+            self.assertEqual((res.reaped, res.kept, res.vanished), (0, 0, 0))
+
+
+# ---------------------------------------------------------------------------
+# reap_all — both dirs + single-source TTL
+# ---------------------------------------------------------------------------
+
+
+class ReapAll(unittest.TestCase):
+    def test_both_dirs_swept(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            stale = now - timedelta(days=2)
+            fresh = now - timedelta(minutes=1)
+            _write_marker(_cascade_dir(), "c_stale", stale)
+            _write_marker(_cascade_dir(), "c_fresh", fresh)
+            _write_marker(_fence_dir(), "f_stale", stale)
+            results = reaper.reap_all(now=now)
+            self.assertEqual(results["cascade"].reaped, 1)
+            self.assertEqual(results["cascade"].kept, 1)
+            self.assertEqual(results["fence"].reaped, 1)
+            self.assertFalse((_cascade_dir() / "c_stale.json").exists())
+            self.assertTrue((_cascade_dir() / "c_fresh.json").exists())
+            self.assertFalse((_fence_dir() / "f_stale.json").exists())
+
+    def test_ttl_is_single_source(self):
+        # The reaper reuses the constant from _fence_synthesis — one age
+        # boundary, no divergent copy.
+        self.assertEqual(reaper.MARKER_TTL_SECONDS, fence_synth.MARKER_TTL_SECONDS)
+
+    def test_format_summary_wording(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            stale = now - timedelta(days=2)
+            _write_marker(_cascade_dir(), "c1", stale)
+            _write_marker(_fence_dir(), "f1", stale)
+            results = reaper.reap_all(now=now)
+            summary = reaper.format_summary(results)
+            self.assertIn("1 cascade", summary)
+            self.assertIn("1 fence", summary)
+
+
+# ---------------------------------------------------------------------------
+# SessionStart invocation path
+# ---------------------------------------------------------------------------
+
+
+class SessionContextInvocation(unittest.TestCase):
+    def test_reaper_line_executes_sweep_and_reports(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            f_stale = _write_marker(_fence_dir(), "f_stale", now - timedelta(days=2))
+            c_stale = _write_marker(
+                _cascade_dir(), "c_stale", now - timedelta(days=2)
+            )
+            line = sc._reaper_line()
+            # The sweep is the load-bearing side effect: both stale markers
+            # are unlinked, not merely reported.
+            self.assertFalse(f_stale.exists())
+            self.assertFalse(c_stale.exists())
+            assert line is not None
+            self.assertIn("marker-gc", line)
+            self.assertIn("1 cascade", line)
+            self.assertIn("1 fence", line)
+
+    def test_reaper_line_silent_on_zero(self):
+        with _TmpHome():
+            # No markers → nothing reaped → banner silent (return None),
+            # matching the other producers' silent-on-zero convention.
+            self.assertIsNone(sc._reaper_line())
+
+    def test_reaper_line_silent_when_only_fresh(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            _write_marker(_fence_dir(), "fresh", now - timedelta(minutes=1))
+            self.assertIsNone(sc._reaper_line())
+
+
+# ---------------------------------------------------------------------------
+# CLI tool entry point (single-handler seam)
+# ---------------------------------------------------------------------------
+
+
+class CliTool(unittest.TestCase):
+    def test_tool_sweeps_via_shared_reaper(self):
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            now = datetime.now(timezone.utc)
+            stale = home / "state" / "fence_pending" / "old.json"
+            stale.parent.mkdir(parents=True, exist_ok=True)
+            stale.write_text(
+                json.dumps(
+                    {"written_at": (now - timedelta(days=2)).isoformat()}
+                ),
+                encoding="utf-8",
+            )
+            env = dict(os.environ, EPISTEME_HOME=str(home))
+            proc = subprocess.run(
+                [sys.executable, str(_REPO_ROOT / "tools" / "fence_marker_cleanup.py")],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertFalse(stale.exists(), "tool must reap the stale marker")
+            self.assertIn("marker_cleanup:", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/fence_marker_cleanup.py
+++ b/tools/fence_marker_cleanup.py
@@ -1,66 +1,43 @@
 #!/usr/bin/env python3
-"""CP-FENCE-01 Fix B — drop stale fence_pending markers past TTL.
+"""Manual marker GC — TTL-unlink orphaned pairing markers (Event 146).
 
-Walks ``~/.episteme/state/fence_pending/`` and removes markers whose
-``written_at`` timestamp is older than MARKER_TTL_SECONDS (24 hours,
-matching ``core/hooks/_fence_synthesis.py``). Corrupt markers with
-unparseable timestamps are also removed — a legitimate fence-synthesis
-PostToolUse would have deleted them by now.
+Sweeps BOTH pending-marker directories
+(``~/.episteme/state/cascade_pending/`` + ``~/.episteme/state/fence_pending/``)
+and removes markers whose age exceeds MARKER_TTL_SECONDS (24 hours). A
+well-formed marker ages by its ``written_at`` payload field (matching the
+TTL read-check in ``core/hooks/_fence_synthesis.py``); a malformed marker
+ages by file ``mtime`` and is removed only when it too is past TTL.
 
-Prints a one-line summary to stderr and exits 0 on success.
+Single-handler (Event 145 B1): this tool and the SessionStart hook
+(``core/hooks/session_context.py``) share ONE sweep implementation —
+``core/hooks/_marker_reaper.py``. This file is the standalone / cron entry
+point; it carries no cleanup logic and no duplicated TTL constant of its
+own. The reaper normally runs automatically at SessionStart; run this only
+to force a sweep out of band.
 
-Safe to run repeatedly; idempotent.
+Prints a one-line summary to stderr and exits 0. Safe to run repeatedly;
+idempotent.
 """
 from __future__ import annotations
 
-import json
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
+_HOOKS_DIR = Path(__file__).resolve().parents[1] / "core" / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
 
-MARKER_TTL_SECONDS = 24 * 60 * 60
-
-
-def cleanup(pending_dir: Path) -> dict:
-    removed = 0
-    kept = 0
-    parse_failures = 0
-    if not pending_dir.is_dir():
-        return {"removed": 0, "kept": 0, "parse_failures": 0,
-                "reason": "pending dir absent"}
-    now = datetime.now(timezone.utc)
-    for path in sorted(pending_dir.glob("*.json")):
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                data = json.load(f)
-        except (OSError, json.JSONDecodeError):
-            parse_failures += 1
-            path.unlink(missing_ok=True)
-            removed += 1
-            continue
-        written = data.get("written_at") if isinstance(data, dict) else None
-        age = float("inf")
-        if isinstance(written, str):
-            try:
-                dt = datetime.fromisoformat(written.replace("Z", "+00:00"))
-                age = (now - dt).total_seconds()
-            except ValueError:
-                pass
-        if age > MARKER_TTL_SECONDS:
-            path.unlink(missing_ok=True)
-            removed += 1
-        else:
-            kept += 1
-    return {"removed": removed, "kept": kept, "parse_failures": parse_failures}
+import _marker_reaper  # type: ignore  # noqa: E402  # pyright: ignore[reportMissingImports]
 
 
 def main() -> int:
-    pending = Path.home() / ".episteme" / "state" / "fence_pending"
-    result = cleanup(pending)
+    results = _marker_reaper.reap_all()
+    cascade = results["cascade"]
+    fence = results["fence"]
     print(
-        f"fence_marker_cleanup: removed={result['removed']} "
-        f"kept={result['kept']} parse_failures={result['parse_failures']}",
+        f"marker_cleanup: {_marker_reaper.format_summary(results)}; "
+        f"kept={cascade.kept + fence.kept} "
+        f"vanished={cascade.vanished + fence.vanished}",
         file=sys.stderr,
     )
     return 0


### PR DESCRIPTION
## What

Adds a TTL-based garbage-collection reaper that removes orphaned Pre/Post pairing markers from both `state/cascade_pending` and `state/fence_pending` once per session at SessionStart.

## Failure mode countered (anti-accretion gate)

**Unbounded marker leak → hot-path decay.** `MARKER_TTL_SECONDS` (24h, `core/hooks/_fence_synthesis.py`) gated marker READS only: `read_pending_marker` (docstring: "Does NOT delete") and `_signature_scan` skip a stale marker without removing it. The only deletion path was unlink-on-successful-pairing, so a Pre marker whose Post never pairs was orphaned forever (audit: cascade_pending ~689 files / 2.7 MB / ~350 per day; fence_pending 235, oldest 75x past TTL). Worse, `_signature_scan` re-globs + `json.loads` every pending file on each admitted Post hook, so per-op latency grew with the leak.

**What it replaces / bounds:** it does not change pairing semantics or add a new deletion trigger on the hot path — it bounds the pending sets to `< 24h` of markers by reclaiming what the read-side TTL already treats as expired. It also **replaces** the orphaned `tools/fence_marker_cleanup.py` (previously wired to nothing and carrying a duplicated TTL constant + fence-only loop) with a thin CLI entry point over one shared implementation.

## Design

- **Single source of truth for age.** The reaper reuses `MARKER_TTL_SECONDS` from `_fence_synthesis` and the two `_pending_dir` resolvers from the synthesis modules that own them — no copied constant, no copied path.
- **Age semantics (matches the read-check).** A well-formed marker ages by its `written_at` payload field, byte-identical to `read_pending_marker` / `_signature_scan`, so a marker the reader already treats as stale/absent is exactly what the reaper reclaims. A malformed (unparseable-JSON) or schema-drift (missing/unparseable `written_at`) marker has no payload age, so it falls back to file `mtime` and is reclaimed only when it too has sat on disk past TTL — this cannot catch a fresh in-flight marker (a refinement over the old tool, which reclaimed malformed markers unconditionally).
- **Single-handler (Event 145 B1).** `core/hooks/_marker_reaper.py` is the one sweep implementation. `session_context._reaper_line()` (SessionStart hook) and `tools/fence_marker_cleanup.py` (CLI) both import it — no duplicated logic.
- **Concurrency / lock-order.** Marker dirs are per-correlation-id JSON files written atomically via tempfile + `os.replace`, and the fence/cascade docstrings state they are OUTSIDE the rewrite-mutex scope. The `_chain.py` lock-order law (`rewrite_lock → _locked(file)`) governs chain-file rewrites under the framework dir, not these marker dirs, so the ledger rewrite mutex is **not** taken — per-file atomic removal with `FileNotFoundError` tolerance suffices and cannot deadlock against appenders. Every glob → stat → read → remove step tolerates `FileNotFoundError` so a parallel session pairing/removing the same marker mid-sweep is skipped, never a crash.
- **Existing scan paths verified.** `read_pending_marker` and `_signature_scan` (both fence and cascade) already wrap `open()` in `except (OSError, json.JSONDecodeError)`, and `FileNotFoundError` is a subclass of `OSError` — a file vanishing between glob and load is already tolerated, so no hardening was needed there.
- **Silent-on-zero banner.** `_reaper_line()` performs the sweep as a side effect and returns a one-line summary (`marker-gc: reaped N cascade + M fence markers past 24h TTL`) only when at least one marker was reclaimed, matching the other SessionStart producers.

## Tests

New `tests/test_marker_reaper.py` (15 tests, tmp `EPISTEME_HOME` only — never `~/.episteme`): TTL boundary (just-under stays / just-over removed), fresh+stale mix, vanishing file mid-sweep (missing-path probe + remove-between-scan-and-unlink), malformed JSON (reclaimed when old by mtime / kept when fresh), empty+missing dirs, `reap_all` over both dirs, single-source TTL, and the SessionStart invocation seam (`_reaper_line` executes the sweep, reports, and is silent on zero / fresh-only). A subprocess smoke test exercises the CLI tool's shared-reaper wiring.

Verified fail-before/pass-after: with `_marker_reaper.py` moved aside the file fails at collection (`ImportError`); restored, all 15 pass.

**Full suite: `1473 passed, 11 skipped, 72 subtests passed`** (baseline 1458 + 15 new), conda base runtime.

## Out of scope (deferred)

- Routing the cascade arm through the fence `pair_signature` ladder.
- Changing pairing semantics.
- `hooks.log` rotation.

## Handoff

Shipped: the reaper module, SessionStart wiring, the tool refactor, and tests. No residual risks — marker dirs are now bounded to `< 24h` of markers after one SessionStart, and `_signature_scan` cost is bounded accordingly. Next agent: nothing required; the three deferred items above remain open if the operator wants them.
