### PR TITLE
fix: close two fail-open regressions in reasoning surface guard

### DIFF
--- a/core/hooks/reasoning_surface_guard.py
+++ b/core/hooks/reasoning_surface_guard.py
@@ -315,9 +315,13 @@ def _match_against_patterns(text: str) -> str | None:
 # logic beyond shlex + operator splitting + heredoc/substitution extraction.
 # ---------------------------------------------------------------------------
 
-# Heredoc intro: `<<WORD`, `<<-WORD`, `<<'WORD'`, `<<"WORD"`. The body that
-# follows is data (a file / stdin payload), never an executed command line.
-_HEREDOC_INTRO = re.compile(r"<<-?\s*([\"']?)([A-Za-z_][A-Za-z0-9_]*)\1")
+# Heredoc terminator word shape — used by `_heredoc_terminator` to validate
+# the token following a genuine `<<` / `<<-` operator. A regex over the raw
+# line is NOT used to DETECT the intro (FINDING 2): `<<`-lookalikes inside a
+# quoted string literal (`git commit -m "add a<<b shift"`) must not register
+# as a heredoc. Detection goes through shlex so a `<<` embedded in a quoted
+# token stays inside that token and is never mistaken for an operator.
+_HEREDOC_TERMINATOR_WORD = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 # Command-substitution spans — their contents ARE executed, so they are
 # extracted and scanned recursively rather than treated as data.
@@ -350,6 +354,38 @@ def _is_quoted(tok: str) -> bool:
     return len(tok) >= 2 and tok[0] in ("'", '"') and tok[-1] == tok[0]
 
 
+# FINDING 1 backstop — bare (unquoted) executor tokens that run a
+# command-STRING argument somewhere in the segment: `bash -c ...`,
+# `python -c ...`, `eval ...`, or a trailing-command builder (`xargs`).
+# The set of *prefix* wrappers that can precede one of these
+# (timeout / env / nohup / nice / stdbuf / command / ionice / xvfb-run / ...)
+# is OPEN-ENDED, so we do NOT enumerate prefixes. Instead we detect the
+# executor token wherever it lands and fall the whole segment back to the
+# pre-146 whole-text sensitivity (see `_scan_segment`). `python*` (python2 /
+# python3 / python3.11) is matched by prefix, not enumerated here.
+_EXECUTOR_BASES = frozenset({
+    "bash", "sh", "zsh", "ksh", "dash", "eval", "xargs",
+})
+
+
+def _is_executor_token(tok: str) -> bool:
+    """True when `tok` is a BARE (unquoted) command-string executor.
+
+    A quoted token is data, never an executor — `echo "bash -c git push"`
+    must stay inert. A path-qualified executor (`/usr/bin/bash`) matches on
+    its basename.
+    """
+    if _is_quoted(tok):
+        return False
+    base = tok.rsplit("/", 1)[-1]
+    if base in _EXECUTOR_BASES:
+        return True
+    if base.startswith("python"):
+        rest = base[len("python"):]
+        return rest == "" or rest.replace(".", "").isdigit()
+    return False
+
+
 def _neutralize_token(tok: str) -> str:
     """Command-position reconstruction rule for one non-posix shlex token.
 
@@ -369,11 +405,52 @@ def _neutralize_token(tok: str) -> str:
     return tok
 
 
+def _heredoc_terminator(line: str) -> str | None:
+    """Return the terminator WORD if `line` opens a GENUINE heredoc, else None.
+
+    FINDING 2b — detection goes through shlex, not a raw-line regex. A genuine
+    `<<` / `<<-` operator tokenizes as its own operator token under non-posix
+    shlex; a `<<` that lives inside a quoted string literal
+    (`git commit -m "add a<<b shift"`, `echo "compare x << y"`) stays embedded
+    in its quoted token and never surfaces as an operator — so it is not
+    mistaken for an intro. A here-string (`<<<`) tokenizes as a distinct `<<<`
+    token and is likewise ignored. Any tokenization failure (unbalanced quote)
+    returns None: the fail-closed direction here is NOT to strip.
+    """
+    if "<<" not in line:
+        return None
+    try:
+        tokens = _tokenize_nonposix(line)
+    except ValueError:
+        return None
+    for idx, tok in enumerate(tokens):
+        if tok in ("<<", "<<-"):
+            if idx + 1 >= len(tokens):
+                return None
+            word = tokens[idx + 1]
+            # `<<-EOF` tokenizes as `<<` + `-EOF`; drop the strip-tabs dash.
+            if word.startswith("-"):
+                word = word[1:]
+            word = _strip_quotes(word)
+            if _HEREDOC_TERMINATOR_WORD.fullmatch(word):
+                return word
+            return None
+    return None
+
+
 def _strip_heredoc_bodies(cmd: str) -> str:
     """Drop heredoc BODY lines (data), keeping the intro and terminator lines.
 
     Without this, the body's bare words tokenize as ordinary command-position
     tokens and a body line like `git push origin main` classifies as an op.
