### PR TITLE
chore(release): pin prerelease versioning strategy + document GA graduation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,6 +292,52 @@ git push origin --delete event-NN-shortname
 
 ---
 
+## Release lifecycle (release-please)
+
+Releases are cut by `googleapis/release-please-action@v4` (`.github/workflows/release-please.yml`) driven by `release-please-config.json` + `.release-please-manifest.json`. The versioning contract lives here; the git-merge mechanics that feed it live in `## Git workflow protocol` above.
+
+### rc iteration math (`"versioning": "prerelease"`)
+
+The package config pins `"versioning": "prerelease"` alongside `"prerelease": true` + `"prerelease-type": "rc"`. Under the prerelease strategy (upstream `googleapis/release-please/src/versioning-strategies/prerelease.ts`, `bumpPrerelease()`):
+
+- Last release `1.9.0-rc1`; a releasable commit lands (`feat:` / `fix:` / `perf:` / `deps:` / `revert:` — the non-`hidden` `changelog-sections` types). The strategy sees a prerelease identifier with `patch === 0`, so it increments the trailing prerelease number (zero-padding preserved) and **holds the base**: `1.9.0-rc1` → `1.9.0-rc2` → `1.9.0-rc3`, one bump per release PR merged.
+- While an rc is open the commit **type no longer moves the base** — `feat:` vs `fix:` only selects the changelog section; both iterate the same rc counter. The base advances again only after graduation to a stable tag, at which point the next `feat:` on `1.9.0` opens a fresh cycle at `1.10.0-rc1`.
+- Non-releasable commits (`chore:`, `docs:`, `refactor:`, `test:`, `ci:`, `build:`, `style:`, `chore(chkpt):` — the `hidden` sections) do **not** open a release PR. The strategy change is therefore observable only on the next releasable commit after it merges.
+
+**`versioning` is load-bearing — do not remove it.** `tests/test_release_please_config.py` fails CI if the key is dropped or set to anything but `prerelease`. The JSON schema (upstream `googleapis/release-please/schemas/config.json`) types `versioning` as a bare string with no enum, so a typo would pass schema validation and silently restore the treadmill; the test is the real guard.
+
+### Graduation to a stable GA tag (e.g. `1.9.0`)
+
+Two routes convert the open `1.9.0-rcN` line into the stable `1.9.0` GA. Both are irreversible-once-tagged (a public tag + GitHub Release is a Tier-1 checkpoint per `docs/EVENTS.md` / risk posture) — verify BEFORE merging the release PR.
+
+**Route 1 — `Release-As:` footer (RECOMMENDED; one-shot, deterministic).** `Release-As: x.x.x` bypasses conventional-commit analysis and sets the version verbatim (upstream `googleapis/release-please/README.md`), so it forces exactly `1.9.0` regardless of what accumulated in the commit window — immune to a stray `feat!:` graduating to `2.0.0`. It leaves `prerelease: true` intact, so the next cycle resumes the rc cadence (`1.10.0-rc1`) with no further config change. master is branch-protected (Path A only), so the empty commit lands via a PR, not a direct push:
+
+```bash
+git fetch origin
+git checkout -b release/graduate-1.9.0 origin/master
+git commit --allow-empty -m "chore: release 1.9.0" -m "Release-As: 1.9.0"
+git push -u origin release/graduate-1.9.0
+gh pr create --title "chore: graduate to 1.9.0 GA" \
+  --body "Release-As: 1.9.0 — forces the next release-please proposal to the stable tag, base held."
+# Operator merges via GitHub UI or: gh pr merge --merge   (NOT --squash — the footer must survive)
+```
+
+The push from that merge triggers a release-please run that opens a release PR proposing `1.9.0`. **Before merging the release PR, verify the proposed version is exactly `1.9.0` with NO `-rc` suffix.** If it shows any `-rc`, the footer was not honored in this action version — STOP, do not merge, fall to Route 2.
+
+**Route 2 — flip `prerelease: false` (ALTERNATIVE; mode change, not one-shot).** Setting `"prerelease": false` in `release-please-config.json` engages the strategy's graduation branch (`if (!this.prerelease)` in `prerelease.ts`): on `1.9.0-rc1` with non-breaking commits it strips the identifier and holds the base → `1.9.0`. Caveats: (i) a pending breaking change (`feat!:` / `BREAKING CHANGE:`) in the window graduates to `2.0.0` instead — audit the window first; (ii) it needs its own config-change PR before the release PR (two PRs); (iii) it is a **mode flip** — after `1.9.0` ships, the next `feat:` produces a STABLE `1.10.0` (no rc). To resume the rc cadence you must flip `prerelease` back to `true`. Use Route 2 only when Route 1's pre-merge check showed an unexpected `-rc`.
+
+**Verify on the resulting GitHub Release (after merging the release PR):**
+
+- Tag name is `episteme-v1.9.0` (`include-v-in-tag: true` + component `episteme`).
+- The Release is **NOT** marked "Pre-release". Per upstream `googleapis/release-please/src/manifest.ts`, the prerelease flag on the GitHub Release is `config.prerelease && (version.preRelease || major === 0)`; for `1.9.0` the prerelease identifier is empty and major is `1`, so the box is unchecked even though `config.prerelease` may still be `true`. If the box IS checked, the tag carried a residual `-rc` — investigate before announcing.
+- `pyproject.toml`, `kernel/CHANGELOG.md`, and the three `extra-files` (`.claude-plugin/plugin.json` `$.version`, `.claude-plugin/marketplace.json` `$.plugins[0].version` and `$.metadata.version`) all read `1.9.0`.
+
+### Failure mode this closes
+
+Before this config, `prerelease: true` + `prerelease-type: rc` ran under the **default** versioning strategy (no `versioning` key ⇒ default), which strips `-rc`, bumps the BASE per conventional commits, and re-appends `-rc1` every time. Result: **0/11 pipeline releases ever reached a stable tag** — all eleven were `-rc1` (`1.1.0-rc1` .. `1.9.0-rc1`), a `feat:` advanced the minor (`1.9.0-rc1` → `1.10.0-rc1`) instead of the counter, and `-rc2` was structurally unreachable. Pinning `versioning: prerelease` bounds the base within an open rc line so the counter iterates, and makes GA an explicit operator action (Route 1/2) rather than an unreachable state.
+
+---
+
 ## Commit and handoff conventions
 
 - Commit messages: imperative mood, scoped (`kernel: …`, `docs: …`, `adapters: …`). Checkpoint commits use the Conventional-Commits-valid prefix `chore(chkpt):`.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,6 +27,7 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
