### PR TITLE
fix(guard): resolve .episteme artifacts to the governed root, stop at repo boundary (Event 148)

### DIFF
--- a/core/hooks/_interrogation.py
+++ b/core/hooks/_interrogation.py
@@ -87,14 +87,35 @@ def _is_lazy(text: str) -> bool:
     return collapsed.rstrip(".!?,;:") in _LAZY_TOKENS
 
 
+# Mirror of reasoning_surface_guard._ROOT_WALK_MAX_DEPTH — duplicated per the
+# hooks-stay-self-contained convention.
+_ROOT_WALK_MAX_DEPTH = 64
+
+
 def _canonical_project_root(cwd: Path) -> Path:
-    """Walk up to the nearest directory holding ``.episteme/``. Mirrors
-    reasoning_surface_guard._canonical_project_root minus the git probe —
-    the artifact lives beside the surface, so the walk target is the same."""
+    """Nearest ancestor holding ``.episteme/``, bounded by the repo boundary.
+
+    Mirrors ``reasoning_surface_guard._resolve_episteme_root`` (duplicated per
+    the hooks-stay-self-contained convention): walk UP for a directory holding
+    ``.episteme/``, STOPPING at the first directory carrying a ``.git`` entry
+    (dir in a normal checkout, FILE in a linked worktree) and at the
+    filesystem root. The boundary directory itself is inspected first — a repo
+    root carries both. NEVER cross the boundary into a parent repo.
+
+    Event 148 — the interrogation verdict is an admission-path artifact (an
+    alternative satisfier to the Reasoning Surface). Without the boundary a
+    nested child repo would inherit the parent's ``interrogation.json`` and a
+    governed op could be admitted via a verdict the child never authored
+    (fail-open). Returns ``cwd`` when nothing is found up to the boundary, so
+    ``artifact_path`` names a non-existent file and ``artifact_status`` reports
+    ``missing`` — the guard then falls through to the v1 (fail-closed) path.
+    """
     probe = cwd.resolve() if cwd.exists() else cwd
-    for _ in range(8):
+    for _ in range(_ROOT_WALK_MAX_DEPTH):
         if (probe / ".episteme").is_dir():
             return probe
+        if (probe / ".git").exists():
+            return cwd
         if probe.parent == probe:
             break
         probe = probe.parent

--- a/core/hooks/reasoning_surface_guard.py
+++ b/core/hooks/reasoning_surface_guard.py
@@ -842,53 +842,88 @@ def _match_high_impact(tool_name: str, payload: dict) -> str | None:
     return None
 
 
-def _canonical_project_root(cwd: Path) -> Path:
-    """Resolve the project root so the surface lookup survives subdirectory cwd.
+# Belt-and-suspenders traversal cap for the root walk. The `.git` repo
+# boundary and the filesystem root both terminate the walk in governed and
+# ungoverned trees respectively; this cap only bites on a pathological
+# symlink cycle or an absurdly deep ungoverned path. Generous enough that a
+# real subdirectory cwd (e.g. `pkg/a/b/c/d/e/…`) still reaches its root.
+_ROOT_WALK_MAX_DEPTH = 64
 
-    Claude Code's Bash-tool cwd can inherit from prior subdirectory ops (e.g.
-    `pnpm build` in `web/`), making `cwd / ".episteme"` miss the project-level
-    surface. This helper canonicalizes by preferring:
 
-      1. `git rev-parse --show-toplevel` — fast, authoritative inside a repo.
-      2. Walking up from cwd for a directory containing `.episteme/` — covers
-         non-git contexts or deeply-nested tooling cwds (bounded to 8 levels
-         to avoid runaway traversal on pathological symlinks).
-      3. Falling back to cwd itself — preserves original behavior outside a
-         git/episteme context (e.g. test fixtures, tmpdirs).
+def _resolve_episteme_root(cwd: Path) -> Path | None:
+    """Nearest ancestor holding `.episteme/`, bounded by the repo boundary.
 
-    Timeout on the git subprocess is 2 seconds; if git is unavailable or slow
-    the walk fallback kicks in. Hook hot-path impact measured negligible
-    (< 30ms in the common case).
+    Walk UP from ``cwd`` until a directory containing `.episteme/` is found,
+    STOPPING at the first directory that carries a `.git` entry (a directory
+    in a normal checkout, a FILE in a linked worktree) and at the filesystem
+    root. The `.git`-boundary directory itself IS inspected for `.episteme/`
+    BEFORE the walk stops — a repo root carries both. The walk NEVER crosses
+    a `.git` boundary into a parent repo:
 