+
+    FINDING 2a — when the terminator line is never found, NOTHING is stripped:
+    an unterminated heredoc is either malformed input or a false intro match,
+    and dropping every remaining line hid trailing REAL commands
+    (`git commit -m "a<<b"` + newline + `git push origin main`). Not-stripping
+    is the fail-closed direction — the raw text then reaches the tokenizer,
+    whose quoted-token handling neutralizes data while keeping later commands
+    visible.
     """
     if "<<" not in cmd:
         return cmd
@@ -382,18 +459,23 @@ def _strip_heredoc_bodies(cmd: str) -> str:
     i = 0
     while i < len(lines):
         line = lines[i]
-        out.append(line)
-        m = _HEREDOC_INTRO.search(line)
-        if m:
-            terminator = m.group(2)
-            j = i + 1
-            while j < len(lines) and lines[j].strip() != terminator:
-                j += 1
-            if j < len(lines):
-                out.append(lines[j])  # retain the terminator line
-            i = j + 1
+        terminator = _heredoc_terminator(line)
+        if terminator is None:
+            out.append(line)
+            i += 1
             continue
-        i += 1
+        j = i + 1
+        while j < len(lines) and lines[j].strip() != terminator:
+            j += 1
+        if j < len(lines):
+            # Terminator found — strip the body [i+1, j); keep intro + term.
+            out.append(line)
+            out.append(lines[j])
+            i = j + 1
+        else:
+            # Terminator absent — keep ALL remaining lines untouched.
+            out.extend(lines[i:])
+            break
     return "\n".join(out)
 
 
@@ -501,6 +583,21 @@ def _scan_segment(tokens: list[str]) -> str | None:
         label = _match_against_patterns(_normalize_command(inner))
         if label:
             return label
+    # FINDING 1 backstop — an open-ended set of exec prefixes
+    # (timeout / env / nohup / nice / stdbuf / command / ionice / xvfb-run / ...)
+    # can carry a `bash -c "<op>"` deeper in the segment than the base-token
+    # wrapper fast path above ever inspects, and the neutralizing
+    # reconstruction below would erase the quoted payload as data. If ANY bare
+    # token is a command-string executor, scan the WHOLE segment (quoted
+    # contents included) with the pre-146 whole-text sensitivity so a real op
+    # cannot go invisible. A bare `bash` in data position
+    # (`echo bash -c "git push"`) over-classifies here — the accepted,
+    # fail-closed direction.
+    if any(_is_executor_token(t) for t in tokens):
+        seg_text = " ".join(_strip_quotes(t) for t in tokens)
+        label = _match_against_patterns(_normalize_command(seg_text))
+        if label:
+            return label
     reconstructed = " ".join(_neutralize_token(t) for t in tokens)
     return _match_against_patterns(reconstructed)
 
@@ -581,6 +678,17 @@ def _match_script_execution(cwd: Path, cmd: str) -> str | None:
     return None
 
 
+def _episteme_home() -> Path:
+    """Resolve the episteme state root, honoring ``EPISTEME_HOME``.
+
+    FINDING 4 — mirrors the resolver the fence / cascade / pending-contract
+    modules use for their pending dirs so a relocated ``EPISTEME_HOME`` keeps
+    ALL guard state under one root. Falls back to ``~/.episteme`` when unset —
+    which is why tests that patch ``Path.home`` still isolate state.
+    """
+    return Path(os.environ.get("EPISTEME_HOME") or (Path.home() / ".episteme"))
+
+
 def _state_store_path() -> Path:
     return Path.home() / ".episteme" / "state" / "session_context.json"
 
@@ -600,7 +708,7 @@ def _advisory_shown_marker(session_id: str) -> Path:
     fence / cascade pending markers; isolated in tests via `Path.home`.
     """
     return (
-        Path.home() / ".episteme" / "state" / "advisory_shown"
+        _episteme_home() / "state" / "advisory_shown"
         / f"{_safe_session_id(session_id)}.marker"
     )
 

