### PR TITLE
feat(spot-check): backpressure on the operator-queue write-path (Event 148, M1)

### DIFF
--- a/core/hooks/_spot_check.py
+++ b/core/hooks/_spot_check.py
@@ -74,6 +74,7 @@ import json
 import os
 import random
 import sys
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -82,6 +83,13 @@ from typing import Any, Iterable, Literal
 _HOOKS_DIR = Path(__file__).resolve().parent
 if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
+
+# src/episteme — for the D11 cognitive-budget fatigue signal (Event 148).
+# Mirrors _arm_a_post.py's path bootstrap. The import stays lazy (inside
+# _fatigue_active) so module load never hard-depends on the package.
+_SRC_DIR = _HOOKS_DIR.parent.parent / "src"
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
 
 from _chain import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     ChainError,
@@ -110,6 +118,22 @@ MULTIPLIER_SYNTHESIS_PRODUCED = 2.0
 MULTIPLIER_BLUEPRINT_D_RESOLUTION = 2.0
 
 SKIP_TTL_SECONDS = 7 * 24 * 60 * 60
+
+# Enqueue backpressure (Event 148, M1). The spot-check queue is
+# operator-facing and drained manually; automatic enqueue paired with a
+# manual-only drain is unbounded-accumulation-prone (the live queue
+# reached ~490 pending / 0 verdicts). ``maybe_sample`` consults
+# ``count_pending()`` before every append and declines silently once the
+# pending set reaches the cap.
+#
+# Config choice: a global env var ``EPISTEME_SPOT_CHECK_CAP`` (integer)
+# overrides ``DEFAULT_PENDING_CAP``. Chosen over the per-project
+# ``.episteme/spot_check_rate`` file idiom deliberately — the sampling
+# *rate* is a per-project tuning knob (how much to sample in this repo),
+# but the pending *cap* is a global safety bound on operator review
+# load, so it takes a global knob rather than a per-project one.
+DEFAULT_PENDING_CAP = 100
+_SKIP_COUNTER_FILENAME = "spot_check_skipped.json"
 
 # Enum allow-lists — enforced by the CLI verdict writer.
 SURFACE_VALIDITY_VALUES = frozenset({"real", "vapor", "wrong_blueprint"})
@@ -143,6 +167,18 @@ def _anchor_path() -> Path:
 
 def _project_override_path(cwd: Path) -> Path:
     return cwd / ".episteme" / "spot_check_rate"
+
+
+def _skip_counter_path() -> Path:
+    return _episteme_home() / "state" / _SKIP_COUNTER_FILENAME
+
+
+def _reflective_dir() -> Path:
+    """Cognitive-budget approval-history dir, resolved EPISTEME_HOME-aware
+    so test ``EphemeralHome`` isolation and production both land correctly.
+    Equals ``_cognitive_budget.DEFAULT_REFLECTIVE_DIR`` when EPISTEME_HOME
+    is unset."""
+    return _episteme_home() / "memory" / "reflective"
 
 
 # ---------------------------------------------------------------------------
@@ -271,7 +307,7 @@ class SampleResult:
     effective_rate: float
     multipliers: tuple[str, ...]
     entry_hash: str | None