-    Path-A Event 42 fix — pulled forward from v1.0.1 hook-ergonomics rider
-    after repeated REASONING SURFACE MISSING blocks in the 2026-04-23 session.
+      Event 148 fail-open closer — a nested child repo WITHOUT its own
+      `.episteme` must not inherit the parent's surface / advisory marker /
+      interrogation verdict. Crossing the boundary would silently disarm the
+      guard for an ungoverned repo (a governed op admitted, or blocked-op
+      downgraded to advisory, on artifacts the child never authored). That is
+      the fail-open shape this resolver exists to prevent.
+
+    Returns ``None`` when no `.episteme/` is found up to (and including) the
+    boundary, the filesystem root, or the depth cap — the caller then falls
+    back to today's missing-artifact (fail-closed) behavior.
+
+    Pure path checks only — NO `git rev-parse` subprocess on this hot path
+    (Event 148 deliverable 5; the subprocess it replaces both crossed the
+    nested-repo boundary via its walk fallback and coupled the gate to the
+    `git` binary's presence and cwd-discovery quirks). ``cwd`` is resolved to
+    its real path first so a symlinked cwd is checked against the real tree.
     """
-    import subprocess
-    try:
-        out = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            cwd=str(cwd),
-            capture_output=True,
-            text=True,
-            timeout=2,
-        )
-        if out.returncode == 0 and out.stdout.strip():
-            return Path(out.stdout.strip())
-    except (subprocess.TimeoutExpired, OSError, FileNotFoundError):
-        pass
     probe = cwd.resolve() if cwd.exists() else cwd
-    for _ in range(8):
+    for _ in range(_ROOT_WALK_MAX_DEPTH):
         if (probe / ".episteme").is_dir():
             return probe
+        # Repo boundary — checked AFTER `.episteme` so a repo root (which
+        # carries both) resolves to itself. `.exists()` matches the `.git`
+        # dir of a normal checkout AND the `.git` FILE of a linked worktree.
+        if (probe / ".git").exists():
+            return None
         if probe.parent == probe:
             break
         probe = probe.parent
-    return cwd
+    return None
+
+
+def _canonical_project_root(cwd: Path) -> Path:
+    """Governed root for `.episteme` artifact discovery, or ``cwd`` fallback.
+
+    Back-compat wrapper over :func:`_resolve_episteme_root`: returns the
+    governed root when one is found before the repo boundary, else ``cwd`` —
+    so ``cwd / ".episteme" / …`` names a non-existent artifact and the caller
+    gets today's missing-artifact (fail-closed) behavior. The fallback can
+    never accidentally satisfy discovery: if ``cwd/.episteme`` existed the
+    resolver would have returned ``cwd`` at depth 0.
+
+    Path-A Event 42 (subdirectory cwd survives) is preserved by the walk;
+    Event 148 removes the `git rev-parse` subprocess and adds the `.git`
+    boundary so a nested child repo cannot inherit a parent's artifacts.
+    """
+    return _resolve_episteme_root(cwd) or cwd
 
 
 def _surface_path(cwd: Path) -> Path:
     """Canonical path to the reasoning surface — honors canonical root."""
     return _canonical_project_root(cwd) / ".episteme" / "reasoning-surface.json"
+
+
+def _advisory_marker_path(cwd: Path) -> Path:
+    """Canonical path to the advisory opt-out marker — honors canonical root.
+
+    Routed through the same boundary-aware resolver as the surface so the
+    advisory opt-out is seen from a subdirectory cwd (was read from the raw
+    cwd and missed — a false strict block) AND is NOT inherited across a
+    nested `.git` boundary (a child repo must not be downgraded to advisory
+    by a parent's marker — Event 148 fail-open closer).
+    """
+    return _canonical_project_root(cwd) / ".episteme" / "advisory-surface"
 
 
 def _read_surface(cwd: Path) -> dict | None:
@@ -1788,7 +1823,11 @@ def main() -> int:
 
     cwd = Path(payload.get("cwd") or os.getcwd())
     status, detail = _surface_status(cwd)
-    advisory_only = (cwd / ".episteme" / "advisory-surface").exists()
+    # Event 148 — resolve the advisory marker through the boundary-aware
+    # root helper (same as the surface), NOT the raw cwd: a subdir cwd must
+    # still see the root marker, and a nested child repo must NOT inherit
+    # the parent's marker.
+    advisory_only = _advisory_marker_path(cwd).exists()
     mode = "advisory" if advisory_only else "strict"
     # Default blueprint name — overridden by the layer-2/3 block when
     # the surface file exists and scenario detection runs. Declared

--- a/tests/test_interrogation.py
+++ b/tests/test_interrogation.py
@@ -397,5 +397,52 @@ class LessonSynthesis(unittest.TestCase):
             )
 
 
+class RootBoundary(unittest.TestCase):
+    """Event 148 — interrogation artifact discovery walks UP to the
+    governed root but STOPS at the first repo boundary (`.git` file or
+    dir). A nested child repo without its own `.episteme` must NOT resolve
+    to the parent's verdict (fail-open: a governed op admitted via a
+    verdict the child never authored)."""
+
+    @staticmethod
+    def _mk(base: Path, rel: str, is_dir: bool = False, content: str = "") -> Path:
+        p = base / rel
+        if is_dir:
+            p.mkdir(parents=True, exist_ok=True)
+        else:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_walks_up_to_episteme_root_from_subdir(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            self._mk(root, ".git", is_dir=True)
+            self._mk(root, ".episteme", is_dir=True)
+            sub = self._mk(root, "pkg/src", is_dir=True)
+            self.assertEqual(_interrogation._canonical_project_root(sub), root)
+
+    def test_child_repo_does_not_inherit_parent_verdict(self):
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td).resolve()
+            self._mk(td, "parent/.git", is_dir=True)
+            self._mk(td, "parent/.episteme", is_dir=True)
+            _write_artifact(td / "parent", _valid_artifact())
+            self._mk(td, "parent/child/.git", content="gitdir: /nowhere")
+            child = td / "parent" / "child"
+            childsub = self._mk(td, "parent/child/src", is_dir=True)
+            # child has no `.episteme` → status "missing", NOT the parent's
+            # fresh "ok" verdict.
+            self.assertEqual(_interrogation.artifact_status(child)[0], "missing")
+            self.assertEqual(
+                _interrogation.artifact_status(childsub)[0], "missing")
+
+    def test_bare_dir_no_git_no_episteme_missing(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            sub = self._mk(root, "a/b/c", is_dir=True)
+            self.assertEqual(_interrogation.artifact_status(sub)[0], "missing")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reasoning_surface_guard.py
+++ b/tests/test_reasoning_surface_guard.py
@@ -773,5 +773,192 @@ class Event146DedupTests(unittest.TestCase):
             )
 
 
+class Event148RootResolutionTests(unittest.TestCase):
+    """Event 148 — `.episteme` artifact discovery walks UP to the governed
+    root but STOPS at the first repo boundary (`.git` file or dir) and at
+    the filesystem root. The boundary directory itself IS inspected (a repo
+    root carries both `.git` and `.episteme`). A nested child repo without
+    its own `.episteme` must NOT inherit the parent's surface / advisory
+    marker — that would silently disarm the guard for an ungoverned repo
+    (fail-open). Pure path checks only: no `git rev-parse` subprocess."""
+
+    @staticmethod
+    def _mk(base: Path, rel: str, is_dir: bool = False, content: str = "") -> Path:
+        p = base / rel
+        if is_dir:
+            p.mkdir(parents=True, exist_ok=True)
+        else:
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content, encoding="utf-8")
+        return p
+
+    def _run(self, cmd: str, cwd: Path, home: Path) -> tuple[int, str, str]:
+        payload = {"tool_name": "Bash", "tool_input": {"command": cmd},
+                   "cwd": str(cwd), "session_id": "sess-e148"}
+        with patch("sys.stdin", new=io.StringIO(json.dumps(payload))), \
+             patch("sys.stdout", new=io.StringIO()) as out, \
+             patch("sys.stderr", new=io.StringIO()) as err, \
+             patch.object(guard.Path, "home", return_value=home):
+            rc = guard.main()
+        return rc, out.getvalue(), err.getvalue()
+
+    # ----- resolver unit tests -----
+
+    def test_resolver_walks_up_to_episteme_root_from_subdir(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            self._mk(root, ".git", is_dir=True)
+            self._mk(root, ".episteme", is_dir=True)
+            sub = self._mk(root, "core/memory/global", is_dir=True)
+            self.assertEqual(guard._resolve_episteme_root(sub), root)
+
+    def test_resolver_repo_root_with_both_git_and_episteme_returns_itself(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            self._mk(root, ".git", is_dir=True)
+            self._mk(root, ".episteme", is_dir=True)
+            self.assertEqual(guard._resolve_episteme_root(root), root)
+
+    def test_resolver_git_file_worktree_boundary_is_checked(self):
+        # Linked worktrees have a `.git` FILE, not a dir; the boundary dir
+        # itself must still be inspected for `.episteme`.
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            self._mk(root, ".git", content="gitdir: /somewhere/.git/worktrees/wt")
+            self._mk(root, ".episteme", is_dir=True)
+            sub = self._mk(root, "web", is_dir=True)
+            self.assertEqual(guard._resolve_episteme_root(sub), root)
+
+    def test_resolver_stops_at_git_boundary_no_cross_into_parent(self):
+        # THE fail-open closer — a child repo (own `.git`, NO `.episteme`)
+        # nested inside a governed parent must NOT resolve to the parent.
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td).resolve()
+            self._mk(td, "parent/.git", is_dir=True)
+            self._mk(td, "parent/.episteme", is_dir=True)
+            self._mk(td, "parent/child/.git", content="gitdir: /nowhere")
+            child = td / "parent" / "child"
+            childsub = self._mk(td, "parent/child/src/deep", is_dir=True)
+            self.assertIsNone(guard._resolve_episteme_root(child))
+            self.assertIsNone(guard._resolve_episteme_root(childsub))
+
+    def test_resolver_no_git_no_episteme_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            sub = self._mk(root, "a/b/c", is_dir=True)
+            self.assertIsNone(guard._resolve_episteme_root(sub))
+
+    def test_resolver_no_subprocess_on_hot_path(self):
+        # Deliverable 5 — pure path checks; `git rev-parse` is forbidden.
+        import subprocess
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            self._mk(root, ".git", is_dir=True)
+            self._mk(root, ".episteme", is_dir=True)
+            sub = self._mk(root, "x/y", is_dir=True)
+            with patch.object(
+                subprocess, "run",
+                side_effect=AssertionError("subprocess forbidden on hot path"),
+            ):
+                self.assertEqual(guard._resolve_episteme_root(sub), root)
+                self.assertEqual(guard._canonical_project_root(sub), root)
+
+    def test_canonical_root_falls_back_to_cwd_when_ungoverned(self):
+        # Deliverable 3 — nothing found up to the boundary yields today's
+        # missing-artifact behavior: `_surface_path` points at a
+        # non-existent file so `_surface_status` reports "missing".
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            self._mk(root, "parent/.git", is_dir=True)
+            self._mk(root, "parent/.episteme", is_dir=True)
+            self._mk(root, "parent/child/.git", content="gitdir: /nowhere")
+            child = root / "parent" / "child"
+            self.assertEqual(guard._canonical_project_root(child), child)
+            self.assertEqual(guard._surface_status(child)[0], "missing")
+
+    # ----- end-to-end admission-path tests -----
+
+    def test_subdir_cwd_admits_with_root_surface(self):
+        # Deliverable 4(a) — governed root, valid surface, cwd = subdir.
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td).resolve()
+            home = self._mk(td, "home", is_dir=True)
+            root = self._mk(td, "proj", is_dir=True)
+            self._mk(root, ".git", is_dir=True)
+            self._mk(root, ".episteme", is_dir=True)
+            (root / ".episteme" / "reasoning-surface.json").write_text(
+                json.dumps(_fresh_surface_payload()), encoding="utf-8")
+            sub = self._mk(root, "core/memory/global", is_dir=True)
+            rc, out, err = self._run(_GP + " origin main", sub, home)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(err, "")
+
+    def test_subdir_cwd_advisory_marker_downgrades_from_subdir(self):
+        # Advisory opt-out lives at the root; a subdir cwd must still see
+        # it. Today the marker is read from the raw cwd and missed →
+        # false strict block. After fix it resolves through the root.
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td).resolve()
+            home = self._mk(td, "home", is_dir=True)
+            root = self._mk(td, "proj", is_dir=True)
+            self._mk(root, ".git", is_dir=True)
+            self._mk(root, ".episteme", is_dir=True)
+            (root / ".episteme" / "advisory-surface").write_text(
+                "", encoding="utf-8")
+            sub = self._mk(root, "web/app", is_dir=True)
+            rc, out, err = self._run(_GP + " origin main", sub, home)
+        self.assertEqual(rc, 0, "advisory opt-out from a subdir must not block")
+        ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("Advisory mode is active", ctx)
+
+    def test_nested_child_repo_does_not_inherit_parent_governance(self):
+        # Deliverable 4(b) — parent governed (valid surface + advisory
+        # marker); child repo inside with its own `.git` but NO
+        # `.episteme`. A high-impact op in the child must NOT be admitted
+        # via the parent's surface, nor downgraded via the parent's
+        # advisory marker — it stays STRICT (fail-closed).
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td).resolve()
+            home = self._mk(td, "home", is_dir=True)
+            self._mk(td, "parent/.git", is_dir=True)
+            self._mk(td, "parent/.episteme", is_dir=True)
+            (td / "parent" / ".episteme" / "reasoning-surface.json").write_text(
+                json.dumps(_fresh_surface_payload()), encoding="utf-8")
+            (td / "parent" / ".episteme" / "advisory-surface").write_text(
+                "", encoding="utf-8")
+            self._mk(td, "parent/child/.git", content="gitdir: /nowhere")
+            child = td / "parent" / "child"
+            rc, out, err = self._run(_GP + " origin main", child, home)
+        self.assertEqual(rc, 2, "child repo must not inherit parent governance")
+        self.assertIn("REASONING SURFACE MISSING", err)
+
+    def test_worktree_own_seeded_episteme_unchanged(self):
+        # Deliverable 4(c) — a worktree (`.git` FILE) with its OWN seeded
+        # `.episteme` + valid surface admits from the worktree root.
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td).resolve()
+            home = self._mk(td, "home", is_dir=True)
+            wt = self._mk(td, "wt", is_dir=True)
+            self._mk(wt, ".git", content="gitdir: /main/.git/worktrees/wt")
+            self._mk(wt, ".episteme", is_dir=True)
+            (wt / ".episteme" / "reasoning-surface.json").write_text(
+                json.dumps(_fresh_surface_payload()), encoding="utf-8")
+            rc, out, err = self._run(_GP + " origin main", wt, home)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(err, "")
+
+    def test_bare_tmp_dir_no_git_blocks_strict(self):
+        # Deliverable 4(d) — no `.git` and no `.episteme` anywhere: the
+        # walk terminates at the filesystem root / depth cap and the op
+        # gets today's fail-closed strict block.
+        with tempfile.TemporaryDirectory() as td:
+            td = Path(td).resolve()
+            home = self._mk(td, "home", is_dir=True)
+            bare = self._mk(td, "bare/a/b", is_dir=True)
+            rc, out, err = self._run(_GP + " origin main", bare, home)
+        self.assertEqual(rc, 2)
+        self.assertIn("REASONING SURFACE MISSING", err)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes the ledgered guard defect that false-blocked benign ops in every E146/E147 lane and two live sessions: artifact discovery (`reasoning-surface.json`, `advisory-surface`, `interrogation.json`) resolved from the tool payload cwd via a `git rev-parse` subprocess whose fallback CROSSED nested `.git` boundaries — a subdir cwd false-blocked (fail-closed annoyance), and a nested child repo without its own `.episteme/` inherited the parent's artifacts (fail-open: guard silently disarmed for an ungoverned repo, probe-confirmed pre-fix).

Fix: `_resolve_episteme_root()` — pure-path walk up from `cwd.resolve()` for `.episteme/`, stopping at the first `.git` entry (dir OR worktree file) and at fs root; the boundary dir itself is inspected first; depth-capped at 64; no subprocess on the hot path (68µs/call vs ~30ms). `_interrogation.py` mirrors the boundary walk (hooks-stay-self-contained convention). Ungoverned trees keep today's missing-artifact fail-closed behavior. Fence/cascade pending markers verified unaffected (HOME+correlation keyed — cwd is marker data, not path; 140 pairing tests green).

Verification: red-green 10 failing → 15 passing targeted tests (subdir false-block, nested-repo inheritance, worktree `.git`-file, symlinked cwd, no-git bare dir); stash-verified worktree delta exactly +15, 0 regressions; suite 1584 passed + 76 subtests, 0 failed. Independent adversarial review (fail-open hunt: parent inheritance, symlink smuggling, depth-cap semantics): CLEAN (1 minor — `spot_check_rate` per-project override still cwd-resolved; addressed in the Event 148 follow-up PR).