+      "versioning": "prerelease",
       "prerelease": true,
       "prerelease-type": "rc",
       "changelog-sections": [

--- a/tests/test_release_please_config.py
+++ b/tests/test_release_please_config.py
@@ -1,0 +1,104 @@
+"""release-please-config.json must pin the prerelease versioning strategy.
+
+Failure mode this guards (Event 146, audit-confirmed): the config declared
+`prerelease: true` + `prerelease-type: rc` but NO `versioning` key. Release-
+please then falls back to the `default` versioning strategy, which strips the
+`-rc` suffix, bumps the BASE version per conventional commits, and re-appends
+`-rc1` every time. Result: 11/11 pipeline releases were `-rc1`
+(1.1.0-rc1 .. 1.9.0-rc1), rc2 was unreachable, and a `feat:` advanced the
+minor instead of iterating the rc counter.
+
+The fix is a single key: `"versioning": "prerelease"` at the package level.
+Under that strategy release-please increments the prerelease counter and holds
+the base (1.9.0-rc1 + new fix:/feat: -> 1.9.0-rc2). This test asserts the key
+is present and set to the strategy that produces that behaviour, so an
+accidental removal (which silently restores the rc-treadmill) fails CI instead
+of shipping.
+
+Doc-verified against googleapis/release-please (action pinned to @v4):
+- src/versioning-strategies/prerelease.ts (bumpPrerelease increment + the
+  `if (!this.prerelease)` graduation branch)
+- docs/customizing.md (the `versioning` key and its strategy values)
+- schemas/config.json (`versioning` is a valid per-package property)
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = REPO_ROOT / "release-please-config.json"
+
+# The strategy that makes the rc counter iterate instead of resetting.
+# `prerelease-type: rc` is only honoured as a counter-increment under this
+# strategy; under the `default` strategy it is re-appended fresh every bump.
+PRERELEASE_STRATEGY = "prerelease"
+
+# The full set of versioning strategies release-please accepts. Kept here so a
+# typo (e.g. "prerlease") is caught as an invalid-value failure, not silently
+# treated as an unknown-but-tolerated string by the loose JSON schema (the
+# schema types `versioning` as a bare string with no enum).
+VALID_STRATEGIES = frozenset(
+    {
+        "default",
+        "always-bump-patch",
+        "always-bump-minor",
+        "always-bump-major",
+        "service-pack",
+        "prerelease",
+    }
+)
+
+
+class ReleasePleaseConfig(unittest.TestCase):
+    """The versioning strategy is load-bearing config, not decoration."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        cls.pkg = cls.config["packages"]["."]
+
+    def test_versioning_key_present(self) -> None:
+        self.assertIn(
+            "versioning",
+            self.pkg,
+            "release-please-config.json packages['.'] must set a 'versioning' "
+            "strategy; absent means the default strategy re-appends -rc1 every "
+            "bump (Event 146 rc-treadmill).",
+        )
+
+    def test_versioning_is_prerelease_strategy(self) -> None:
+        self.assertEqual(
+            self.pkg.get("versioning"),
+            PRERELEASE_STRATEGY,
+            "versioning must be 'prerelease' so the rc counter iterates "
+            "(1.9.0-rc1 -> 1.9.0-rc2, base held) instead of resetting to -rc1.",
+        )
+
+    def test_versioning_value_is_a_valid_strategy(self) -> None:
+        self.assertIn(
+            self.pkg.get("versioning"),
+            VALID_STRATEGIES,
+            "versioning must be one of the release-please strategy names; the "
+            "JSON schema types it as a bare string and will not catch a typo.",
+        )
+
+    def test_prerelease_flags_consistent_with_strategy(self) -> None:
+        # The prerelease strategy only produces rc iteration when the prerelease
+        # flag/type are also set; guard the trio so a partial edit that breaks
+        # the contract (e.g. dropping prerelease-type) fails here.
+        self.assertTrue(
+            self.pkg.get("prerelease"),
+            "prerelease:true is required for the prerelease strategy to emit "
+            "an -rc suffix.",
+        )
+        self.assertEqual(
+            self.pkg.get("prerelease-type"),
+            "rc",
+            "prerelease-type:'rc' is the suffix the counter iterates.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Pin the release-please **prerelease versioning strategy** and document the release lifecycle so the pipeline can iterate rc candidates and graduate to a stable GA tag.

- `release-please-config.json`: add `"versioning": "prerelease"` at the package level (one-line diff).
- `AGENTS.md`: new `## Release lifecycle (release-please)` section — rc iteration math, the two graduation routes to `1.9.0` GA, post-tag verification, and the failure mode closed.
- `tests/test_release_please_config.py`: guard the key against accidental removal.

## Failure mode this closes (anti-accretion gate)

**Failure mode — the rc-treadmill.** `release-please-config.json` set `prerelease: true` + `prerelease-type: rc` with **no `versioning` key**, so release-please fell back to the `default` versioning strategy. The default strategy strips `-rc`, bumps the BASE per conventional commits, and re-appends `-rc1` every run. Observed consequence: **0/11 pipeline releases ever reached a stable tag** — all eleven were `-rc1` (`1.1.0-rc1` .. `1.9.0-rc1`); a `feat:` advanced the minor (`1.9.0-rc1` -> `1.10.0-rc1`) instead of the counter, so `-rc2` was structurally unreachable and no GA has ever been cut. The graduation mechanisms (`Release-As` footer / `prerelease:false`) were unused, untested, and undocumented.

**What the mechanism replaces / bounds.** `versioning: prerelease` swaps the default strategy for the prerelease strategy, which increments the trailing prerelease number and **holds the base** (`1.9.0-rc1` + releasable commit -> `1.9.0-rc2`). It bounds the base-version drift to an explicit operator graduation action (documented Route 1/2) rather than leaving GA as an unreachable state. The new test bounds the config against silent regression: the upstream JSON schema types `versioning` as a bare string with no enum, so a dropped key or a typo would pass schema validation and silently restore the treadmill — the test is the real guard, not the schema.

## Doc verification (action pinned `googleapis/release-please-action@v4`)

Verified against the pinned action's core, not from memory (context7 MCP over `/googleapis/release-please` + WebFetch of the upstream repo):

- **`docs/customizing.md`** — the config key is `versioning`; value `prerelease` is one of the strategies (`default`, `always-bump-patch`, `always-bump-minor`, `always-bump-major`, `service-pack`, `prerelease`).
- **`src/versioning-strategies/prerelease.ts`** — `bumpPrerelease()` extracts the trailing prerelease number and increments it (zero-padding preserved); the `PrereleaseMinorVersionUpdate.bump()` branch `if (version.preRelease) { if (version.patch === 0) { ... bumpPrerelease ... } }` confirms `1.9.0-rc1` + releasable commit -> `1.9.0-rc2` (base held). The graduation branch `if (!this.prerelease) { ... }` strips the identifier and holds the base for non-breaking commits (`1.9.0-rc1` -> `1.9.0`; a breaking change would go `2.0.0`).
- **`src/manifest.ts`** — a GitHub Release is flagged prerelease only when `config.prerelease && (version.preRelease || major === 0)`; a `1.9.0` tag (empty preRelease, major 1) is therefore NOT marked Pre-release even while `config.prerelease` stays `true`.
- **`README.md`** — `Release-As: x.x.x` on an empty commit forces the version verbatim, "bypassing conventional commit analysis" (case-insensitive).
- **`schemas/config.json`** — `versioning` is a valid per-package property (`ReleaserConfigOptions`, `additionalProperties: false`), so the one-key diff stays schema-valid.

## Pre-committed disconfirmation (caveat — this changes the NEXT release-please run)

This changes version math for the next run on `master`. **After this merges, the first release-please proposal triggered by the next releasable commit (`feat:`/`fix:`/`perf:`/`deps:`/`revert:`) must be `1.9.0-rc2` — NOT `1.10.0-rc1`.** (The window since `episteme-v1.9.0-rc1` currently holds only a hidden `chore:` + a merge commit, so nothing releases until the next non-hidden commit; the effect is observable only then.) **If the bot proposes `1.10.0-rc1`, the config verification above was wrong and this PR must be reverted.**

## Test verification

`tests/test_release_please_config.py` fails BEFORE the fix and passes AFTER (verified by temporarily removing the `versioning` key: 3 of 4 assertions fail — `key_present`, `is_prerelease_strategy`, `value_is_a_valid_strategy`; restore -> 4 pass).

Full suite green: `1462 passed, 11 skipped, 72 subtests passed` (`/Users/junlee/miniconda3/bin/python -m pytest tests/`).

## Do NOT merge

Opened for review per repo policy (master is branch-protected, Path A). Merge is the operator's call.