-    reason: str  # "queued" | "rate_zero" | "already_queued" | "random_miss" | "error"
+    reason: str  # "queued" | "rate_zero" | "already_queued" | "random_miss" | "cap_exceeded" | "fatigue_skip" | "error"
 
 
 def _correlation_already_queued(
@@ -291,6 +327,127 @@ def _correlation_already_queued(
     return False
 
 
+# ---------------------------------------------------------------------------
+# Enqueue backpressure (Event 148, M1)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_pending_cap(explicit: int | None = None) -> int:
+    """Resolve the pending-queue cap. Precedence: explicit arg (test
+    seam) > ``EPISTEME_SPOT_CHECK_CAP`` env var > ``DEFAULT_PENDING_CAP``.
+    Non-parseable / negative values fall back to the default — a bad knob
+    must never break the admit path. Never raises."""
+    if explicit is not None:
+        try:
+            return max(0, int(explicit))
+        except (TypeError, ValueError):
+            return DEFAULT_PENDING_CAP
+    raw = os.environ.get("EPISTEME_SPOT_CHECK_CAP", "").strip()
+    if raw:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            pass
+    return DEFAULT_PENDING_CAP
+
+
+def read_skip_counter(path: Path | None = None) -> dict:
+    """Read the backpressure skip sidecar. Returns
+    ``{"skipped_count": int, ...}`` — ``{"skipped_count": 0}`` when the
+    sidecar is absent or unreadable. Never raises.
+
+    SessionStart may later surface this counter; emitting that banner is
+    OUT OF SCOPE for Event 148 (follow-up) — this reader exists so the
+    counter is inspectable/testable now."""
+    target = path if path is not None else _skip_counter_path()
+    try:
+        if target.is_file():
+            data = json.loads(target.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(
+                data.get("skipped_count"), int
+            ):
+                return data
+    except (OSError, json.JSONDecodeError, ValueError):
+        pass
+    return {"skipped_count": 0}
+
+
+def _bump_skip_counter(
+    reason: str, now: datetime, *, path: Path | None = None
+) -> int | None:
+    """Monotonically increment the backpressure skip counter via an
+    atomic temp+rename (same discipline as the fence/cascade markers).
+    Returns the new count, or None if the write degraded. Never raises —
+    a counter-write failure must not block the admit path (the entry is
+    already being skipped for backpressure regardless)."""
+    target = path if path is not None else _skip_counter_path()
+    current = read_skip_counter(target).get("skipped_count", 0)
+    if not isinstance(current, int) or current < 0:
+        current = 0
+    payload = {
+        "skipped_count": current + 1,
+        "last_skipped_at": _iso(now),
+        "last_reason": reason,
+    }
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            prefix=target.name + ".tmp-", dir=str(target.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f, ensure_ascii=False)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, target)
+        except OSError:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            return None
+    except OSError:
+        return None
+    return current + 1
+
+
+def _fatigue_active(
+    cwd: Path | None, reflective_dir: Path | None
+) -> bool:
+    """D11 wiring (Event 148). True when the operator cognitive-budget
+    stream currently shows an ``attention_bottleneck`` fatigue signal —
+    the operator is approving too fast to be reviewing carefully. Piling
+    more review items onto a fatigued operator is exactly the
+    accumulation this lane bounds, so a live fatigue signal is an
+    additional enqueue-skip condition.
+
+    Evidence-gated and inert by default: approval-time capture is manual
+    today (``_cognitive_budget`` auto-instrumentation is deferred), so an
+    empty stream yields no signal and this gate is a no-op — the hard
+    pending cap remains the safety net. Never raises; fails toward *not
+    fatigued* (enqueue) when the budget module is unavailable."""
+    try:
+        from episteme import (  # type: ignore  # pyright: ignore[reportMissingImports]
+            _cognitive_budget as cb,
+        )
+    except Exception:
+        return False
+    try:
+        rdir = reflective_dir if reflective_dir is not None else _reflective_dir()
+        window, p50, rate = cb.load_thresholds(
+            cwd if cwd is not None else Path.cwd()
+        )
+        signal = cb.detect_fatigue(
+            window=window,
+            p50_threshold_seconds=p50,
+            sub_second_rate_threshold=rate,
+            reflective_dir=rdir,
+        )
+        return signal is not None
+    except Exception:
+        return False
+
+
 def maybe_sample(
     *,
     correlation_id: str,
@@ -304,6 +461,9 @@ def maybe_sample(
     now: datetime | None = None,
     rng: random.Random | None = None,
     path: Path | None = None,
+    cap: int | None = None,
+    reflective_dir: Path | None = None,
+    skip_counter_path: Path | None = None,
 ) -> SampleResult:
     """Decide whether to sample this admitted op and queue the entry
     if so. Idempotent by ``correlation_id`` — a second call with the
@@ -350,6 +510,34 @@ def maybe_sample(
                 entry_hash=None, reason="random_miss",
             )
 
+        target = path if path is not None else _queue_path()
+
+        # Backpressure (Event 148, M1). Consult the pending set BEFORE
+        # appending. count_pending only runs on the sampled path (post
+        # dice-roll, ~base-rate of ops), and the cap keeps the pending
+        # set bounded going forward so this read stays cheap. A count
+        # error fails toward enqueue — the cap must NEVER block the hook
+        # or lose an existing entry.
+        cap_value = _resolve_pending_cap(cap)
+        try:
+            pending = count_pending(path=target, now=now_dt)
+        except Exception:
+            pending = None
+        if pending is not None and pending >= cap_value:
+            _bump_skip_counter("cap_exceeded", now_dt, path=skip_counter_path)
+            return SampleResult(
+                queued=False, correlation_id=correlation_id,
+                effective_rate=rate, multipliers=tuple(multipliers),
+                entry_hash=None, reason="cap_exceeded",
+            )
+        if _fatigue_active(cwd, reflective_dir):
+            _bump_skip_counter("fatigue", now_dt, path=skip_counter_path)
+            return SampleResult(
+                queued=False, correlation_id=correlation_id,
+                effective_rate=rate, multipliers=tuple(multipliers),
+                entry_hash=None, reason="fatigue_skip",
+            )
+
         payload = {
             "type": ENTRY_TYPE,
             "correlation_id": correlation_id,
@@ -361,7 +549,6 @@ def maybe_sample(
             "multipliers_applied": multipliers,
             "effective_rate_at_sample": rate,
         }
-        target = path if path is not None else _queue_path()
         envelope = _chain_append(target, payload)
         return SampleResult(
             queued=True, correlation_id=correlation_id,

--- a/tests/test_spot_check.py
+++ b/tests/test_spot_check.py
@@ -527,5 +527,195 @@ class BuildPostContext(unittest.TestCase):
             self.assertIsNone(ctx)
 
 
+# ---------- Enqueue backpressure (Event 148, M1) ------------------------
+
+
+def _force_queue(correlation_id: str, cwd_dir, **overrides):
+    """Force-queue one entry at rate 1.0 (no cap) under the current
+    EphemeralHome. Caller supplies a project cwd carrying spot_check_rate."""
+    return _spot_check.maybe_sample(
+        **_sample_inputs(correlation_id=correlation_id, **overrides),
+        cwd=cwd_dir,
+    )
+
+
+class EnqueueBackpressure(unittest.TestCase):
+    def _cwd_rate_one(self, stack):
+        cwd = stack.enter_context(tempfile.TemporaryDirectory())
+        (Path(cwd) / ".episteme").mkdir()
+        (Path(cwd) / ".episteme" / "spot_check_rate").write_text("1.0\n")
+        return Path(cwd)
+
+    def test_at_cap_does_not_enqueue_and_bumps_skip_counter(self):
+        import contextlib
+        with EphemeralHome(), contextlib.ExitStack() as stack:
+            cwd = self._cwd_rate_one(stack)
+            # Seed one entry, then cap=1 → the second sample is at cap.
+            r0 = _force_queue("cid-0", cwd)
+            self.assertTrue(r0.queued)
+            self.assertEqual(_spot_check.count_pending(), 1)
+            r1 = _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-1"), cwd=cwd, cap=1
+            )
+            self.assertFalse(r1.queued)
+            self.assertEqual(r1.reason, "cap_exceeded")
+            # No new entry — the existing entry is untouched.
+            self.assertEqual(len(_spot_check.list_entries()), 1)
+            # Skip counter incremented.
+            self.assertEqual(
+                _spot_check.read_skip_counter()["skipped_count"], 1
+            )
+
+    def test_skip_counter_is_monotonic(self):
+        import contextlib
+        with EphemeralHome(), contextlib.ExitStack() as stack:
+            cwd = self._cwd_rate_one(stack)
+            _force_queue("cid-0", cwd)
+            for i in range(3):
+                _spot_check.maybe_sample(
+                    **_sample_inputs(correlation_id=f"over-{i}"),
+                    cwd=cwd, cap=1,
+                )
+            self.assertEqual(
+                _spot_check.read_skip_counter()["skipped_count"], 3
+            )
+            self.assertEqual(len(_spot_check.list_entries()), 1)
+
+    def test_below_cap_enqueues_as_today(self):
+        import contextlib
+        with EphemeralHome(), contextlib.ExitStack() as stack:
+            cwd = self._cwd_rate_one(stack)
+            _force_queue("cid-0", cwd)
+            _force_queue("cid-1", cwd)
+            r2 = _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-2"), cwd=cwd, cap=5
+            )
+            self.assertTrue(r2.queued)
+            self.assertEqual(r2.reason, "queued")
+            self.assertEqual(len(_spot_check.list_entries()), 3)
+            # No backpressure skip recorded.
+            self.assertEqual(
+                _spot_check.read_skip_counter()["skipped_count"], 0
+            )
+
+    def test_default_cap_is_100(self):
+        # Below the default cap, sampling behaves as today with no
+        # explicit cap argument.
+        import contextlib
+        with EphemeralHome(), contextlib.ExitStack() as stack:
+            cwd = self._cwd_rate_one(stack)
+            r = _force_queue("cid-0", cwd)
+            self.assertTrue(r.queued)
+            self.assertEqual(_spot_check._resolve_pending_cap(), 100)
+
+    def test_env_var_overrides_cap(self):
+        import contextlib
+        orig = os.environ.get("EPISTEME_SPOT_CHECK_CAP")
+        os.environ["EPISTEME_SPOT_CHECK_CAP"] = "1"
+        try:
+            with EphemeralHome(), contextlib.ExitStack() as stack:
+                cwd = self._cwd_rate_one(stack)
+                _force_queue("cid-0", cwd)
+                r1 = _force_queue("cid-1", cwd)
+                self.assertFalse(r1.queued)
+                self.assertEqual(r1.reason, "cap_exceeded")
+        finally:
+            if orig is None:
+                os.environ.pop("EPISTEME_SPOT_CHECK_CAP", None)
+            else:
+                os.environ["EPISTEME_SPOT_CHECK_CAP"] = orig
+
+    def test_malformed_cap_env_falls_back_to_default(self):
+        orig = os.environ.get("EPISTEME_SPOT_CHECK_CAP")
+        os.environ["EPISTEME_SPOT_CHECK_CAP"] = "not-a-number"
+        try:
+            self.assertEqual(_spot_check._resolve_pending_cap(), 100)
+        finally:
+            if orig is None:
+                os.environ.pop("EPISTEME_SPOT_CHECK_CAP", None)
+            else:
+                os.environ["EPISTEME_SPOT_CHECK_CAP"] = orig
+
+    def test_malformed_queue_file_failsafe(self):
+        # A corrupt queue file must never raise past the boundary and
+        # must never spuriously block (cap check fails toward enqueue).
+        import contextlib
+        with EphemeralHome() as home, contextlib.ExitStack() as stack:
+            cwd = self._cwd_rate_one(stack)
+            qpath = home / "state" / "spot_check_queue.jsonl"
+            qpath.parent.mkdir(parents=True, exist_ok=True)
+            qpath.write_text("{ this is not valid json\n@@@garbage@@@\n")
+            # Must not raise; must not falsely report cap_exceeded.
+            result = _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-x"), cwd=cwd, cap=1
+            )
+            self.assertIsInstance(result, _spot_check.SampleResult)
+            self.assertNotEqual(result.reason, "cap_exceeded")
+
+    def test_read_skip_counter_absent_returns_zero(self):
+        with EphemeralHome():
+            self.assertEqual(
+                _spot_check.read_skip_counter()["skipped_count"], 0
+            )
+
+
+class FatigueGate(unittest.TestCase):
+    """D11 wiring — a live operator-fatigue signal is an additional
+    enqueue-skip condition."""
+
+    def _cwd_rate_one(self, stack):
+        cwd = stack.enter_context(tempfile.TemporaryDirectory())
+        (Path(cwd) / ".episteme").mkdir()
+        (Path(cwd) / ".episteme" / "spot_check_rate").write_text("1.0\n")
+        return Path(cwd)
+
+    def _seed_fatigue(self, home: Path, count: int = 5):
+        from episteme import _cognitive_budget as cb
+        rdir = home / "memory" / "reflective"
+        rdir.mkdir(parents=True, exist_ok=True)
+        for i in range(count):
+            cb.record_approval(
+                correlation_id=f"appr-{i}",
+                blueprint="unknown",
+                op_class="bash",
+                elapsed_seconds=0.2,  # sub-second → attention_bottleneck
+                reason="operator approval observation seeded for the fatigue gate test",
+                reflective_dir=rdir,
+            )
+
+    def test_fatigue_signal_skips_enqueue(self):
+        import contextlib
+        with EphemeralHome() as home, contextlib.ExitStack() as stack:
+            cwd = self._cwd_rate_one(stack)
+            self._seed_fatigue(home)
+            result = _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-f"), cwd=cwd, cap=100
+            )
+            self.assertFalse(result.queued)
+            self.assertEqual(result.reason, "fatigue_skip")
+            self.assertEqual(len(_spot_check.list_entries()), 0)
+            self.assertEqual(
+                _spot_check.read_skip_counter()["skipped_count"], 1
+            )
+
+    def test_no_fatigue_history_enqueues_normally(self):
+        import contextlib
+        with EphemeralHome(), contextlib.ExitStack() as stack:
+            cwd = self._cwd_rate_one(stack)
+            # Empty approval stream → detect_fatigue returns None → no skip.
+            result = _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-g"), cwd=cwd, cap=100
+            )
+            self.assertTrue(result.queued)
+            self.assertEqual(result.reason, "queued")
+
+    def test_fatigue_check_never_raises_on_bad_reflective_dir(self):
+        # A non-existent reflective dir must degrade to "not fatigued".
+        with EphemeralHome():
+            self.assertFalse(
+                _spot_check._fatigue_active(None, Path("/nonexistent/xyz"))
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes the structural half of M1 (two audits: E146, E147 prior-art lane): `maybe_sample` — the single write-path all three samplers route through (spot_check, fence_synthesis:264, calibration_telemetry:254) — now consults `count_pending()` before appending. At/over the cap (default 100, `EPISTEME_SPOT_CHECK_CAP` env override) it skips silently and increments a monotonic skip counter (atomic temp+rename sidecar). The D11 `_cognitive_budget` fatigue signal is wired as an additional skip condition — evidence-gated, inert until approval capture is auto-instrumented; the hard cap is the safety net.

Anti-accretion: bounds the existing write-path; no new queue, no new surface, no operator judgments enqueued. Live queue state untouched (archived separately per the E138 verbatim precedent).

Verification: red-green (cap-at-limit → no entry + counter increment; below-cap unchanged; malformed queue → fail-safe never-raises), 11 new tests; worktree suite 1580 passed + 76 subtests, 0 failed (baseline-reconciled: 12 env-dependent skips present as passes in the main checkout). Latency probe ~1.6ms/call at 99 pending, well under the 50ms hook budget. Independent adversarial review: CLEAN (1 minor — fatigue gate's `walk_approvals(verify=True)` is a latent cost once D11 auto-instrumentation lands; addressed in the Event 148 follow-up PR).