### PR TITLE
feat: doc/artifact lifecycle engine — markers, cascade gate, report sink, staleness banner (Event 147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This is the difference between a prompt reminder and a compiler: one asks nicely
 
 `episteme` is **not just a blocker**. The framework's real job is to turn every conflict it resolves into durable know-how that the agent re-applies automatically at the next matching decision.
 
-Here is the loop (v1.0.0 GA shipped · CP1–CP10 green; **v1.4.0-rc1 cut 2026-05-23** · 1170 tests + 54 subtests green — see [`docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md)):
+Here is the loop (v1.0.0 GA shipped · CP1–CP10 green; **<!-- episteme-fact:version -->1.9.0-rc1<!-- /episteme-fact:version -->** — see [`docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md)):
 
 1. **Detect conflict.** The agent encounters two valid-looking but incompatible approaches for a context it hasn't fully resolved before.
 2. **Decompose, don't average.** The Thinking Framework refuses the "average" answer. It forces the agent to extract *why* the sources conflict and which feature of the context tips the decision.
@@ -373,7 +373,7 @@ The Korean word **결** (*gyeol*) names the grain of wood or stone: the latent p
       ▼        ▼        ▼            ▼        ▼        ▼
     FRAME → DECOMPOSE → EXECUTE → VERIFY → HANDOFF → (next session)
       │                                        │
-      │ Reasoning Surface                      │ docs/PROGRESS.md
+      │ Reasoning Surface                      │ docs/EVENTS.md
       │ (Knowns / Unknowns /                   │ docs/NEXT_STEPS.md
       │  Assumptions / Disconfirmation)        │ decision artifact
       │                                        │
@@ -460,7 +460,7 @@ The four blueprints (above) and three pillars — Cognitive Blueprints · Append
 - **Arm B · Causal Synthesis** — zero-LLM entity extraction over the deferred-discovery stream produces cluster proposals the framework can act on. Verification window: 60 days.
 - **Arm C · Self-Consistency Convergence** — protocols promote to models that derive disconfirmations structurally. Verification window: 90 days.
 
-The distinction is load-bearing — pillars are settled vocabulary; arms are how the system audits and refines its own outputs across time. Status: **v1.4.0-rc1 cut 2026-05-23**, 1170 tests + 54 subtests green. Arm A substrate shipped (supersede-with-history infrastructure + auto-instrumentation hooks that record operator profile + policy edits to chain streams); Arm A residue resumes opportunistically. **Arm B substrate-facing form formally SUNSET at Event 129** — its premise (a stable model-capability gap) was falsified by the Event 119–120 saturation finding; its operator-facing residue (`core/ptsp/` typed Fact/Inference promotion gate) is retained-and-reachable via `episteme practice trace`. Arm C scoped for a future cycle pending evidence the substrate-gap claim survives.
+The distinction is load-bearing — pillars are settled vocabulary; arms are how the system audits and refines its own outputs across time. Status: **<!-- episteme-fact:version -->1.9.0-rc1<!-- /episteme-fact:version -->**. Arm A substrate shipped (supersede-with-history infrastructure + auto-instrumentation hooks that record operator profile + policy edits to chain streams); Arm A residue resumes opportunistically. **Arm B substrate-facing form formally SUNSET at Event 129** — its premise (a stable model-capability gap) was falsified by the Event 119–120 saturation finding; its operator-facing residue (`core/ptsp/` typed Fact/Inference promotion gate) is retained-and-reachable via `episteme practice trace`. Arm C scoped for a future cycle pending evidence the substrate-gap claim survives.
 
 ---
 

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -244,6 +244,110 @@ def _reaper_line() -> str | None:
     return f"marker-gc: {_marker_reaper.format_summary(results)}"
 
 
+_DOC_STALENESS_EVENT_LAG = 15
+_DOC_STALENESS_DATE_DAYS = 45
+
+
+def _doc_staleness_line() -> str | None:
+    """Event 147 · doc-lifecycle staleness banner.
+
+    Counts tracked ``status=living`` docs whose ``reviewed_as_of`` lags the
+    corpus: by more than ``_DOC_STALENESS_EVENT_LAG`` events when the latest
+    ``E<n>`` tag is resolvable from ``docs/EVENTS.md``, or (fallback) by more
+    than ``_DOC_STALENESS_DATE_DAYS`` days when the marker carries an ISO date
+    instead of an event tag. Emits ONE advisory line only when the count is
+    positive, so the banner stays silent on the common fresh-corpus session —
+    matching the silent-on-zero convention of ``_reaper_line`` and the other
+    producers here.
+
+    Read-only and self-contained: globs ``docs/*.md`` and reads line 1 for the
+    lifecycle marker rather than importing ``src/episteme`` (the hook runs as a
+    standalone script with no guaranteed package path) and never shells out, so
+    it adds well under 50ms to SessionStart. Graceful-degrades to None on any
+    IO / parse failure — session open must not break on an advisory count. The
+    drain is opportunistic: whoever next edits a stale doc bumps its
+    ``reviewed_as_of`` (``episteme docs lint`` reminds; it is not a CI failure).
+    """
+    import re
+
+    try:
+        docs_dir = Path("docs")
+        if not docs_dir.is_dir():
+            return None
+
+        marker_re = re.compile(r"episteme-lifecycle:")
+        status_re = re.compile(r"status=([^;\s]+)")
+        review_re = re.compile(r"reviewed_as_of=([^;\s]+)")
+        event_re = re.compile(r"^E(\d+)$")
+        date_re = re.compile(r"^(\d{4})-(\d{2})-(\d{2})")
+
+        # Latest event tag from the EVENTS index, if resolvable. A private
+        # symlink whose target is present resolves via is_file(); a broken
+        # symlink or absent file leaves latest_event None and the fallback
+        # date rule governs.
+        latest_event: int | None = None
+        events_path = docs_dir / "EVENTS.md"
+        try:
+            if events_path.is_file():
+                text = events_path.read_text(encoding="utf-8", errors="replace")
+                nums = [int(m) for m in re.findall(r"\bE(\d+)\b", text)]
+                if nums:
+                    latest_event = max(nums)
+        except OSError:
+            latest_event = None
+
+        today = datetime.now(timezone.utc).date()
+        stale = 0
+        for path in docs_dir.glob("*.md"):
+            # Skip symlinks (private planning docs are symlinked, lifecycle-exempt).
+            if path.is_symlink():
+                continue
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                    first_line = fh.readline()
+            except OSError:
+                continue
+            if not marker_re.search(first_line):
+                continue
+            sm = status_re.search(first_line)
+            if sm is None or sm.group(1) != "living":
+                continue
+            rm = review_re.search(first_line)
+            if rm is None:
+                continue
+            reviewed = rm.group(1)
+
+            ev = event_re.match(reviewed)
+            if ev is not None:
+                if latest_event is None:
+                    continue  # event-tagged but no corpus latest to compare
+                if latest_event - int(ev.group(1)) > _DOC_STALENESS_EVENT_LAG:
+                    stale += 1
+                continue
+
+            dm = date_re.match(reviewed)
+            if dm is not None:
+                try:
+                    reviewed_date = datetime(
+                        int(dm.group(1)), int(dm.group(2)), int(dm.group(3))
+                    ).date()
+                except ValueError:
+                    continue
+                if (today - reviewed_date).days > _DOC_STALENESS_DATE_DAYS:
+                    stale += 1
+                continue
+            # Unparseable reviewed_as_of: leave for `episteme docs lint`.
+
+        if stale <= 0:
+            return None
+        return (
+            f"doc-staleness: {stale} living docs unreviewed "
+            f">15 events — episteme docs lint"
+        )
+    except Exception:
+        return None
+
+
 _NEXT_STEPS_MAX_CHARS = 8000
 
 
@@ -516,6 +620,13 @@ def main() -> int:
     reaper_line = _reaper_line()
     if reaper_line:
         lines.append(reaper_line)
+
+    # Event 147 · doc-lifecycle staleness — count living docs whose
+    # reviewed_as_of lags the corpus by >15 events (or >45 days when dated).
+    # Silent on zero; read-only advisory, drain is opportunistic on next edit.
+    doc_staleness_line = _doc_staleness_line()
+    if doc_staleness_line:
+        lines.append(doc_staleness_line)
 
     # Phase A · v1.0.1 — noise-watch advisory derived from the operator
     # profile's cognitive.noise_signature axis. Silent when the knob is

--- a/docs/ADAPTER_PORTABILITY.md
+++ b/docs/ADAPTER_PORTABILITY.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=report; reviewed_as_of=E147 -->
 # Adapter Portability Audit
 
 **Status**: `audit (Event 96, 2026-04-30)` — read-only inventory + migration design. No runtime changes proposed in this document.

--- a/docs/ANTHROPIC_MANAGED_AGENTS_BRIDGE.md
+++ b/docs/ANTHROPIC_MANAGED_AGENTS_BRIDGE.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Anthropic Managed Agents Bridge
 
 Purpose: import Managed Agents runtime event logs into `episteme` Memory Contract v1 envelopes as `episodic` records.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Architecture — The Sovereign Kernel (v1.3.0-rc1 shipped · 1066 tests + 54 subtests green)
 
 > Mermaid flowchart. Renders natively on GitHub, Obsidian, and any CommonMark viewer with Mermaid support. **Five** subgraphs trace the full lifecycle from agent intention through the three-pillar kernel — Cognitive Blueprints, Append-Only Hash Chain, Framework Synthesis & Active Guidance — into praxis, the learning loop, and the post-v1.0-RC behavior-conformance extensions (Event 130 — Contract Gate; Event 131 — FAILURE_MODES mode 12 + CALIBRATION_TELEMETRY).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 <!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
-# Architecture — The Sovereign Kernel (v1.3.0-rc1 shipped · 1066 tests + 54 subtests green)
+# Architecture — The Sovereign Kernel (<!-- episteme-fact:version -->1.9.0-rc1<!-- /episteme-fact:version -->)
 
 > Mermaid flowchart. Renders natively on GitHub, Obsidian, and any CommonMark viewer with Mermaid support. **Five** subgraphs trace the full lifecycle from agent intention through the three-pillar kernel — Cognitive Blueprints, Append-Only Hash Chain, Framework Synthesis & Active Guidance — into praxis, the learning loop, and the post-v1.0-RC behavior-conformance extensions (Event 130 — Contract Gate; Event 131 — FAILURE_MODES mode 12 + CALIBRATION_TELEMETRY).
 >
-> **State.** This diagram depicts the **v1.0 RC shipped state** (spec: [`./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md), status *approved (reframed, third pass)* 2026-04-21) plus the v1.2-RC behavior-conformance extensions in Subgraph ⑤. All ten RC checkpoints shipped with paused-review-before-commit discipline. Current head: v1.3.0-rc1 (cut 2026-05-23 via release-please PR #80); 1066 tests + 54 subtests green. v1.3.0-rc2 stages from this Event's `feat:` commits; release-please regenerates the staging PR automatically — no manual version edit.
+> **State.** This diagram depicts the **v1.0 RC shipped state** (spec: [`./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md), status *approved (reframed, third pass)* 2026-04-21) plus the v1.2-RC behavior-conformance extensions in Subgraph ⑤. All ten RC checkpoints shipped with paused-review-before-commit discipline. Current head: <!-- episteme-fact:version -->1.9.0-rc1<!-- /episteme-fact:version --> (via release-please; test counts are owned by CI, not this prose). v1.3.0-rc2 stages from this Event's `feat:` commits; release-please regenerates the staging PR automatically — no manual version edit.
 
 ---
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -28,7 +28,7 @@ Scope key:
 |---|---|---|
 | `episteme init` | global | One-shot: seed kernel global memory from `core/memory/global/examples/*.example.md`. Only meaningful on a fresh kernel clone. |
 | `episteme setup` | global | Interactive wizard that runs profile + cognition surveys end-to-end. |
-| `episteme profile {survey,infer,hybrid,gap,show,audit}` | global | Manage operator-profile axes (planning strictness, risk tolerance, testing rigor, etc.). |
+| `episteme profile {survey,infer,hybrid,gap,show,override,audit}` | global | Manage operator-profile axes (planning strictness, risk tolerance, testing rigor, etc.); `override` sets a per-project axis override (Event 85) and `audit ack <audit-id>` acknowledges a drift verdict (Event 78). |
 | `episteme cognition {survey,infer,hybrid,show}` | global | Manage cognitive-style axes (dominant lens, noise signature, abstraction entry, etc.). |
 | `episteme update` | global | Pull the latest episteme from git. |
 | `episteme list` | global | Show installed agents, skills, plugins, and active hooks. |
@@ -53,7 +53,6 @@ Scope key:
 | `episteme guide [--deferred]` | framework | List synthesized framework protocols and (with `--deferred`) open deferred discoveries. |
 | `episteme history {axis,policy,protocol}` | framework | Walk Cognitive Arm A supersede-with-history streams: profile axis trajectories (Event 82), policy section changes (Event 83), synthesized-protocol supersede chains (Event 84). |
 | `episteme cognitive-budget {--summary,--check,--record,--list,--tail}` | framework | Inspect operator approval-time observations + D11 fatigue signal (Event 88, Cognitive Arm A). |
-| `episteme profile {show,audit,override,survey,infer,hybrid,gap}` | framework | Profile inspection + Phase 12 audit + per-project override (Event 85, CP-CONTEXT-AWARE-PROFILE-OVERRIDE-01). `audit ack <audit-id>` acknowledges a drift verdict (Event 78). |
 | `episteme inject` | framework | Deploy cognitive enforcement to any directory in one command. |
 | `episteme log` | framework | Show audit log of reasoning-surface checks (passed / advisory / blocked). |
 | `episteme review` | framework | Review sampled Layer 8 spot-check entries (operator verdicts). |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # episteme — command reference
 
 A one-page map of every `episteme` subcommand, grouped by lifecycle phase.

--- a/docs/COMPLIANCE_CROSSWALK.md
+++ b/docs/COMPLIANCE_CROSSWALK.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Compliance Crosswalk — `signed-surface@1.0` → Regulatory Clauses
 
 **What this document is.** A **downstream structural mapping**. Not the primary identity of episteme. Not the primary positioning. Not a sales artifact.

--- a/docs/CONTRACT_GATE.md
+++ b/docs/CONTRACT_GATE.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Contract Gate — deterministic contract-test complement to the Reasoning Surface
 
 **Operational summary:**

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Contributing to episteme
 
 Short version:

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Customization
 
 Three places you can shape episteme to your own working life: personal memory, skills, and hooks.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -14,7 +14,7 @@ Recommended additions:
 
 To keep your system explainable in your own head (and to teammates), add:
 - **Global:** `core/memory/global/build_story.md` — your stable builder narrative.
-- **Project:** `docs/DECISION_STORY.md` — what/why/how trace for major decisions in a specific repository.
+- **Project:** `docs/EVENTS.md` — what/why/how trace for major decisions in a specific repository.
 
 ```bash
 cp core/memory/global/examples/build_story.example.md core/memory/global/build_story.md
@@ -63,7 +63,7 @@ docs/
   PROGRESS.md        completed work and decisions
   NEXT_STEPS.md      next-session handoff
   RUN_CONTEXT.md     runtime assumptions, APIs, execution profiles
-  DECISION_STORY.md  narratable what/why/how for major decisions
+  EVENTS.md          narratable what/why/how for major decisions
 .claude/
   settings.json          permission rules
   settings.local.json    machine-local overrides (gitignored)

--- a/docs/DEMOS.md
+++ b/docs/DEMOS.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Demos
 
 Five demos. Each one targets a different class of LLM failure mode. The

--- a/docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md
+++ b/docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md
@@ -1,4 +1,7 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147; superseded_by=docs/DESIGN_V2_0_EPISTEMIC_ENGINE.md; scope=enforcement-geometry-framing -->
 # Design — Causal-Consequence Scaffolding & Protocol Synthesis — v1.0 RC
+
+> Scope note: the enforcement-geometry product framing was superseded by [DESIGN_V2_0](./DESIGN_V2_0_EPISTEMIC_ENGINE.md) (Event 138); substrate layers documented here remain authoritative.
 
 Status: **approved (reframed, third pass)** · Drafted 2026-04-21 · Approved 2026-04-21 · Reframed 2026-04-21 · Second-pass reframe 2026-04-21 · Third-pass reframe 2026-04-21 · Scope: v1.0 RC upgrade of the Reasoning Surface from syntactic enforcement to causal-consequence scaffolding, protocol synthesis, active guidance, **and continuous architectural self-maintenance** — grafting four things onto an auto-regressive engine that cannot perform any of them natively: a causal world-model interface, a context-indexed thinking framework that synthesizes context-dependent protocols from conflicting sources, an active-guidance loop that uses those protocols to proactively steer the operator, and a cascade-escalation loop that keeps the system's own understanding of itself coherent as the codebase evolves under its own edits.
 

--- a/docs/DESIGN_V2_0_EPISTEMIC_ENGINE.md
+++ b/docs/DESIGN_V2_0_EPISTEMIC_ENGINE.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # DESIGN v2.0 — The Epistemic Engine
 
 Status: **ACTIVE — Event 138 (2026-06-10).** Supersedes the enforcement-geometry framing of

--- a/docs/EVALUATION_METHOD.md
+++ b/docs/EVALUATION_METHOD.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=report; reviewed_as_of=E147 -->
 # Evaluation Method — Does episteme actually make a difference?
 
 > Status: **landed Event 135 (2026-05-23). Calibration data accumulates

--- a/docs/EVOLUTION_CONTRACT.md
+++ b/docs/EVOLUTION_CONTRACT.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Evolution Contract v1
 
 Purpose: define a safe, auditable self-evolution loop for the episteme cognitive+execution harness.

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Harness System
 
 A **harness** defines the operating environment for a specific project type — execution profile, workflow constraints, safety notes, recommended agents. A generic scaffold gives every project the same shape; a harness gives it the right shape.

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Deterministic Safety Hooks
 
 Hooks run deterministically — the model cannot override them. Each hook is a named counter to a specific class of unsafe or inconsistent action; together they form the execution-time enforcement layer for kernel invariants.

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -15,19 +15,44 @@ Packs are applied via `episteme sync` or `episteme setup --sync`.
 
 ## Hook reference
 
-| Hook                    | Event                                                    | What it does                                                                                    |
-|-------------------------|----------------------------------------------------------|-------------------------------------------------------------------------------------------------|
-| `session_context.py`    | `SessionStart`                                           | Prints branch, git status, and `NEXT_STEPS.md` at session open (if present in your project)     |
-| `block_dangerous.py`    | `PreToolUse Bash`                                        | Blocks `rm -rf`, `git reset --hard`, `git push --force`, `sudo`, `pkill`, and more              |
-| `workflow_guard.py`     | `PreToolUse Write\|Edit\|MultiEdit`                      | Advisory nudge to keep authoritative docs (`PLAN.md` / `PROGRESS.md` / `NEXT_STEPS.md`) aligned with edits, when present |
-| `prompt_guard.py`       | `PreToolUse Write\|Edit\|MultiEdit`                      | Advisory detection of prompt-injection patterns when writing durable context                    |
-| `format.py`             | `PostToolUse Write\|Edit`                                | Auto-runs `ruff` (Python) or `prettier` (JS/TS) after every file write                          |
-| `test_runner.py`        | `PostToolUse Write\|Edit`                                | Runs pytest / jest on the file if it is a test file                                             |
-| `context_guard.py`      | `PostToolUse Bash\|Edit\|Write\|MultiEdit\|Agent\|Task`  | Advisory warning when session context approaches compaction thresholds                          |
-| `quality_gate.py`       | `Stop`                                                   | Blocks completion if tests fail (opt-in via `.quality-gate` in project root)                    |
-| `contract_gate.py`      | `Stop`                                                   | Runs declared contract tests (`contracts/*`) at turn-end. Opt-in via settings.json + `contracts/` directory presence. Currently a no-op stub; verifier chain ships in a follow-up Event. See [`CONTRACT_GATE.md`](./CONTRACT_GATE.md) |
-| `checkpoint.py`         | `Stop`                                                   | Auto-commits uncommitted changes as `chore(chkpt):` after every turn                            |
-| `precompact_backup.py`  | `PreCompact`                                             | Backs up session transcripts before context compaction                                          |
+The default `episteme sync` registers **19 hook scripts** (balanced governance mode)
+across the Claude Code event surface. Regenerate this table from the source of
+truth — `build_settings()` in `src/episteme/adapters/claude.py` — after any hook
+change; it is the actual registry, not this prose.
+
+| Hook | Event · matcher | What it does |
+|------|-----------------|--------------|
+| `reasoning_surface_guard.py` | `PreToolUse Bash\|Write\|Edit\|MultiEdit` | Blocks high-impact / irreversible ops and architectural-cascade edits that lack a valid Reasoning Surface |
+| `block_dangerous.py` | `PreToolUse Bash` | Blocks `rm -rf`, `git reset --hard`, `git push --force`, `sudo`, destructive SQL, and more |
+| `_arm_a_pre.py` | `PreToolUse Write\|Edit\|MultiEdit` | Cognitive Arm A pre-snapshot of watched profile/policy files for trajectory diffing |
+| `workflow_guard.py` | `PreToolUse Write\|Edit\|MultiEdit` (balanced/strict) | Advisory nudge to keep authoritative docs (`PLAN.md` / `EVENTS.md` / `NEXT_STEPS.md`) aligned with edits |
+| `prompt_guard.py` | `PreToolUse Write\|Edit\|MultiEdit` (balanced/strict) | Advisory prompt-injection detection when writing durable context |
+| `format.py` | `PostToolUse Write\|Edit\|MultiEdit` (async) | Auto-runs `ruff` (Python) / `prettier` (JS/TS) after a file write |
+| `test_runner.py` | `PostToolUse Write\|Edit\|MultiEdit` | Runs pytest / jest when the edited file is a test |
+| `_arm_a_post.py` | `PostToolUse Write\|Edit\|MultiEdit` | Cognitive Arm A post-record — diffs pre vs post and emits trajectory entries |
+| `state_tracker.py` | `PostToolUse Bash` | Records agent-written files for the guard's indirect-exec scan |
+| `calibration_telemetry.py` | `PostToolUse Bash` | Writes the outcome record paired to the guard's PreToolUse prediction |
+| `episodic_writer.py` | `PostToolUse Bash` | Appends redacted command episodes to the episodic-memory stream |
+| `fence_synthesis.py` | `PostToolUse Bash` | Finalizes Fence / constraint-safety protocol markers when the op exits 0 |
+| `context_guard.py` | `PostToolUse Bash\|Edit\|Write\|MultiEdit\|Agent\|Task` (balanced/strict) | Advisory warning as session context approaches compaction thresholds |
+| `session_context.py` | `SessionStart` | Prints branch, git status, and `NEXT_STEPS.md` at session open (if present) |
+| `conclusion_guard.py` | `UserPromptSubmit` | Emits factual context for the v2 Epistemic Engine conclusion trigger |
+| `precompact_backup.py` | `PreCompact` (async) | Backs up session transcripts before context compaction |
+| `quality_gate.py` | `Stop` | Blocks completion if tests fail (opt-in via `.quality-gate` in project root) |
+| `conclusion_gate.py` | `Stop` | One-shot livelock-proof conclusion nudge, fired before checkpoint |
+| `checkpoint.py` | `Stop`, `SubagentStop` | Auto-commits uncommitted changes as `chore(chkpt):` after every turn / subagent |
+
+`contract_gate.py` is an opt-in `Stop` hook (not in the default sync set); it runs
+declared contract tests when enabled in settings.json with a `contracts/` directory
+present — see [`CONTRACT_GATE.md`](./CONTRACT_GATE.md).
+
+**Plugin subset.** The marketplace plugin (`hooks/hooks.json`) ships a **13-hook
+subset**: `block_dangerous`, `reasoning_surface_guard`, `workflow_guard`, `format`,
+`session_context`, `quality_gate`, `precompact_backup`, `conclusion_guard`,
+`conclusion_gate`, `state_tracker`, `calibration_telemetry`, `episodic_writer`,
+`fence_synthesis`. The six sync-only hooks (`_arm_a_pre`, `_arm_a_post`,
+`test_runner`, `prompt_guard`, `context_guard`, `checkpoint`) are delivered by
+`episteme sync` into settings.json.
 
 ## Customization
 

--- a/docs/HOW_TO_AUTHOR_SIGNED_SURFACE.md
+++ b/docs/HOW_TO_AUTHOR_SIGNED_SURFACE.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # How to author a Signed Reasoning Surface
 
 **Audience:** developer-operator preparing to authorize an irreversible AI-assisted decision.

--- a/docs/HOW_TO_VERIFY_EVIDENCE_PACKET.md
+++ b/docs/HOW_TO_VERIFY_EVIDENCE_PACKET.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # How to verify a Regulator Evidence Packet
 
 **Audience:** external auditor / Internal Audit / Notified Body assessor receiving a `regulator-evidence-packet-<ISO>.zip` from an episteme operator.

--- a/docs/HOW_TO_VERIFY_EVIDENCE_PACKET.md
+++ b/docs/HOW_TO_VERIFY_EVIDENCE_PACKET.md
@@ -41,8 +41,9 @@ If any link in this chain is broken, the verifier exits with a specific code (§
 You need Python 3.10+ and the `episteme` package (any version ≥ Phase 3). Install:
 
 ```bash
-pip install episteme              # zero hard deps
-pip install 'episteme[signing]'   # adds PyNaCl for Ed25519 verification
+git clone https://github.com/junjslee/episteme ~/episteme
+cd ~/episteme && pip install -e .            # editable install from the cloned kernel (PyPI is NOT an install path — see INSTALL.md)
+pip install -e '.[signing]'                  # adds PyNaCl for Ed25519 verification
 ```
 
 Unzip the packet and run:

--- a/docs/LAYER_MODEL.md
+++ b/docs/LAYER_MODEL.md
@@ -117,7 +117,7 @@ Detection: `episteme detect [path]` scores signals in the repo (dependency files
 
 ### 3. Project Memory
 
-Every project keeps its definitive truth in repo files. The episteme reference pattern uses `AGENTS.md` plus a staged-execution doc set (typically `docs/REQUIREMENTS.md`, `docs/PLAN.md`, `docs/PROGRESS.md`, `docs/RUN_CONTEXT.md`, `docs/NEXT_STEPS.md`) — these names are convention, not contract. Adopt or rename to fit your project.
+Every project keeps its definitive truth in repo files. The episteme reference pattern uses `AGENTS.md` plus a staged-execution doc set (in this repo: `docs/PLAN.md`, `docs/EVENTS.md`, `docs/NEXT_STEPS.md`, and `docs/COGNITIVE_SYSTEM_PLAYBOOK.md`; planning-state docs are private) — these names are convention, not contract. Adopt or rename to fit your project.
 
 This layer must remain tool-agnostic.
 

--- a/docs/LAYER_MODEL.md
+++ b/docs/LAYER_MODEL.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # episteme Architecture
 
 *Formerly `COGNITIVE_OS_ARCHITECTURE.md`. Renamed 2026-04-21 to match the repository's actual naming; content updated to the v1.0 RC state.*

--- a/docs/LIVE_REKOR_DECISION.md
+++ b/docs/LIVE_REKOR_DECISION.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=design-history; reviewed_as_of=E147; superseded_by=docs/DESIGN_V2_0_EPISTEMIC_ENGINE.md -->
 # Live transparency-log substrate — decision research
 
 **Status:** operator-gated decision. Phase 3 ships only the shape (typed inclusion-proof field; mock test mode that round-trips). The live append + verification is its own Event.

--- a/docs/MEMORY_CONTRACT.md
+++ b/docs/MEMORY_CONTRACT.md
@@ -25,6 +25,40 @@ Tool-native memory is acceleration only. It is never authoritative on its own.
 - Project memory: `docs/*.md`, `AGENTS.md`, runtime policy docs
 - Optional generated artifacts: `core/memory/global/.generated/*` (non-authoritative until compiled)
 
+## Doc lifecycle contract
+
+Event 147, Mechanism 1. Every tracked top-level `docs/*.md` (symlinks excluded — the private planning docs are lifecycle-exempt) carries a machine-readable, render-invisible lifecycle marker on line 1. The marker makes each doc's status explicit to every automated signal path, so a superseded or stale doc is no longer indistinguishable from a live one. Engine: `src/episteme/doc_lifecycle.py`; enforced by `tests/test_doc_budget.py` over the real corpus and surfaced by `episteme docs lint` / `episteme docs index`.
+
+### Marker format
+
+```
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
+<!-- episteme-lifecycle: status=design-history; reviewed_as_of=E147; superseded_by=docs/DESIGN_V2_0_EPISTEMIC_ENGINE.md -->
+```
+
+Keys (`k=v` pairs, `;`-separated):
+
+- `status` (required) ∈ {`living`, `spec-implemented`, `design-history`, `report`, `tombstone`}. Positive system: only these five validate. A tracked `docs/*.md` with no marker, or an unrecognized status, is a hard lint failure — classification is forced at creation, never inferred later.
+- `reviewed_as_of` (required) — an `E<n>` event tag or ISO date recording when the doc's status was last affirmed.
+- `superseded_by` (required iff `status=design-history`; optional scoped pointer on a `living` doc) — the doc that replaced this one.
+- `scope` (optional) — qualifies a scoped supersession on a `living` doc (part of the doc is superseded while the rest stays authoritative).
+
+### Statuses
+
+- `living` — current, authoritative.
+- `spec-implemented` — a spec whose design has shipped; retained for provenance.
+- `design-history` — superseded design; must carry `superseded_by`.
+- `report` — a point-in-time analysis/evaluation artifact (see report sink below).
+- `tombstone` — retired doc kept only as a redirect/marker.
+
+### Cascade rule (Mechanism 2)
+
+A `status=living` doc may not reference a doc whose status ∈ {`design-history`, `tombstone`} **unless the referencing line itself carries a historical qualifier** — one of `superseded`, `retired`, `historical`, `archive`, `design-history` (case-insensitive substring). Otherwise the citation is a `stale-citation` finding. This keeps the citation *edges* honest with the node statuses: a reader following a live doc's reference is told when the target was retired. Mechanically checkable, no operator judgment. Engine: `find_stale_citations()` in `src/episteme/doc_references.py`, reusing the drift linter's citation walk; enforced by `tests/test_doc_references.py`.
+
+### Report sink (Mechanism 4)
+
+`status=report` is a bounded grandfather set, not an open accretion channel. A tracked `docs/*.md` may carry `status=report` only if it is on the configured grandfather list (`report_grandfather` in `[tool.episteme]` / `.episteme/config.json`; default: `docs/EVALUATION_METHOD.md`, `docs/OSF_PRE_REGISTRATION_DRAFT.md`, `docs/ADAPTER_PORTABILITY.md`). A new report doc must land in `archive/reports/YYYY-MM/` (gitignored local artifacts) or attach to an EVENTS entry rather than accrete as a tracked top-level doc. A non-grandfathered report is a `report-sink` lint failure.
+
 ## Record model
 
 Every memory record (all classes) uses these required fields:

--- a/docs/MEMORY_CONTRACT.md
+++ b/docs/MEMORY_CONTRACT.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Memory Contract v1
 
 Purpose: define a portable, deterministic memory model for episteme and adapter runtimes.

--- a/docs/OPEN_SOURCE_YOUR_PROFILE.md
+++ b/docs/OPEN_SOURCE_YOUR_PROFILE.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Open Source Your Profile
 
 Your personal episteme files — `cognitive_profile.md`, `operator_profile.md`, `workflow_policy.md`, `overview.md`, `python_runtime_policy.md` — are the deepest expression of what episteme is meant to do.

--- a/docs/OSF_PRE_REGISTRATION_DRAFT.md
+++ b/docs/OSF_PRE_REGISTRATION_DRAFT.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=report; reviewed_as_of=E147 -->
 # OSF Pre-Registration — DRAFT (Phase 2 Calibration-Lift Trial)
 
 **Status:** DRAFT — not submitted to OSF.

--- a/docs/PROPOSAL_TIERED_IRREVERSIBLE_GATE.md
+++ b/docs/PROPOSAL_TIERED_IRREVERSIBLE_GATE.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=spec-implemented; reviewed_as_of=E147 -->
 # Proposal — Tiered Irreversible-Op Gate (v1.4.x candidate)
 
 > Status: **Stages 0 + 1 + 2 + 3 + 4 + FINAL all landed (Events 134, 134.1, 135).**

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # episteme docs index
 
 Primary navigation for episteme documentation.
@@ -7,21 +8,46 @@ Primary navigation for episteme documentation.
 - `../README.md` — project overview, what problem it solves, quickstart, full command surface
 - `../kernel/` — the canonical markdown spec: constitution, reasoning surface, system-1 counters, operator-profile schema
 - `../kernel/CONSTITUTION.md` — the governing philosophy: why this system exists, what it believes, and what it is not
-- `ARCHITECTURE.md` — v1.0 RC runtime flowchart (Mermaid) with node annotations and cross-references
-- `LAYER_MODEL.md` — layer model, tool/adapter matrix, bootstrap policy, source-of-truth order
 
-## Contracts
+## Full documentation index (generated)
 
-- `MEMORY_CONTRACT.md` — memory classes, provenance schema, conflict resolution semantics
-- `EVOLUTION_CONTRACT.md` — gated self-evolution lifecycle, mutation library, promotion gates
+Every tracked `docs/*.md`, with its lifecycle status and a one-line purpose. This
+section is generated from the lifecycle markers by `episteme docs index` — do not
+hand-edit between the markers; run the command and commit the result.
 
-## Runtime bridges
-
-- `ANTHROPIC_MANAGED_AGENTS_BRIDGE.md` — import Anthropic Managed Agents runtime events into Memory Contract v1 episodic envelopes
-
-## Open-source guidance
-
-- `OPEN_SOURCE_YOUR_PROFILE.md` — how and why to share your personal episteme profile as a reference implementation
+<!-- episteme-docs-index:start -->
+- [`ADAPTER_PORTABILITY.md`](./ADAPTER_PORTABILITY.md) · report · Adapter Portability Audit
+- [`ANTHROPIC_MANAGED_AGENTS_BRIDGE.md`](./ANTHROPIC_MANAGED_AGENTS_BRIDGE.md) · living · Anthropic Managed Agents Bridge
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) · living · Architecture — The Sovereign Kernel (v1.3.0-rc1 shipped · 1066 tests + 54 subtests green)
+- [`COMMANDS.md`](./COMMANDS.md) · living · episteme — command reference
+- [`COMPLIANCE_CROSSWALK.md`](./COMPLIANCE_CROSSWALK.md) · living · Compliance Crosswalk — `signed-surface@1.0` → Regulatory Clauses
+- [`CONTRACT_GATE.md`](./CONTRACT_GATE.md) · living · Contract Gate — deterministic contract-test complement to the Reasoning Surface
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) · living · Contributing to episteme
+- [`CUSTOMIZATION.md`](./CUSTOMIZATION.md) · living · Customization
+- [`DEMOS.md`](./DEMOS.md) · living · Demos
+- [`DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md) · living · Design — Causal-Consequence Scaffolding & Protocol Synthesis — v1.0 RC
+- [`DESIGN_V2_0_EPISTEMIC_ENGINE.md`](./DESIGN_V2_0_EPISTEMIC_ENGINE.md) · living · DESIGN v2.0 — The Epistemic Engine
+- [`EVALUATION_METHOD.md`](./EVALUATION_METHOD.md) · report · Evaluation Method — Does episteme actually make a difference?
+- [`EVOLUTION_CONTRACT.md`](./EVOLUTION_CONTRACT.md) · living · Evolution Contract v1
+- [`HARNESSES.md`](./HARNESSES.md) · living · Harness System
+- [`HOOKS.md`](./HOOKS.md) · living · Deterministic Safety Hooks
+- [`HOW_TO_AUTHOR_SIGNED_SURFACE.md`](./HOW_TO_AUTHOR_SIGNED_SURFACE.md) · living · How to author a Signed Reasoning Surface
+- [`HOW_TO_VERIFY_EVIDENCE_PACKET.md`](./HOW_TO_VERIFY_EVIDENCE_PACKET.md) · living · How to verify a Regulator Evidence Packet
+- [`LAYER_MODEL.md`](./LAYER_MODEL.md) · living · episteme Architecture
+- [`LIVE_REKOR_DECISION.md`](./LIVE_REKOR_DECISION.md) · design-history · Live transparency-log substrate — decision research
+- [`MEMORY_CONTRACT.md`](./MEMORY_CONTRACT.md) · living · Memory Contract v1
+- [`OPEN_SOURCE_YOUR_PROFILE.md`](./OPEN_SOURCE_YOUR_PROFILE.md) · living · Open Source Your Profile
+- [`OSF_PRE_REGISTRATION_DRAFT.md`](./OSF_PRE_REGISTRATION_DRAFT.md) · report · OSF Pre-Registration — DRAFT (Phase 2 Calibration-Lift Trial)
+- [`PROPOSAL_TIERED_IRREVERSIBLE_GATE.md`](./PROPOSAL_TIERED_IRREVERSIBLE_GATE.md) · spec-implemented · Proposal — Tiered Irreversible-Op Gate (v1.4.x candidate)
+- [`README.md`](./README.md) · living · episteme docs index
+- [`SETUP.md`](./SETUP.md) · living · Setup — Profile, Cognition, One-Command
+- [`SKILLS_AND_PERSONAS.md`](./SKILLS_AND_PERSONAS.md) · living · Skills and Agent Personas
+- [`SPEC_REASONING_SURFACE_BRANCHING.md`](./SPEC_REASONING_SURFACE_BRANCHING.md) · spec-implemented · Spec — Reasoning Surface branching
+- [`SPEC_RIGOR_KNOB.md`](./SPEC_RIGOR_KNOB.md) · spec-implemented · Spec — `episteme rigor` (rigor knob)
+- [`SUBSTRATE_BRIDGE.md`](./SUBSTRATE_BRIDGE.md) · living · Substrate Bridge — A Generalizable Contract for External Memory Systems
+- [`SYNC_AND_MEMORY.md`](./SYNC_AND_MEMORY.md) · living · Sync and Memory Model
+- [`THE_WAY_TO_THINK.md`](./THE_WAY_TO_THINK.md) · living · The Way to Think — 생각의 틀
+<!-- episteme-docs-index:end -->
 
 ## Recommended reading order
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ hand-edit between the markers; run the command and commit the result.
 <!-- episteme-docs-index:start -->
 - [`ADAPTER_PORTABILITY.md`](./ADAPTER_PORTABILITY.md) · report · Adapter Portability Audit
 - [`ANTHROPIC_MANAGED_AGENTS_BRIDGE.md`](./ANTHROPIC_MANAGED_AGENTS_BRIDGE.md) · living · Anthropic Managed Agents Bridge
-- [`ARCHITECTURE.md`](./ARCHITECTURE.md) · living · Architecture — The Sovereign Kernel (v1.3.0-rc1 shipped · 1066 tests + 54 subtests green)
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) · living · Architecture — The Sovereign Kernel (1.9.0-rc1)
 - [`COMMANDS.md`](./COMMANDS.md) · living · episteme — command reference
 - [`COMPLIANCE_CROSSWALK.md`](./COMPLIANCE_CROSSWALK.md) · living · Compliance Crosswalk — `signed-surface@1.0` → Regulatory Clauses
 - [`CONTRACT_GATE.md`](./CONTRACT_GATE.md) · living · Contract Gate — deterministic contract-test complement to the Reasoning Surface

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Setup — Profile, Cognition, One-Command
 
 Deterministic onboarding for episteme. Two axes:

--- a/docs/SKILLS_AND_PERSONAS.md
+++ b/docs/SKILLS_AND_PERSONAS.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Skills and Agent Personas
 
 Two extension surfaces shipped with episteme: **skills** (reusable operator capabilities) and **personas** (subagent definitions). Both propagate via `episteme sync`.

--- a/docs/SPEC_REASONING_SURFACE_BRANCHING.md
+++ b/docs/SPEC_REASONING_SURFACE_BRANCHING.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=spec-implemented; reviewed_as_of=E147 -->
 # Spec — Reasoning Surface branching
 
 **Status:** proposed (Tier 2.3 design spec, Event 110, 2026-05-08). Implementation deferred to Tier 3 — see § Implementation path below for decomposition.

--- a/docs/SPEC_RIGOR_KNOB.md
+++ b/docs/SPEC_RIGOR_KNOB.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=spec-implemented; reviewed_as_of=E147 -->
 # Spec — `episteme rigor` (rigor knob)
 
 **Status:** proposed (Tier 2.3 design spec, Event 110, 2026-05-08). Implementation deferred to Tier 3 — see § Implementation path below for decomposition.

--- a/docs/SUBSTRATE_BRIDGE.md
+++ b/docs/SUBSTRATE_BRIDGE.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Substrate Bridge — A Generalizable Contract for External Memory Systems
 
 The kernel speaks exactly one format: `memory-contract-v1` envelopes. Every external memory system — mem0, Memori, MemOS, claude-mem, a vector DB, a filesystem tree, an MCP server, a future substrate we haven't heard of yet — integrates through the same adapter protocol. No substrate becomes authoritative; they are caches with **declared capabilities** and **declared lossy fields**.

--- a/docs/SYNC_AND_MEMORY.md
+++ b/docs/SYNC_AND_MEMORY.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # Sync and Memory Model
 
 How the kernel + operator profile reach every runtime, and how memory is structured, scoped, and reconciled.

--- a/docs/THE_WAY_TO_THINK.md
+++ b/docs/THE_WAY_TO_THINK.md
@@ -180,7 +180,7 @@ The practice maps to artifacts that fall into three lanes:
 |---|---|---|
 | Standalone `episteme verify` CLI | Independent verification of any signed surface; runs without trusting the episteme runtime | `src/episteme/verify/` |
 | `episteme evidence packet build` | On-demand ZIP packet for auditor / regulator / future-self / new-teammate review | `src/episteme/evidence/_packet.py` |
-| Sigstore Rekor inclusion-proof shape | Append-only off-system witness (live integration deferred per `docs/LIVE_REKOR_DECISION.md`) | `core/signing/transparency.py` |
+| Sigstore Rekor inclusion-proof shape | Append-only off-system witness (live integration deferred per the design-history record `docs/LIVE_REKOR_DECISION.md`) | `core/signing/transparency.py` |
 | RFC 3161 TSA timestamps | Independent third-party time-binding | `core/signing/tsa.py` |
 
 ---

--- a/docs/THE_WAY_TO_THINK.md
+++ b/docs/THE_WAY_TO_THINK.md
@@ -1,3 +1,4 @@
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
 # The Way to Think — 생각의 틀
 
 > *"The product is a way to think when the model can finish your sentences."*

--- a/src/episteme/_memory_promote.py
+++ b/src/episteme/_memory_promote.py
@@ -380,6 +380,54 @@ def render_promotion_report(
     return "\n".join(lines)
 
 
+# ----- Source lifecycle transition (Event 147, A3) --------------------
+
+def supersede_promoted_sources(
+    proposals: Sequence[dict],
+    records_dir: Path,
+) -> int:
+    """Mark the source ``.memory.json`` records copied into these proposals as
+    ``status=superseded`` (the D11 promote-path auto-transition).
+
+    When a promotion lifts an episodic record's evidence into a semantic
+    proposal, the source record has been superseded by the higher-tier
+    generalization; this transitions it so ``memory list --status active`` stops
+    surfacing it as a live standalone. Matches a proposal's ``evidence_refs``
+    (episodic record ids) against the ``id`` field of records under
+    ``records_dir/{global,project,episodic}``. Idempotent (records already
+    ``superseded`` are skipped) and never raises — a bookkeeping transition must
+    not break the promote run. Returns the number of records transitioned.
+    """
+    refs: set[str] = set()
+    for p in proposals:
+        for r in p.get("evidence_refs", []) or []:
+            r = str(r).strip()
+            if r:
+                refs.add(r)
+    if not refs:
+        return 0
+    transitioned = 0
+    for cls in ("global", "project", "episodic"):
+        cls_dir = records_dir / cls
+        if not cls_dir.is_dir():
+            continue
+        for f in sorted(cls_dir.glob("*.memory.json")):
+            try:
+                rec = json.loads(f.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                continue
+            if not isinstance(rec, dict):
+                continue
+            if str(rec.get("id", "")) in refs and rec.get("status") != "superseded":
+                rec["status"] = "superseded"
+                try:
+                    f.write_text(json.dumps(rec, indent=2) + "\n", encoding="utf-8")
+                except OSError:
+                    continue
+                transitioned += 1
+    return transitioned
+
+
 # ----- Public entry point --------------------------------------------
 
 def run_promote(
@@ -389,10 +437,19 @@ def run_promote(
     output_path: Path | None = None,
     min_cluster_size: int = DEFAULT_MIN_CLUSTER_SIZE,
     now_iso: str | None = None,
+    records_dir: Path | None = None,
 ) -> tuple[str, int, Path | None]:
     """Read episodic records, compute proposals, write to reflective tier,
     render a report. Returns (report_markdown, proposal_count,
     proposals_file_path_or_None).
+
+    When ``records_dir`` is provided, the promote path also transitions any
+    source ``.memory.json`` record copied into a proposal to
+    ``status=superseded`` (Event 147 D11 wiring). ``records_dir`` is injected
+    rather than hardcoded so the module stays portable — the CLI passes the
+    repo's ``core/memory/records`` and tests pass a fixture dir. Left None (the
+    default) the promote run is read-only against the record tiers, preserving
+    prior behaviour.
 
     CLI wrapper prints the markdown and/or writes it to ``output_path``.
     """
@@ -401,6 +458,8 @@ def run_promote(
     records = load_episodic_records(ed)
     proposals = build_proposals(records, min_cluster_size=min_cluster_size)
     written_to = write_proposals(proposals, rd, now_iso=now_iso)
+    if records_dir is not None:
+        supersede_promoted_sources(proposals, records_dir)
     report = render_promotion_report(
         proposals, total_records=len(records), min_cluster_size=min_cluster_size
     )

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -5664,6 +5664,12 @@ def build_parser() -> argparse.ArgumentParser:
     audit = sub.add_parser("audit", help="Reasoning check: verify the current project session has addressed cognitive unknowns")
     audit.add_argument("--fix", action="store_true", help="Append stub Reasoning Surface blocks to files that are missing them")
 
+    docs_cmd = sub.add_parser("docs", help="Doc/artifact lifecycle — marker lint + generated index")
+    docs_sub = docs_cmd.add_subparsers(dest="docs_action", required=True)
+    docs_sub.add_parser("lint", help="Validate lifecycle markers on every tracked docs/*.md (positive system)")
+    d_index = docs_sub.add_parser("index", help="Regenerate the docs/README.md index from lifecycle markers")
+    d_index.add_argument("--check", action="store_true", help="Verify the committed index is up to date (CI gate); do not write")
+
     kernel = sub.add_parser("kernel", help="Kernel integrity manifest + ledger maintenance operations")
     kernel_sub = kernel.add_subparsers(dest="kernel_action", required=True)
     kernel_sub.add_parser("verify", help="Verify managed kernel files match the manifest")
@@ -6448,6 +6454,13 @@ def main(argv: Iterable[str] | None = None) -> int:
         return _init_memory()
     if args.command == "doctor":
         return _doctor()
+    if args.command == "docs":
+        from . import doc_lifecycle as _dl
+        if args.docs_action == "lint":
+            return _dl.run_lint_cli()
+        if args.docs_action == "index":
+            return _dl.run_index_cli(check=getattr(args, "check", False))
+        return 0
     if args.command == "memory":
         if args.memory_action == "record":
             return _memory_record(

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -1744,6 +1744,53 @@ def _memory_search(query: str) -> int:
     return 0
 
 
+def _find_memory_record(record_id: str) -> Path | None:
+    """Locate the ``.memory.json`` file backing ``record_id`` across the three
+    tiers, or None. Matches on the record's ``id`` field (the stored UUID),
+    which is authoritative — the filename mirrors it but the field is the
+    contract the reader keys on."""
+    for cls in ("global", "project", "episodic"):
+        cls_dir = MEMORY_RECORDS_DIR / cls
+        if not cls_dir.is_dir():
+            continue
+        for f in cls_dir.glob("*.memory.json"):
+            try:
+                rec = json.loads(f.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            if isinstance(rec, dict) and str(rec.get("id", "")) == record_id:
+                return f
+    return None
+
+
+def _memory_set_status(record_id: str, status: str) -> int:
+    """Writer for the memory-record status lifecycle (Event 147, A3).
+
+    Closes the D11 gap: the status enum {active, archived, superseded} existed
+    on every ``.memory.json`` record and ``memory list --status`` already
+    filtered on it, but nothing could transition a record between states. This
+    is the explicit writer. It rewrites only the ``status`` field, preserving
+    the rest of the record verbatim."""
+    path = _find_memory_record(record_id)
+    if path is None:
+        print(f"No memory record found with id {record_id!r}", file=sys.stderr)
+        return 1
+    try:
+        rec = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Could not read record {path}: {exc}", file=sys.stderr)
+        return 1
+    old_status = rec.get("status", "active")
+    rec["status"] = status
+    try:
+        path.write_text(json.dumps(rec, indent=2) + "\n", encoding="utf-8")
+    except OSError as exc:
+        print(f"Could not write record {path}: {exc}", file=sys.stderr)
+        return 1
+    print(f"Memory record {record_id} status: {old_status} -> {status}")
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # doctor
 # ---------------------------------------------------------------------------
@@ -5398,7 +5445,7 @@ command map (grouped by lifecycle phase):
     start                    launch the preferred agent surface for this project
     doctor                   verify runtime wiring (Conda, core tools, optional tools)
     audit                    check whether the current session addressed its unknowns
-    memory                   record, list, search, promote memory records
+    memory                   record, list, search, set-status, promote memory records
 
   setup & admin
     init                     seed kernel global memory from examples (one-shot after clone)
@@ -5453,6 +5500,15 @@ def build_parser() -> argparse.ArgumentParser:
     m_list.add_argument("--limit", type=int, default=20)
     m_search = memory_sub.add_parser("search", help="Search active memory records by text")
     m_search.add_argument("query", help="Text to search for (case-insensitive)")
+
+    m_setstatus = memory_sub.add_parser(
+        "set-status",
+        help="Transition a memory record's lifecycle status (active/archived/superseded)",
+    )
+    m_setstatus.add_argument("record_id", help="Record id (UUID) to transition")
+    m_setstatus.add_argument(
+        "status", choices=["active", "archived", "superseded"], help="New status"
+    )
 
     m_promote = memory_sub.add_parser(
         "promote",
@@ -6477,6 +6533,8 @@ def main(argv: Iterable[str] | None = None) -> int:
             )
         if args.memory_action == "search":
             return _memory_search(args.query)
+        if args.memory_action == "set-status":
+            return _memory_set_status(args.record_id, args.status)
         if args.memory_action == "promote":
             from pathlib import Path as _Path
             from . import _memory_promote as _mp
@@ -6485,6 +6543,7 @@ def main(argv: Iterable[str] | None = None) -> int:
                 reflective_dir=_Path(args.reflective_dir) if args.reflective_dir else None,
                 output_path=_Path(args.output) if args.output else None,
                 min_cluster_size=args.min_cluster,
+                records_dir=MEMORY_RECORDS_DIR,
             )
             print(report)
             if written_to is not None:

--- a/src/episteme/doc_lifecycle.py
+++ b/src/episteme/doc_lifecycle.py
@@ -1,0 +1,496 @@
+"""Doc/artifact lifecycle engine — machine-readable status markers as code.
+
+Event 147, Mechanism 1. Counters FAILURE_MODES: doc-staleness-invisibility —
+a tracked ``docs/*.md`` had no machine-readable lifecycle state, so a stale or
+superseded doc was indistinguishable from a live one to every automated signal
+path. This module makes the classification explicit at line 1 of every doc and
+turns it into a lint gate + a self-healing index.
+
+BOUNDS (anti-accretion, PLAYBOOK:220), does NOT add a parallel path:
+``tests/test_doc_budget.py`` is reseated onto ``lint()`` here (the marker
+contract subsumes the ad-hoc ceiling test's corpus walk) and the doc index in
+``docs/README.md`` is generated from these markers rather than hand-listed.
+
+## Marker contract
+
+Line 1 of every tracked ``docs/*.md`` (symlinks skipped) carries a render-
+invisible HTML comment::
+
+    <!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
+    <!-- episteme-lifecycle: status=design-history; reviewed_as_of=E147; superseded_by=docs/DESIGN_V2_0_EPISTEMIC_ENGINE.md -->
+
+Keys:
+
+* ``status`` (required) ∈ {living, spec-implemented, design-history, report,
+  tombstone}. Positive system — only the five enumerated statuses validate; a
+  tracked ``docs/*.md`` with no marker is a lint failure (classification forced
+  at creation, not inferred later).
+* ``reviewed_as_of`` (required) — ``E<n>`` event tag or ISO date.
+* ``superseded_by`` (required iff status=design-history; optional scoped
+  pointer on a living doc).
+* ``scope`` (optional) — qualifies a scoped supersession on a living doc.
+
+## Portability
+
+Repo-specific values (docs dir, report grandfather list) come from config
+discovery — ``[tool.episteme]`` in ``pyproject.toml`` or ``.episteme/config.json``
+— never hardcoded here. Another repo adopts the mechanism via ``episteme sync``
+plus config alone. Default docs dir is ``docs/``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+try:  # Python 3.11+ stdlib; fall back to tomli if ever run under 3.10.
+    import tomllib as _tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - defensive for <3.11
+    try:
+        import tomli as _tomllib  # type: ignore[import-not-found, no-redef]
+    except ModuleNotFoundError:  # pragma: no cover
+        _tomllib = None  # type: ignore[assignment]
+
+
+# --------------------------------------------------------------------------- #
+# Vocabulary                                                                   #
+# --------------------------------------------------------------------------- #
+
+#: The five enumerated lifecycle statuses. Positive system: only these validate.
+VALID_STATUSES: frozenset[str] = frozenset(
+    {"living", "spec-implemented", "design-history", "report", "tombstone"}
+)
+
+#: Statuses that mandate a ``superseded_by`` pointer.
+_REQUIRES_SUPERSEDED_BY: frozenset[str] = frozenset({"design-history"})
+
+#: Default report docs allowed to remain tracked under status=report (the
+#: report-sink grandfather list). Overridable via config; new reports must land
+#: in ``archive/reports/`` or attach to EVENTS entries rather than accrete here.
+_DEFAULT_REPORT_GRANDFATHER: tuple[str, ...] = (
+    "docs/EVALUATION_METHOD.md",
+    "docs/OSF_PRE_REGISTRATION_DRAFT.md",
+    "docs/ADAPTER_PORTABILITY.md",
+)
+
+#: Index splice markers in the docs README.
+INDEX_START = "<!-- episteme-docs-index:start -->"
+INDEX_END = "<!-- episteme-docs-index:end -->"
+
+# ``<!-- episteme-lifecycle: <body> -->`` anywhere on the first line.
+_MARKER_RE = re.compile(r"<!--\s*episteme-lifecycle:\s*(?P<body>.*?)\s*-->")
+# Strip any HTML comment (incl. volatile-fact spans) when deriving a purpose.
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->")
+
+
+# --------------------------------------------------------------------------- #
+# Config discovery                                                             #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Config:
+    """Repo-specific lifecycle configuration (portable via discovery)."""
+
+    docs_dir: str = "docs"
+    report_grandfather: tuple[str, ...] = _DEFAULT_REPORT_GRANDFATHER
+
+
+def discover_config(root: Path) -> Config:
+    """Resolve lifecycle config for ``root``.
+
+    Precedence: ``.episteme/config.json`` (local override) > ``pyproject.toml``
+    ``[tool.episteme]`` (tracked, portable) > built-in defaults. Any malformed
+    source degrades to the next source rather than raising — config discovery
+    must never break the lint gate.
+    """
+    root = Path(root)
+    data: Dict[str, object] = {}
+
+    pyproject = root / "pyproject.toml"
+    if _tomllib is not None and pyproject.is_file():
+        try:
+            with open(pyproject, "rb") as fh:
+                parsed = _tomllib.load(fh)
+            tool = parsed.get("tool")
+            if isinstance(tool, dict):
+                section = tool.get("episteme")
+                if isinstance(section, dict):
+                    data.update(section)
+        except (OSError, ValueError):
+            pass
+
+    cfg_json = root / ".episteme" / "config.json"
+    if cfg_json.is_file():
+        try:
+            parsed_json = json.loads(cfg_json.read_text(encoding="utf-8"))
+            if isinstance(parsed_json, dict):
+                data.update(parsed_json)
+        except (OSError, ValueError):
+            pass
+
+    docs_dir = data.get("docs_dir", "docs")
+    if not isinstance(docs_dir, str) or not docs_dir.strip():
+        docs_dir = "docs"
+    docs_dir = docs_dir.strip().rstrip("/")
+
+    raw_grandfather = data.get("report_grandfather")
+    if isinstance(raw_grandfather, (list, tuple)) and all(
+        isinstance(x, str) for x in raw_grandfather
+    ):
+        report_grandfather: tuple[str, ...] = tuple(raw_grandfather)
+    else:
+        report_grandfather = _DEFAULT_REPORT_GRANDFATHER
+
+    return Config(docs_dir=docs_dir, report_grandfather=report_grandfather)
+
+
+# --------------------------------------------------------------------------- #
+# Data model                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Marker:
+    """A parsed ``episteme-lifecycle`` marker (line 1 of a doc)."""
+
+    status: str
+    reviewed_as_of: str
+    superseded_by: Optional[str] = None
+    scope: Optional[str] = None
+    extra: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A lint violation against the marker contract."""
+
+    file: str
+    line: int
+    kind: str
+    message: str
+
+
+# --------------------------------------------------------------------------- #
+# Parsing                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _parse_marker_body(body: str) -> Dict[str, str]:
+    """Parse ``k=v; k=v`` pairs from a marker body into a dict."""
+    out: Dict[str, str] = {}
+    for chunk in body.split(";"):
+        chunk = chunk.strip()
+        if not chunk or "=" not in chunk:
+            continue
+        key, _, value = chunk.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if key:
+            out[key] = value
+    return out
+
+
+def parse_marker_text(first_line: str) -> Optional[Marker]:
+    """Parse a marker from a single line of text, or ``None`` if absent."""
+    match = _MARKER_RE.search(first_line)
+    if match is None:
+        return None
+    kv = _parse_marker_body(match.group("body"))
+    known = {"status", "reviewed_as_of", "superseded_by", "scope"}
+    extra = {k: v for k, v in kv.items() if k not in known}
+    return Marker(
+        status=kv.get("status", ""),
+        reviewed_as_of=kv.get("reviewed_as_of", ""),
+        superseded_by=kv.get("superseded_by") or None,
+        scope=kv.get("scope") or None,
+        extra=extra,
+    )
+
+
+def parse_marker(path: Path) -> Optional[Marker]:
+    """Return the lifecycle marker on line 1 of ``path``, or ``None``.
+
+    ``None`` means the first line carries no ``episteme-lifecycle`` comment —
+    the caller (``lint``) treats that as a missing-marker finding. Read errors
+    also yield ``None`` so a transient IO failure surfaces as a lint finding
+    rather than a crash.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            first_line = fh.readline()
+    except OSError:
+        return None
+    return parse_marker_text(first_line)
+
+
+# --------------------------------------------------------------------------- #
+# Corpus enumeration                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def tracked_docs(root: Path, config: Optional[Config] = None) -> List[str]:
+    """Repo-root-relative paths of tracked top-level ``<docs_dir>/*.md`` files.
+
+    Excludes symlinks (private planning docs are symlinked and lifecycle-exempt)
+    and any nested path (assets/subdirs are out of scope). Tracked-only keeps
+    the corpus environment-stable between a maintainer checkout and a clean CI
+    clone.
+    """
+    root = Path(root)
+    cfg = config or discover_config(root)
+    docs_dir = cfg.docs_dir
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z", f"{docs_dir}/*.md"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError(
+            "doc_lifecycle requires git to enumerate tracked docs; run inside "
+            "a git working tree"
+        ) from exc
+    out: List[str] = []
+    for rel in proc.stdout.split("\0"):
+        if not rel:
+            continue
+        # Top-level only: exactly ``<docs_dir>/<name>.md`` (one slash).
+        if rel.count("/") != 1:
+            continue
+        if (root / rel).is_symlink():
+            continue
+        out.append(rel)
+    return sorted(out)
+
+
+# --------------------------------------------------------------------------- #
+# Lint                                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def lint(root: Path, config: Optional[Config] = None) -> List[Finding]:
+    """Validate every tracked top-level doc against the marker contract.
+
+    Failing findings (positive system): a doc with no marker, an unrecognised
+    status, a missing ``reviewed_as_of``, or a ``design-history`` doc without a
+    ``superseded_by`` pointer. Deterministic order (by file, then line).
+    """
+    root = Path(root)
+    cfg = config or discover_config(root)
+    findings: List[Finding] = []
+    for rel in tracked_docs(root, cfg):
+        marker = parse_marker(root / rel)
+        if marker is None:
+            findings.append(
+                Finding(
+                    file=rel,
+                    line=1,
+                    kind="missing-marker",
+                    message=(
+                        "no episteme-lifecycle marker on line 1 — every tracked "
+                        f"{cfg.docs_dir}/*.md must declare status + reviewed_as_of "
+                        "at creation (positive system)"
+                    ),
+                )
+            )
+            continue
+        if marker.status not in VALID_STATUSES:
+            findings.append(
+                Finding(
+                    file=rel,
+                    line=1,
+                    kind="invalid-status",
+                    message=(
+                        f"status={marker.status!r} is not one of "
+                        f"{sorted(VALID_STATUSES)}"
+                    ),
+                )
+            )
+        if not marker.reviewed_as_of:
+            findings.append(
+                Finding(
+                    file=rel,
+                    line=1,
+                    kind="missing-reviewed-as-of",
+                    message="marker is missing the required reviewed_as_of key",
+                )
+            )
+        if marker.status in _REQUIRES_SUPERSEDED_BY and not marker.superseded_by:
+            findings.append(
+                Finding(
+                    file=rel,
+                    line=1,
+                    kind="missing-superseded-by",
+                    message=(
+                        f"status={marker.status} requires a superseded_by pointer"
+                    ),
+                )
+            )
+    return findings
+
+
+def format_findings(findings: Sequence[Finding]) -> str:
+    """Render findings as one human-readable line each."""
+    return "\n".join(
+        f"  {f.file}:{f.line}  [{f.kind}]  {f.message}" for f in findings
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Index generation                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def _doc_purpose(path: Path) -> str:
+    """Derive a one-line purpose from a doc's first H1 heading.
+
+    Strips HTML comments (marker + volatile-fact spans keep their inner value)
+    and collapses whitespace. Falls back to an empty string when no H1 exists.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("# "):
+            title = _HTML_COMMENT_RE.sub("", stripped[2:])
+            return re.sub(r"\s+", " ", title).strip()
+    return ""
+
+
+def generate_index(root: Path, config: Optional[Config] = None) -> str:
+    """Return the generated docs-index body (markdown list) from markers.
+
+    One line per tracked top-level doc: linked filename, lifecycle status, and a
+    one-line purpose derived from the doc's H1. Sorted by filename so the output
+    is deterministic and diff-stable. Docs without a valid marker are listed with
+    ``status=?`` so the index still surfaces them (lint is the gate that forces
+    the marker; the index does not hide the gap).
+    """
+    root = Path(root)
+    cfg = config or discover_config(root)
+    lines: List[str] = []
+    for rel in tracked_docs(root, cfg):
+        name = rel.split("/", 1)[1]
+        marker = parse_marker(root / rel)
+        status = marker.status if (marker and marker.status) else "?"
+        purpose = _doc_purpose(root / rel)
+        entry = f"- [`{name}`](./{name}) · {status}"
+        if purpose:
+            entry += f" · {purpose}"
+        lines.append(entry)
+    return "\n".join(lines)
+
+
+def render_index_section(root: Path, config: Optional[Config] = None) -> str:
+    """Return the full splice block (markers + generated body)."""
+    body = generate_index(root, config)
+    return f"{INDEX_START}\n{body}\n{INDEX_END}"
+
+
+def update_readme_index(
+    root: Path, config: Optional[Config] = None
+) -> tuple[bool, str]:
+    """Splice the generated index into ``<docs_dir>/README.md`` in place.
+
+    Replaces the content between :data:`INDEX_START` and :data:`INDEX_END`. When
+    the markers are absent, appends a fresh index section under a heading. Returns
+    ``(changed, message)``. Idempotent — running twice with no doc changes is a
+    no-op.
+    """
+    root = Path(root)
+    cfg = config or discover_config(root)
+    readme = root / cfg.docs_dir / "README.md"
+    try:
+        original = readme.read_text(encoding="utf-8")
+    except OSError as exc:
+        return False, f"could not read {readme}: {exc}"
+
+    section = render_index_section(root, cfg)
+    if INDEX_START in original and INDEX_END in original:
+        pattern = re.compile(
+            re.escape(INDEX_START) + r".*?" + re.escape(INDEX_END),
+            re.DOTALL,
+        )
+        updated = pattern.sub(lambda _m: section, original, count=1)
+    else:
+        suffix = "" if original.endswith("\n") else "\n"
+        updated = (
+            f"{original}{suffix}\n## Full index (generated)\n\n"
+            f"Regenerate with `episteme docs index`.\n\n{section}\n"
+        )
+
+    if updated == original:
+        return False, "docs index already up to date"
+    readme.write_text(updated, encoding="utf-8")
+    return True, f"updated docs index in {cfg.docs_dir}/README.md"
+
+
+# --------------------------------------------------------------------------- #
+# CLI entry points                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def run_lint_cli(root: Optional[Path] = None) -> int:
+    """`episteme docs lint` — exit 1 when the corpus has marker violations."""
+    root = Path(root) if root is not None else _repo_root()
+    findings = lint(root)
+    if not findings:
+        print("docs lifecycle: clean")
+        return 0
+    print(f"{len(findings)} doc lifecycle violation(s):")
+    print(format_findings(findings))
+    return 1
+
+
+def run_index_cli(root: Optional[Path] = None, check: bool = False) -> int:
+    """`episteme docs index` — regenerate (or, with ``check``, verify) the index."""
+    root = Path(root) if root is not None else _repo_root()
+    cfg = discover_config(root)
+    if check:
+        readme = root / cfg.docs_dir / "README.md"
+        try:
+            original = readme.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"docs index: could not read {readme}: {exc}")
+            return 1
+        section = render_index_section(root, cfg)
+        if INDEX_START in original and INDEX_END in original:
+            pattern = re.compile(
+                re.escape(INDEX_START) + r".*?" + re.escape(INDEX_END),
+                re.DOTALL,
+            )
+            match = pattern.search(original)
+            if match is not None and match.group(0) == section:
+                print("docs index: up to date")
+                return 0
+        print("docs index: STALE — run `episteme docs index` and commit")
+        return 1
+    changed, message = update_readme_index(root, cfg)
+    print(f"docs index: {message}")
+    return 0
+
+
+def _repo_root() -> Path:
+    """Resolve the repo root (git top-level, else the package's parents[2])."""
+    here = Path(__file__).resolve()
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(here.parent), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        top = proc.stdout.strip()
+        if top:
+            return Path(top)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        pass
+    return here.parents[2]

--- a/src/episteme/doc_lifecycle.py
+++ b/src/episteme/doc_lifecycle.py
@@ -332,6 +332,25 @@ def lint(root: Path, config: Optional[Config] = None) -> List[Finding]:
                     ),
                 )
             )
+        # Report sink (Event 147, Mechanism 4): status=report is a bounded
+        # grandfather set, not an open accretion channel. A tracked report doc
+        # is allowed only if it is on the config grandfather list; new reports
+        # must land in ``archive/reports/YYYY-MM/`` (gitignored) or attach to an
+        # EVENTS entry rather than accrete as tracked top-level docs.
+        if marker.status == "report" and rel not in cfg.report_grandfather:
+            findings.append(
+                Finding(
+                    file=rel,
+                    line=1,
+                    kind="report-sink",
+                    message=(
+                        "status=report is only permitted for grandfathered docs "
+                        f"({sorted(cfg.report_grandfather)}); a new report must "
+                        "land in archive/reports/YYYY-MM/ (gitignored) or attach "
+                        "to an EVENTS entry, not accrete as a tracked doc"
+                    ),
+                )
+            )
     return findings
 
 

--- a/src/episteme/doc_references.py
+++ b/src/episteme/doc_references.py
@@ -417,13 +417,150 @@ def _format_findings(findings: Sequence[Finding]) -> str:
     )
 
 
+# --------------------------------------------------------------------------- #
+# Stale-citation cascade gate (Event 147, Mechanism 2)                         #
+# --------------------------------------------------------------------------- #
+#
+# Counters FAILURE_MODES: stale-citation-cascade — a doc gets reclassified as
+# design-history or tombstone, but the living docs that cite it keep pointing
+# at it as though it were current, so a reader following the reference lands on
+# a superseded artifact with no signal that it was retired. The lifecycle
+# marker (Mechanism 1) makes each doc's status machine-readable; this gate makes
+# the *edges* honor it: a status=living doc may not cite a status ∈
+# {design-history, tombstone} doc unless the referencing line itself carries a
+# historical qualifier that tells the reader the target is not current.
+#
+# Mechanically checkable, no operator judgment (M1): the qualifier test is a
+# case-insensitive substring scan of the citing line against a fixed word set.
+# Reuses the same citation walk as the drift linter (``extract_references``) so
+# there is no second, divergent notion of "what a doc cites".
+
+#: Lifecycle statuses whose docs must not be cited bare by a living doc.
+HISTORICAL_STATUSES: frozenset[str] = frozenset({"design-history", "tombstone"})
+
+#: Words that, present anywhere on the citing line, mark the reference as a
+#: deliberate historical pointer (case-insensitive substring match). ``archive``
+#: also covers ``archived``; ``supersede`` covers ``superseded``/``supersedes``.
+HISTORICAL_QUALIFIERS: tuple[str, ...] = (
+    "supersede",
+    "retired",
+    "historical",
+    "archive",
+    "design-history",
+)
+
+
+@dataclass(frozen=True)
+class StaleCitation:
+    """A living doc citing a design-history/tombstone doc without a qualifier."""
+
+    citing_file: str
+    line: int
+    raw: str
+    target: str
+    target_status: str
+
+
+def _line_has_qualifier(line_text: str) -> bool:
+    """True iff the citing line carries a historical qualifier word."""
+    low = line_text.lower()
+    return any(q in low for q in HISTORICAL_QUALIFIERS)
+
+
+def _lifecycle_status_map(repo_root: Path) -> dict:
+    """Map tracked top-level doc paths -> lifecycle status (via doc_lifecycle).
+
+    Imported lazily so ``doc_references`` stays importable without the lifecycle
+    engine present, and so callers can inject an explicit ``status_map`` in tests
+    without touching git or the filesystem.
+    """
+    from episteme import doc_lifecycle  # local import: avoid import-time coupling
+
+    root = Path(repo_root)
+    out: dict = {}
+    for rel in doc_lifecycle.tracked_docs(root):
+        marker = doc_lifecycle.parse_marker(root / rel)
+        out[rel] = marker.status if marker is not None else None
+    return out
+
+
+def find_stale_citations(
+    repo_root: Path,
+    doc_files: Optional[Sequence[str]] = None,
+    status_map: Optional[dict] = None,
+) -> List[StaleCitation]:
+    """Return every living-doc citation of a historical doc lacking a qualifier.
+
+    Rule (Mechanism 2): a ``status=living`` doc may cite a doc whose status is in
+    :data:`HISTORICAL_STATUSES` only if the citing line carries a word from
+    :data:`HISTORICAL_QUALIFIERS`. Otherwise the citation is a ``stale-citation``
+    finding.
+
+    ``status_map`` (doc path -> status) is injectable for tests; when ``None`` it
+    is derived from the lifecycle markers of the tracked corpus. ``doc_files``
+    (the citing set) defaults to the docs that carry a ``living`` status in the
+    map — the only docs the rule constrains.
+    """
+    root = Path(repo_root)
+    smap = status_map if status_map is not None else _lifecycle_status_map(root)
+    historical = {
+        rel for rel, st in smap.items() if st in HISTORICAL_STATUSES
+    }
+    if doc_files is None:
+        doc_files = sorted(rel for rel, st in smap.items() if st == "living")
+
+    findings: List[StaleCitation] = []
+    for rel in doc_files:
+        if smap.get(rel) != "living":
+            continue
+        if rel in EXEMPT_CITING_FILES or rel.startswith(EXEMPT_CITING_PREFIXES):
+            continue
+        try:
+            text = (root / rel).read_text(encoding="utf-8", errors="replace")
+        except (OSError, UnicodeError):
+            continue
+        lines = text.splitlines()
+        for ref in extract_references(text, rel):
+            if ref.target not in historical:
+                continue
+            line_text = lines[ref.line - 1] if 0 <= ref.line - 1 < len(lines) else ""
+            if _line_has_qualifier(line_text):
+                continue
+            findings.append(
+                StaleCitation(
+                    citing_file=rel,
+                    line=ref.line,
+                    raw=ref.raw,
+                    target=ref.target,
+                    target_status=smap[ref.target],
+                )
+            )
+    return findings
+
+
+def _format_stale_citations(findings: Sequence[StaleCitation]) -> str:
+    return "\n".join(
+        f"  {f.citing_file}:{f.line}  cites  {f.raw!r}  ->  {f.target} "
+        f"({f.target_status}, no historical qualifier)"
+        for f in findings
+    )
+
+
 if __name__ == "__main__":  # pragma: no cover
     import sys
 
     root = Path(__file__).resolve().parents[2]
+    exit_code = 0
     result = find_drift(root)
     if result:
         print(f"{len(result)} dangling doc->code reference(s):")
         print(_format_findings(result))
-        sys.exit(1)
-    print("doc references: clean")
+        exit_code = 1
+    stale = find_stale_citations(root)
+    if stale:
+        print(f"{len(stale)} stale citation(s) of historical docs by living docs:")
+        print(_format_stale_citations(stale))
+        exit_code = 1
+    if exit_code == 0:
+        print("doc references: clean")
+    sys.exit(exit_code)

--- a/tests/doc_references_baseline.txt
+++ b/tests/doc_references_baseline.txt
@@ -39,6 +39,5 @@ kernel/FALSIFIABILITY_CONDITIONS.md	core/hooks/_reasoning_surface_validator.py
 #
 # ── contract placeholders: per-project memory-contract docs, never instantiated ─
 docs/HARNESSES.md	docs/RUN_CONTEXT.md
-docs/LAYER_MODEL.md	docs/REQUIREMENTS.md
 docs/LAYER_MODEL.md	docs/RUN_CONTEXT.md
 skills/custom/requirements-to-plan/SKILL.md	docs/REQUIREMENTS.md

--- a/tests/test_doc_budget.py
+++ b/tests/test_doc_budget.py
@@ -13,16 +13,27 @@ content-key dedup + compaction. Two invariants:
 Registered against FAILURE_MODES: unbounded-accumulation (Event 145). The
 generation rate of doc artifacts had exceeded their consumption rate at every
 class; this test is the standing counter for the tracked-doc class.
+
+Event 147 reseat: the doc-lifecycle marker contract (``src/episteme/doc_lifecycle.py``)
+subsumes the ad-hoc corpus walk. This module now BOUNDS that engine — it runs
+``doc_lifecycle.lint()`` over the tracked corpus as the standing gate that every
+tracked ``docs/*.md`` carries a valid lifecycle marker (positive system), rather
+than duplicating a second parallel walk. The 32-file ceiling and the
+no-planning-state invariant are retained unchanged.
 """
 
 from __future__ import annotations
 
 import re
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from episteme import doc_lifecycle  # noqa: E402
 
 # Ceiling for tracked top-level ``docs/*.md``. Current tracked count is 31.
 # Bumping this is a deliberate act — change the number here and the edit is the
@@ -85,6 +96,25 @@ class NoPlanningStateInTrackedTree(unittest.TestCase):
             "private-only working memory (symlink to ~/episteme-private/docs, "
             "gitignore the symlink) — they may not be tracked anywhere in the "
             "tree. Found tracked:\n  " + "\n  ".join(offenders),
+        )
+
+
+class TrackedDocsCarryLifecycleMarker(unittest.TestCase):
+    """Reseat (Event 147): every tracked ``docs/*.md`` carries a valid marker.
+
+    This runs the portable lifecycle linter over the real corpus. A missing or
+    malformed marker (positive system — only the five enumerated statuses
+    validate) is a hard failure, so a new tracked doc cannot enter the tree
+    without a conscious lifecycle classification at creation.
+    """
+
+    def test_corpus_lint_is_clean(self):
+        findings = doc_lifecycle.lint(_REPO_ROOT)
+        self.assertEqual(
+            findings,
+            [],
+            "doc lifecycle marker violations in the tracked corpus:\n"
+            + doc_lifecycle.format_findings(findings),
         )
 
 

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -134,6 +134,54 @@ class LintFixtureTests(unittest.TestCase):
             self.assertEqual(dl.lint(root), [])
 
 
+class ReportSinkFixtureTests(unittest.TestCase):
+    """RED/GREEN: status=report is bounded to the config grandfather list
+    (Event 147, Mechanism 4). A non-grandfathered report doc is flagged; a
+    grandfathered one passes."""
+
+    def test_non_grandfathered_report_is_flagged(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            _add(
+                root,
+                "docs/NEW_REPORT.md",
+                "<!-- episteme-lifecycle: status=report; reviewed_as_of=E147 -->\n# R\n",
+            )
+            findings = dl.lint(root)
+            kinds = {(f.file, f.kind) for f in findings}
+            self.assertIn(("docs/NEW_REPORT.md", "report-sink"), kinds)
+
+    def test_grandfathered_report_is_clean(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            _add(
+                root,
+                "docs/EVALUATION_METHOD.md",
+                "<!-- episteme-lifecycle: status=report; reviewed_as_of=E147 -->\n# R\n",
+            )
+            # docs/EVALUATION_METHOD.md is in the default grandfather list.
+            self.assertEqual(dl.lint(root), [])
+
+    def test_config_can_extend_grandfather_list(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            (root / ".episteme").mkdir()
+            (root / ".episteme" / "config.json").write_text(
+                '{"report_grandfather": ["docs/NEW_REPORT.md"]}', encoding="utf-8"
+            )
+            _add(
+                root,
+                "docs/NEW_REPORT.md",
+                "<!-- episteme-lifecycle: status=report; reviewed_as_of=E147 -->\n# R\n",
+            )
+            # With NEW_REPORT.md grandfathered via config, no report-sink finding.
+            kinds = {(f.file, f.kind) for f in dl.lint(root)}
+            self.assertNotIn(("docs/NEW_REPORT.md", "report-sink"), kinds)
+
+
 class GenerateIndexTests(unittest.TestCase):
     def test_index_lists_docs_with_status_and_purpose(self):
         with TemporaryDirectory() as td:

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -1,0 +1,208 @@
+"""Tests for the doc/artifact lifecycle engine (Event 147, Mechanism 1).
+
+Red-green discipline: the synthetic-fixture tests below demonstrate ``lint``
+FAILING on a marker-less / malformed doc before the corpus test asserts the
+real repo is clean. The fixtures build throwaway git repos so ``tracked_docs``'
+``git ls-files`` walk exercises the real enumeration path.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from episteme import doc_lifecycle as dl
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _init_repo(root: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
+
+
+def _add(root: Path, rel: str, text: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    subprocess.run(["git", "add", rel], cwd=root, check=True)
+
+
+class ParseMarkerTests(unittest.TestCase):
+    def test_parse_living(self):
+        m = dl.parse_marker_text(
+            "<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->"
+        )
+        assert m is not None
+        self.assertEqual(m.status, "living")
+        self.assertEqual(m.reviewed_as_of, "E147")
+        self.assertIsNone(m.superseded_by)
+
+    def test_parse_design_history_with_superseded_by(self):
+        m = dl.parse_marker_text(
+            "<!-- episteme-lifecycle: status=design-history; "
+            "reviewed_as_of=E147; superseded_by=docs/DESIGN_V2_0_EPISTEMIC_ENGINE.md -->"
+        )
+        assert m is not None
+        self.assertEqual(m.status, "design-history")
+        self.assertEqual(m.superseded_by, "docs/DESIGN_V2_0_EPISTEMIC_ENGINE.md")
+
+    def test_parse_scope_on_living(self):
+        m = dl.parse_marker_text(
+            "<!-- episteme-lifecycle: status=living; reviewed_as_of=E147; "
+            "superseded_by=docs/DESIGN_V2_0_EPISTEMIC_ENGINE.md; "
+            "scope=enforcement-geometry-framing -->"
+        )
+        assert m is not None
+        self.assertEqual(m.scope, "enforcement-geometry-framing")
+
+    def test_no_marker_returns_none(self):
+        self.assertIsNone(dl.parse_marker_text("# Just a heading"))
+
+
+class LintFixtureTests(unittest.TestCase):
+    """RED: lint must flag marker-less / malformed docs in a synthetic repo."""
+
+    def test_missing_marker_is_flagged(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            _add(root, "docs/NO_MARKER.md", "# A doc with no lifecycle marker\n")
+            findings = dl.lint(root)
+            kinds = {(f.file, f.kind) for f in findings}
+            self.assertIn(("docs/NO_MARKER.md", "missing-marker"), kinds)
+
+    def test_invalid_status_is_flagged(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            _add(
+                root,
+                "docs/BAD_STATUS.md",
+                "<!-- episteme-lifecycle: status=archived; reviewed_as_of=E147 -->\n# x\n",
+            )
+            kinds = {(f.file, f.kind) for f in dl.lint(root)}
+            self.assertIn(("docs/BAD_STATUS.md", "invalid-status"), kinds)
+
+    def test_design_history_without_superseded_by_is_flagged(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            _add(
+                root,
+                "docs/DH.md",
+                "<!-- episteme-lifecycle: status=design-history; reviewed_as_of=E147 -->\n# x\n",
+            )
+            kinds = {(f.file, f.kind) for f in dl.lint(root)}
+            self.assertIn(("docs/DH.md", "missing-superseded-by"), kinds)
+
+    def test_missing_reviewed_as_of_is_flagged(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            _add(
+                root,
+                "docs/NR.md",
+                "<!-- episteme-lifecycle: status=living -->\n# x\n",
+            )
+            kinds = {(f.file, f.kind) for f in dl.lint(root)}
+            self.assertIn(("docs/NR.md", "missing-reviewed-as-of"), kinds)
+
+    def test_well_formed_doc_is_clean(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            _add(
+                root,
+                "docs/OK.md",
+                "<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->\n# Good\n",
+            )
+            self.assertEqual(dl.lint(root), [])
+
+    def test_symlink_is_skipped(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            _add(root, "real/PLAN.md", "# no marker here\n")
+            link = root / "docs" / "PLAN.md"
+            link.parent.mkdir(parents=True, exist_ok=True)
+            link.symlink_to(root / "real" / "PLAN.md")
+            subprocess.run(["git", "add", "docs/PLAN.md"], cwd=root, check=True)
+            self.assertEqual(dl.lint(root), [])
+
+
+class GenerateIndexTests(unittest.TestCase):
+    def test_index_lists_docs_with_status_and_purpose(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            _add(
+                root,
+                "docs/ALPHA.md",
+                "<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->\n"
+                "# Alpha — the first doc\n",
+            )
+            index = dl.generate_index(root)
+            self.assertIn("[`ALPHA.md`](./ALPHA.md)", index)
+            self.assertIn("living", index)
+            self.assertIn("Alpha — the first doc", index)
+
+    def test_update_readme_index_is_idempotent(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _init_repo(root)
+            _add(
+                root,
+                "docs/ALPHA.md",
+                "<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->\n# Alpha\n",
+            )
+            _add(
+                root,
+                "docs/README.md",
+                "<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->\n"
+                "# Index\n\n" + dl.INDEX_START + "\nOLD\n" + dl.INDEX_END + "\n",
+            )
+            changed1, _ = dl.update_readme_index(root)
+            self.assertTrue(changed1)
+            changed2, _ = dl.update_readme_index(root)
+            self.assertFalse(changed2)
+
+
+class ConfigDiscoveryTests(unittest.TestCase):
+    def test_defaults(self):
+        with TemporaryDirectory() as td:
+            cfg = dl.discover_config(Path(td))
+            self.assertEqual(cfg.docs_dir, "docs")
+            self.assertEqual(
+                cfg.report_grandfather, dl._DEFAULT_REPORT_GRANDFATHER
+            )
+
+    def test_pyproject_override(self):
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "pyproject.toml").write_text(
+                "[tool.episteme]\ndocs_dir = \"documentation\"\n",
+                encoding="utf-8",
+            )
+            cfg = dl.discover_config(root)
+            self.assertEqual(cfg.docs_dir, "documentation")
+
+
+class RepoCorpusTests(unittest.TestCase):
+    """GREEN: the real repo corpus is clean once every doc is stamped."""
+
+    def test_repo_corpus_is_clean(self):
+        findings = dl.lint(_REPO_ROOT)
+        self.assertEqual(
+            findings,
+            [],
+            "doc lifecycle violations in the tracked corpus:\n"
+            + dl.format_findings(findings),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_doc_references.py
+++ b/tests/test_doc_references.py
@@ -421,5 +421,104 @@ class RealCorpusHasNoNewDrift(unittest.TestCase):
             )
 
 
+class StaleCitationCascadeTests(unittest.TestCase):
+    """Cascade gate (Event 147, Mechanism 2): a status=living doc may cite a
+    design-history/tombstone doc only if the citing LINE carries a historical
+    qualifier. status_map + doc_files are injectable so fixtures need no git."""
+
+    def _repo(self, d):
+        root = Path(d)
+        (root / "docs").mkdir()
+        return root
+
+    def test_living_citing_historical_without_qualifier_is_flagged(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = self._repo(d)
+            (root / "docs" / "OLD.md").write_text("# old\n")
+            (root / "docs" / "LIVE.md").write_text(
+                "current design lives in `docs/OLD.md`\n"
+            )
+            findings = dr.find_stale_citations(
+                root,
+                doc_files=["docs/LIVE.md"],
+                status_map={"docs/LIVE.md": "living", "docs/OLD.md": "design-history"},
+            )
+            self.assertEqual(1, len(findings))
+            self.assertEqual("docs/OLD.md", findings[0].target)
+            self.assertEqual("design-history", findings[0].target_status)
+            self.assertEqual("docs/LIVE.md", findings[0].citing_file)
+
+    def test_living_citing_historical_with_qualifier_is_clean(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = self._repo(d)
+            (root / "docs" / "OLD.md").write_text("# old\n")
+            (root / "docs" / "LIVE.md").write_text(
+                "superseded by v2; see the historical `docs/OLD.md`\n"
+            )
+            findings = dr.find_stale_citations(
+                root,
+                doc_files=["docs/LIVE.md"],
+                status_map={"docs/LIVE.md": "living", "docs/OLD.md": "design-history"},
+            )
+            self.assertEqual([], findings)
+
+    def test_tombstone_target_is_also_gated(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = self._repo(d)
+            (root / "docs" / "GONE.md").write_text("# gone\n")
+            (root / "docs" / "LIVE.md").write_text("see `docs/GONE.md`\n")
+            findings = dr.find_stale_citations(
+                root,
+                doc_files=["docs/LIVE.md"],
+                status_map={"docs/LIVE.md": "living", "docs/GONE.md": "tombstone"},
+            )
+            self.assertEqual(1, len(findings))
+            self.assertEqual("tombstone", findings[0].target_status)
+
+    def test_non_living_citer_is_not_gated(self):
+        # A design-history doc citing another historical doc is not a living
+        # edge; the rule only constrains living citers.
+        with tempfile.TemporaryDirectory() as d:
+            root = self._repo(d)
+            (root / "docs" / "OLD.md").write_text("# old\n")
+            (root / "docs" / "ALSO_OLD.md").write_text("see `docs/OLD.md`\n")
+            findings = dr.find_stale_citations(
+                root,
+                doc_files=["docs/ALSO_OLD.md"],
+                status_map={
+                    "docs/ALSO_OLD.md": "design-history",
+                    "docs/OLD.md": "design-history",
+                },
+            )
+            self.assertEqual([], findings)
+
+    def test_living_citing_living_is_not_gated(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = self._repo(d)
+            (root / "docs" / "OTHER.md").write_text("# other\n")
+            (root / "docs" / "LIVE.md").write_text("see `docs/OTHER.md`\n")
+            findings = dr.find_stale_citations(
+                root,
+                doc_files=["docs/LIVE.md"],
+                status_map={"docs/LIVE.md": "living", "docs/OTHER.md": "living"},
+            )
+            self.assertEqual([], findings)
+
+
+class RealCorpusHasNoStaleCitations(unittest.TestCase):
+    """THE cascade guardrail on the real corpus: no living doc cites a
+    design-history/tombstone doc without a historical qualifier."""
+
+    def test_no_stale_citations_in_corpus(self):
+        findings = dr.find_stale_citations(_REPO_ROOT)
+        if findings:
+            self.fail(
+                f"{len(findings)} stale citation(s) of historical docs by living "
+                f"docs:\n{dr._format_stale_citations(findings)}\n\n"
+                "Add a historical qualifier (superseded / retired / historical / "
+                "archive / design-history) to the citing line, or repoint it."
+            )
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/tests/test_memory_set_status.py
+++ b/tests/test_memory_set_status.py
@@ -1,0 +1,191 @@
+"""Event 147 · A3 — memory-record status writer + promote auto-transition.
+
+Covers the D11 gap: the status enum {active, archived, superseded} existed on
+every ``.memory.json`` record and ``memory list --status`` filtered on it, but
+nothing could transition a record. Two mechanisms under test:
+
+1. ``episteme memory set-status <id> <status>`` — the explicit writer
+   (``cli._memory_set_status``): the transition persists to disk and
+   ``memory list --status`` then filters on the new state.
+2. Promote auto-transition — ``_memory_promote.supersede_promoted_sources``
+   (and its wiring through ``run_promote(records_dir=...)``) marks a source
+   record superseded when a promotion copies its evidence into a proposal.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from episteme import cli
+from episteme import _memory_promote as mp
+
+
+def _record(rec_id: str, cls: str = "episodic", status: str = "active") -> dict:
+    return {
+        "id": rec_id,
+        "memory_class": cls,
+        "summary": f"record {rec_id}",
+        "details": {},
+        "provenance": {
+            "source_type": "human",
+            "source_ref": "cli",
+            "captured_at": "2026-07-08T00:00:00Z",
+            "captured_by": "test",
+            "confidence": "medium",
+            "evidence_refs": [],
+        },
+        "status": status,
+        "version": "memory-contract-v1",
+    }
+
+
+def _write_record(records_dir: Path, rec: dict) -> Path:
+    cls_dir = records_dir / rec["memory_class"]
+    cls_dir.mkdir(parents=True, exist_ok=True)
+    path = cls_dir / f"{rec['id']}.memory.json"
+    path.write_text(json.dumps(rec, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+class SetStatusWriter(unittest.TestCase):
+    def test_transition_persists(self):
+        with tempfile.TemporaryDirectory() as td:
+            records_dir = Path(td) / "records"
+            path = _write_record(records_dir, _record("rec-1"))
+            with patch.object(cli, "MEMORY_RECORDS_DIR", records_dir):
+                rc = cli._memory_set_status("rec-1", "archived")
+            self.assertEqual(rc, 0)
+            persisted = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["status"], "archived")
+            # The rest of the record is preserved verbatim.
+            self.assertEqual(persisted["summary"], "record rec-1")
+
+    def test_unknown_id_returns_error(self):
+        with tempfile.TemporaryDirectory() as td:
+            records_dir = Path(td) / "records"
+            _write_record(records_dir, _record("rec-1"))
+            with patch.object(cli, "MEMORY_RECORDS_DIR", records_dir):
+                rc = cli._memory_set_status("does-not-exist", "archived")
+            self.assertEqual(rc, 1)
+
+    def test_list_status_filter_reflects_transition(self):
+        with tempfile.TemporaryDirectory() as td:
+            records_dir = Path(td) / "records"
+            _write_record(records_dir, _record("rec-active"))
+            _write_record(records_dir, _record("rec-2"))
+            with patch.object(cli, "MEMORY_RECORDS_DIR", records_dir):
+                cli._memory_set_status("rec-2", "superseded")
+                # After transition, only rec-active is active; rec-2 is superseded.
+                import io
+                import contextlib
+
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    cli._memory_list(memory_class=None, status="active", limit=20)
+                active_out = buf.getvalue()
+                self.assertIn("rec-active", active_out)
+                self.assertNotIn("rec-2", active_out)
+
+                buf2 = io.StringIO()
+                with contextlib.redirect_stdout(buf2):
+                    cli._memory_list(memory_class=None, status="superseded", limit=20)
+                superseded_out = buf2.getvalue()
+                self.assertIn("rec-2", superseded_out)
+
+
+class PromoteAutoTransition(unittest.TestCase):
+    def test_supersede_promoted_sources_marks_matches(self):
+        with tempfile.TemporaryDirectory() as td:
+            records_dir = Path(td) / "records"
+            kept = _write_record(records_dir, _record("keep-me"))
+            promoted = _write_record(records_dir, _record("promoted-1"))
+            proposals = [{"evidence_refs": ["promoted-1", "ghost-id"]}]
+            n = mp.supersede_promoted_sources(proposals, records_dir)
+            self.assertEqual(n, 1)
+            self.assertEqual(
+                json.loads(promoted.read_text())["status"], "superseded"
+            )
+            # A record not referenced stays active.
+            self.assertEqual(json.loads(kept.read_text())["status"], "active")
+
+    def test_idempotent(self):
+        with tempfile.TemporaryDirectory() as td:
+            records_dir = Path(td) / "records"
+            _write_record(records_dir, _record("promoted-1"))
+            proposals = [{"evidence_refs": ["promoted-1"]}]
+            first = mp.supersede_promoted_sources(proposals, records_dir)
+            second = mp.supersede_promoted_sources(proposals, records_dir)
+            self.assertEqual(first, 1)
+            self.assertEqual(second, 0, "already-superseded records are skipped")
+
+    def test_no_refs_is_noop(self):
+        with tempfile.TemporaryDirectory() as td:
+            records_dir = Path(td) / "records"
+            _write_record(records_dir, _record("a"))
+            self.assertEqual(mp.supersede_promoted_sources([], records_dir), 0)
+
+    def test_run_promote_wires_transition(self):
+        """End-to-end: a clusterable episodic set promotes, and the matching
+        source record under records_dir is superseded."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            # Build 3 clusterable episodic jsonl records with ids r0..r2.
+            episodic = tmp / "episodic"
+            episodic.mkdir()
+            recs = []
+            for i in range(3):
+                recs.append({
+                    "id": f"r{i}",
+                    "memory_class": "episodic",
+                    "summary": "bash: git push",
+                    "details": {
+                        "exit_code": 0,
+                        "high_impact_patterns_matched": ["git push"],
+                        "reasoning_surface": {"domain": "Complicated"},
+                    },
+                    "provenance": {"captured_at": "2026-07-08T00:00:00Z"},
+                    "status": "active",
+                    "version": "memory-contract-v1",
+                })
+            (episodic / "2026-07-08.jsonl").write_text(
+                "\n".join(json.dumps(r) for r in recs) + "\n", encoding="utf-8"
+            )
+            # Matching source .memory.json records under a records dir.
+            records_dir = tmp / "records"
+            for i in range(3):
+                _write_record(records_dir, _record(f"r{i}"))
+
+            report, count, path = mp.run_promote(
+                episodic_dir=episodic,
+                reflective_dir=tmp / "reflective",
+                records_dir=records_dir,
+            )
+            self.assertEqual(count, 1)
+            for i in range(3):
+                rec_path = records_dir / "episodic" / f"r{i}.memory.json"
+                self.assertEqual(
+                    json.loads(rec_path.read_text())["status"],
+                    "superseded",
+                    f"r{i} should be superseded after promotion",
+                )
+
+    def test_run_promote_without_records_dir_leaves_records_untouched(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            episodic = tmp / "episodic"
+            episodic.mkdir()
+            (episodic / "e.jsonl").write_text("", encoding="utf-8")
+            records_dir = tmp / "records"
+            path = _write_record(records_dir, _record("r0"))
+            mp.run_promote(
+                episodic_dir=episodic,
+                reflective_dir=tmp / "reflective",
+            )
+            self.assertEqual(json.loads(path.read_text())["status"], "active")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_context_doc_staleness.py
+++ b/tests/test_session_context_doc_staleness.py
@@ -1,0 +1,130 @@
+"""Event 147 · A3 — SessionStart doc-lifecycle staleness banner.
+
+Covers ``_doc_staleness_line()``: the silent-on-zero advisory that counts
+tracked ``status=living`` docs whose ``reviewed_as_of`` lags the corpus by
+more than 15 events (or 45 days when the marker carries a date). Same
+discipline as ``_reaper_line`` — silent on the fresh-corpus session, one line
+otherwise, never raises.
+
+The producer globs ``docs/*.md`` relative to cwd (the hook runs with cwd =
+project root), so these tests build a throwaway docs/ tree and chdir into it.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from core.hooks import session_context as sc  # pyright: ignore[reportAttributeAccessIssue]
+
+
+@contextmanager
+def _chdir(path: Path):
+    prev = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev)
+
+
+def _marker(status: str, reviewed: str) -> str:
+    return f"<!-- episteme-lifecycle: status={status}; reviewed_as_of={reviewed} -->\n# Title\n"
+
+
+def _write_doc(docs: Path, name: str, status: str, reviewed: str) -> None:
+    (docs / name).write_text(_marker(status, reviewed), encoding="utf-8")
+
+
+class DocStalenessBanner(unittest.TestCase):
+    def test_no_docs_dir_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            with _chdir(Path(td)):
+                self.assertIsNone(sc._doc_staleness_line())
+
+    def test_zero_case_emits_nothing(self):
+        """All living docs within the 15-event window ⇒ silent."""
+        with tempfile.TemporaryDirectory() as td:
+            docs = Path(td) / "docs"
+            docs.mkdir()
+            (docs / "EVENTS.md").write_text("# Events\n- E200 something\n", encoding="utf-8")
+            _write_doc(docs, "A.md", "living", "E200")
+            _write_doc(docs, "B.md", "living", "E190")  # lag 10 ≤ 15
+            with _chdir(Path(td)):
+                self.assertIsNone(sc._doc_staleness_line())
+
+    def test_stale_case_emits_one_line(self):
+        """A living doc lagging >15 events ⇒ exactly one advisory line."""
+        with tempfile.TemporaryDirectory() as td:
+            docs = Path(td) / "docs"
+            docs.mkdir()
+            (docs / "EVENTS.md").write_text("# Events\n- E200\n- E147\n", encoding="utf-8")
+            _write_doc(docs, "A.md", "living", "E200")  # fresh
+            _write_doc(docs, "B.md", "living", "E147")  # lag 53 > 15 ⇒ stale
+            _write_doc(docs, "C.md", "living", "E100")  # lag 100 > 15 ⇒ stale
+            with _chdir(Path(td)):
+                line = sc._doc_staleness_line()
+            self.assertIsNotNone(line)
+            assert line is not None
+            self.assertEqual(line.count("\n"), 0, "must emit exactly one line")
+            self.assertIn("doc-staleness: 2 living docs", line)
+            self.assertIn("episteme docs lint", line)
+
+    def test_non_living_status_ignored(self):
+        """design-history / report / spec-implemented never count as stale."""
+        with tempfile.TemporaryDirectory() as td:
+            docs = Path(td) / "docs"
+            docs.mkdir()
+            (docs / "EVENTS.md").write_text("E200\n", encoding="utf-8")
+            _write_doc(docs, "A.md", "design-history", "E10")
+            _write_doc(docs, "B.md", "report", "E10")
+            _write_doc(docs, "C.md", "spec-implemented", "E10")
+            with _chdir(Path(td)):
+                self.assertIsNone(sc._doc_staleness_line())
+
+    def test_date_fallback_when_no_events_index(self):
+        """No EVENTS.md ⇒ event-tagged docs skip; dated docs use the 45-day rule."""
+        old = (datetime.now(timezone.utc) - timedelta(days=100)).strftime("%Y-%m-%d")
+        fresh = (datetime.now(timezone.utc) - timedelta(days=5)).strftime("%Y-%m-%d")
+        with tempfile.TemporaryDirectory() as td:
+            docs = Path(td) / "docs"
+            docs.mkdir()
+            _write_doc(docs, "A.md", "living", old)      # >45 days ⇒ stale
+            _write_doc(docs, "B.md", "living", fresh)    # within window
+            _write_doc(docs, "C.md", "living", "E10")    # event-tagged, no index ⇒ skip
+            with _chdir(Path(td)):
+                line = sc._doc_staleness_line()
+            self.assertIsNotNone(line)
+            assert line is not None
+            self.assertIn("doc-staleness: 1 living docs", line)
+
+    def test_symlinked_doc_skipped(self):
+        """Private planning docs are symlinked and lifecycle-exempt."""
+        with tempfile.TemporaryDirectory() as td:
+            docs = Path(td) / "docs"
+            docs.mkdir()
+            (docs / "EVENTS.md").write_text("E200\n", encoding="utf-8")
+            real = Path(td) / "PLAN_real.md"
+            real.write_text(_marker("living", "E10"), encoding="utf-8")
+            try:
+                (docs / "PLAN.md").symlink_to(real)
+            except (OSError, NotImplementedError):
+                self.skipTest("symlinks unsupported on this platform")
+            with _chdir(Path(td)):
+                self.assertIsNone(sc._doc_staleness_line())
+
+    def test_never_raises_on_unparseable_reviewed(self):
+        with tempfile.TemporaryDirectory() as td:
+            docs = Path(td) / "docs"
+            docs.mkdir()
+            (docs / "EVENTS.md").write_text("E200\n", encoding="utf-8")
+            _write_doc(docs, "A.md", "living", "garbage-value")
+            with _chdir(Path(td)):
+                self.assertIsNone(sc._doc_staleness_line())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Closes the back half of the doc/artifact lifecycle (deprecate → archive → delete were previously unautomated everywhere except cascade/fence markers). Operator-ratified Event 147 cycle; design spec derived from the E147 20-agent audit (15 load-bearing claims adversarially verified, 0 refuted).

**Mechanism 1 — lifecycle marker contract** (`src/episteme/doc_lifecycle.py`, new, portable):
- Every tracked `docs/*.md` carries a render-invisible line-1 marker: `<!-- episteme-lifecycle: status=…; reviewed_as_of=… -->`; statuses are a positive system: `living | spec-implemented | design-history | report | tombstone`.
- `episteme docs lint` / `episteme docs index [--check]` CLI; `tests/test_doc_budget.py` reseated onto `lint()` (bounds the prior ad-hoc walk — anti-accretion; 32-file ceiling kept).
- All 31 docs stamped per the ratified tier map (23 living incl. the signed-surface trio which documents LIVE subsystems; DESIGN_V1 living + scoped supersession note; 3 spec-implemented; LIVE_REKOR design-history; 3 report). Config discovery via `[tool.episteme]` / `.episteme/config.json` — portable to any repo.

**Mechanism 2 — retirement cascade gate** (`doc_references.py`): a living doc citing a design-history/tombstone doc without a historical qualifier is a `stale-citation` finding (CI-gated). The class of drift this kills: README/LAYER_MODEL still pointing at retired PROGRESS.md.

**Mechanism 4 — report sink**: `status=report` in `docs/` allowed only for the 3 grandfathered files (config-overridable); new reports land in `archive/reports/`. Contract documented in MEMORY_CONTRACT.md.

**Mechanism 5 — staleness banner** (`session_context.py`): silent-on-zero SessionStart line when living docs' `reviewed_as_of` lags >15 events (45-day date fallback); `_reaper_line` idiom, never raises. No operator queue anywhere (M1 constraint).

**Plus**: `episteme memory set-status` writer + promote auto-transition (closes the write-once status enum D11 gap), and 9 adversarially-verified content-drift repairs (stale PROGRESS citations, nonexistent REQUIREMENTS/RUN_CONTEXT references, `pip install episteme` removal, version-string volatile-fact markers, HOOKS.md regenerated from `build_settings()`, self-healing docs/README index).

## Verification

- Full suite in worktree: **1547 passed, 11 skipped, 76 subtests** (baseline 1518; +29 new tests), `episteme docs lint` clean, `episteme docs index --check` clean, `episteme doctor` 14 ok/0/0.
- Red-green demonstrated: corpus lint failed on unmarked docs before stamping; fixture tests cover missing-marker/invalid-status/missing-superseded-by/report-sink/stale-citation.
- Independent adversarial review (fail-open hunt, M1 check, portability check, own suite re-run): **CLEAN** — one minor cosmetic finding (banner wording on date-fallback), deferred with rationale.

## Merge order

Merge this PR **before** #112 — both touch `cli.py`; the other PR rebases trivially if needed.