--- a/tests/test_reasoning_surface_guard.py
+++ b/tests/test_reasoning_surface_guard.py
@@ -1,5 +1,6 @@
 import io
 import json
+import os
 import tempfile
 import time
 import unittest
@@ -584,6 +585,89 @@ class Event146ClassificationTests(unittest.TestCase):
         self.assertIn("git reset --hard", err)
 
 
+class Event146FailClosedRegressionTests(unittest.TestCase):
+    """Post-merge review falsified Event 146's fail-closed claim for two
+    realistic shapes: a real executed high-impact op became INVISIBLE to the
+    gate (rc 0, no output).
+
+    FINDING 1 — wrapper-prefix under-classification: a `-c` executor behind an
+    open-ended prefix (`timeout`, `env`, `nohup`, `nice`, `stdbuf`, `command`,
+    `ionice`, `xvfb-run`, ...) left `_wrapper_command_string` returning None
+    and the quoted payload erased as data.
+
+    FINDING 2 — heredoc stripping dropped trailing executed commands: a `<<`
+    inside a quoted string (`git commit -m "add a<<b shift"`) matched the intro
+    regex, and with no terminator line the loop discarded every remaining
+    line — swallowing a real `git push` on the next line.
+
+    Every case runs end-to-end through `main()` with a cwd carrying no
+    surface / advisory artifact — the exact state in which a fail-open lets the
+    op through silently.
+    """
+
+    def _run(self, cmd: str, cwd: Path) -> tuple[int, str, str]:
+        payload = {"tool_name": "Bash", "tool_input": {"command": cmd},
+                   "cwd": str(cwd)}
+        with patch("sys.stdin", new=io.StringIO(json.dumps(payload))), \
+             patch("sys.stdout", new=io.StringIO()) as out, \
+             patch("sys.stderr", new=io.StringIO()) as err:
+            rc = guard.main()
+        return rc, out.getvalue(), err.getvalue()
+
+    def _assert_classifies(self, cmd: str, label: str) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            rc, _out, err = self._run(cmd, Path(td))
+        self.assertEqual(rc, 2, f"expected block for {cmd!r}, got rc={rc}")
+        self.assertIn(label, err)
+
+    def _assert_inert(self, cmd: str) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            rc, out, err = self._run(cmd, Path(td))
+        self.assertEqual(rc, 0, f"expected inert for {cmd!r}, got rc={rc} err={err!r}")
+        self.assertEqual(out, "")
+        self.assertEqual(err, "")
+
+    # ----- FINDING 1 — wrapper-prefix under-classification MUST CLASSIFY -----
+
+    def test_timeout_bash_c_push_classifies(self):
+        self._assert_classifies(
+            'timeout 30 bash -c "' + _GP + ' origin main"', "git push")
+
+    def test_env_prefix_bash_c_push_classifies(self):
+        self._assert_classifies(
+            'env A=B bash -c "' + _GP + ' origin main"', "git push")
+
+    def test_nohup_bash_c_publish_classifies(self):
+        self._assert_classifies('nohup bash -c "npm publish"', "npm publish")
+
+    # ----- FINDING 2 — quoted-`<<` no longer eats trailing commands -----
+
+    def test_quoted_lshift_commit_then_push_classifies(self):
+        self._assert_classifies(
+            'git commit -m "add a<<b shift"\n' + _GP + ' origin main',
+            "git push")
+
+    def test_quoted_lshift_echo_then_reset_hard_classifies(self):
+        self._assert_classifies(
+            'echo "compare x << y"\n' + _GRH + ' HEAD~1', "git reset --hard")
+
+    def test_genuine_heredoc_then_push_after_terminator_classifies(self):
+        cmd = "cat <<EOF\n" + _GP + " in body\nEOF\n" + _GP + " origin main"
+        self._assert_classifies(cmd, "git push")
+
+    # ----- MUST STAY INERT -----
+
+    def test_genuine_heredoc_body_push_stays_inert(self):
+        cmd = "cat <<'EOF'\nremember to " + _GP + " origin main after merge\nEOF"
+        self._assert_inert(cmd)
+
+    def test_quoted_string_literal_push_stays_inert(self):
+        self._assert_inert('echo "' + _GP + ' origin master is the command"')
+
+    def test_quoted_lshift_line_then_benign_stays_inert(self):
+        self._assert_inert('echo "compare x << y"\nls -la')
+
+
 class Event146DedupTests(unittest.TestCase):
     """Event 146 — the full ~2.3 KB remediation schema is emitted once per
     session; repeat firings collapse to a compact pointer keyed on
@@ -665,6 +749,28 @@ class Event146DedupTests(unittest.TestCase):
         self.assertIn(self._POINTER_MARKER, ctx2)
         self.assertNotIn(self._SCHEMA_MARKER, ctx2)
         self.assertLess(len(ctx2.encode()), 200)
+
+    def test_advisory_marker_honors_episteme_home(self):
+        # FINDING 4 — the advisory-shown marker resolves through the same
+        # EPISTEME_HOME-aware resolver as the fence / cascade pending dirs, so
+        # a relocated root keeps all guard state under one tree instead of
+        # splitting the dedup marker off under a hardcoded ~/.episteme.
+        cmd = _GP + " origin master"
+        with tempfile.TemporaryDirectory() as td:
+            cwd, home = Path(td) / "proj", Path(td) / "home"
+            root = Path(td) / "relocated"
+            cwd.mkdir(); home.mkdir()
+            with patch.dict(os.environ, {"EPISTEME_HOME": str(root)}):
+                rc, _, _ = self._run(cmd, cwd, home, session_id="sess-relo")
+            self.assertEqual(rc, 2)
+            # Marker lands under the relocated root ...
+            self.assertTrue(
+                (root / "state" / "advisory_shown" / "sess-relo.marker").exists()
+            )
+            # ... and NOT under the Path.home fallback tree.
+            self.assertFalse(
+                (home / ".episteme" / "state" / "advisory_shown").exists()
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Failure mode

An independent post-merge review **falsified the Event 146 change's fail-closed claim**. For two realistic command shapes, a real executed high-impact op became **invisible to the surface gate** — `rc 0`, no output, verified end-to-end through `main()`. This is fail-open under-classification: the op runs without ever demanding a Reasoning Surface.

Two shapes were affected:

- **Wrapper-prefix under-classification** — `timeout 30 bash -c "<op>"`, `env A=B bash -c "<op>"`, and `nohup` / `nice` / `stdbuf -oL` / `command` / `ionice` / `xvfb-run` equivalents.
- **Quoted-`<<` heredoc mis-detection** — a commit message (or any quoted argument) containing `<<` followed on the next line by a real op.

## Mechanism

**FINDING 1 (`_scan_segment` / `_wrapper_command_string` / `_neutralize_token`).** The base token (`timeout`, `env`, ...) is not a recognized wrapper, so `_wrapper_command_string` returns `None`, control falls to the neutralizing reconstruction, and the quoted multi-word payload (`"git push origin main"`) is erased as data — the segment matches nothing. The prefix class is **open-ended**, so the fix does not enumerate prefixes. `_scan_segment` now falls the WHOLE segment back to the pre-146 whole-text sensitivity (`_match_against_patterns(_normalize_command(...))` over the segment including quoted-token contents) whenever ANY **bare** token is a `-c` executor (`bash`/`sh`/`zsh`/`ksh`/`dash`/`python*`) or `eval`/`xargs`. A bare executor token in data position (`echo bash -c "git push"`) now over-classifies — the accepted, fail-closed direction. The base-token wrapper fast path is retained; the executor-token-anywhere rule is the backstop.

**FINDING 2 (`_strip_heredoc_bodies` / heredoc intro detection).** The intro regex matched `<<`-lookalikes inside quoted strings, and when no standalone terminator line followed, the loop discarded EVERY remaining line — dropping the trailing real op. Detection now goes through `shlex` (`_heredoc_terminator`): a genuine `<<` / `<<-` operator tokenizes as its own operator token, while a `<<` embedded in a quoted string literal stays inside that token and is never read as an intro (no hand-rolled character-level quoting engine — shlex does the quote accounting, and any tokenization ambiguity falls toward not-a-heredoc). When a terminator line is never found, **nothing is stripped**, so trailing commands stay visible to the tokenizer. Genuine heredocs (terminator present) keep their current behavior: body inert, commands after the terminator still classified.

**FINDING 4 (`_advisory_shown_marker`).** Switched from a hardcoded `Path.home()/".episteme"` to an `EPISTEME_HOME`-aware `_episteme_home()` resolver (mirroring the fence/cascade pending dirs), so a relocated `EPISTEME_HOME` keeps all guard state under one root. Falls back to `~/.episteme` when unset, so the existing `Path.home`-patching test isolation still holds.

## Tests

New end-to-end regression matrix in `tests/test_reasoning_surface_guard.py`, all through `main()` against a cwd with no surface/advisory artifact. Red-green confirmed: the must-classify cases return `None` (fail-open) on the pre-fix code and classify after the fix.

- MUST CLASSIFY: `timeout 30 bash -c "git push ..."`, `env A=B bash -c "git push ..."`, `nohup bash -c "npm publish"`, `git commit -m "add a<<b shift"` + newline + `git push origin main`, `echo "compare x << y"` + newline + `git reset --hard HEAD~1`, genuine heredoc followed by `git push` after the terminator.
- MUST STAY INERT: genuine heredoc whose body contains `git push`, `echo "git push origin master is the command"`, and a quoted-`<<` line followed by only benign commands.
- FINDING 4: a relocated `EPISTEME_HOME` places the dedup marker under the new root, not the `Path.home` fallback tree.

Full suite: `1507 passed, 11 skipped, 76 subtests passed`.

## Reviewer disconfirmation probe

```
printf 'timeout 30 bash -c "git push origin main"' | python3 -c "import json,sys,subprocess; payload=json.dumps({'tool_name':'Bash','tool_input':{'command':sys.stdin.read()},'cwd':'/tmp','session_id':'probe-ff1'}); r=subprocess.run(['python3','core/hooks/reasoning_surface_guard.py'],input=payload,capture_output=True,text=True); print('rc',r.returncode)"
```

Pre-fix: `rc 0` (op invisible). Post-fix: `rc 2` (blocked, surface demanded).
