### PR TITLE
fix: Event 148 bounded repair bundle (banner wording, argparse guard, inflections, upstream citations, Pyright)

### DIFF
--- a/core/hooks/_specificity.py
+++ b/core/hooks/_specificity.py
@@ -67,13 +67,40 @@ _CONDITIONAL_TRIGGER_PATTERNS: tuple[re.Pattern, ...] = (
     re.compile(r"\bunless\b", re.I),
 )
 
+# Failure/observable verbs, matched across their regular inflections.
+# Event 146 finding: the v0.11.0 lexicon matched base + ``-s`` only
+# (``fails`` matched, ``failed`` / ``crashing`` did not), so an author who
+# wrote a perfectly specific observable in an inflected form was rejected.
+def _verb_inflections(stem: str) -> str:
+    """Alternation body matching ``stem`` across base / -s / -es / -ed / -ing.
+
+    A strict superset of a bare ``stem s?``: never drops a previously-matched
+    form, and adds the ``-ed`` / ``-ing`` forms the old lexicon missed. Only
+    the ``has_observable`` boolean is consumed downstream, so alternation
+    order is irrelevant. Irregular stems (``throw``→``threw``,
+    ``panic``→``panicked``) match their regular forms only — this is a bounded
+    suffix-stem widen (Event 148 · smallfix #5), not a lemmatizer.
+    """
+    return rf"{re.escape(stem)}(?:es|ed|ing|s)?"
+
+
+_FAILURE_VERB_STEMS: tuple[str, ...] = (
+    "fail", "error", "crash", "exit", "panic", "throw", "reject",
+)
+_FAILURE_VERB_RE_BODY = "|".join(_verb_inflections(s) for s in _FAILURE_VERB_STEMS)
+
 # Specific observables — numeric thresholds, metric references, failure
 # verbs naming something that can be watched for.
 _OBSERVABLE_PATTERNS: tuple[re.Pattern, ...] = (
     re.compile(r"\d+\s*%"),
     re.compile(r"\d+\s*(?:ms|sec|seconds?|min|minutes?|h|hours?|MB|GB|KB|rps|qps|errors?)\b", re.I),
     re.compile(r"\b(?:exceeds?|drops?|rises?|passes?|crosses?|hits?|reaches?|exceeds?)\s+\d"),
-    re.compile(r"\b(?:fails?|errors?|times?\s*out|crashes?|exits?|panics?|throws?|rejects?|returns?\s+non-?zero|non-?zero\s+exit)\b", re.I),
+    re.compile(
+        r"\b(?:" + _FAILURE_VERB_RE_BODY
+        + r"|tim(?:e|es|ed|ing)\s*out"
+        + r"|return(?:s|ed|ing)?\s+non-?zero|non-?zero\s+exit)\b",
+        re.I,
+    ),
     re.compile(r"\b(?:log\s+shows?|query[- ]log|telemetry|ci|pipeline|build|test\s+suite|audit\s+log)\b", re.I),
     re.compile(r"\bexit\s*code\b", re.I),
     re.compile(r"\bwithin\s+\d", re.I),

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -297,7 +297,14 @@ def _doc_staleness_line() -> str | None:
             latest_event = None
 
         today = datetime.now(timezone.utc).date()
-        stale = 0
+        # Split the count by which threshold fired so the banner names the
+        # actual staleness class. A doc can be stale by event-lag (its marker
+        # carries an ``E<n>`` tag and the corpus has advanced past the lag) or
+        # by the date fallback (its marker carries an ISO date > the day
+        # threshold). Reporting ">15 events" when only the date rule fired is
+        # inaccurate (Event 148 · smallfix #1).
+        stale_events = 0
+        stale_date = 0
         for path in docs_dir.glob("*.md"):
             # Skip symlinks (private planning docs are symlinked, lifecycle-exempt).
             if path.is_symlink():
@@ -322,7 +329,7 @@ def _doc_staleness_line() -> str | None:
                 if latest_event is None:
                     continue  # event-tagged but no corpus latest to compare
                 if latest_event - int(ev.group(1)) > _DOC_STALENESS_EVENT_LAG:
-                    stale += 1
+                    stale_events += 1
                 continue
 
             dm = date_re.match(reviewed)
@@ -334,15 +341,26 @@ def _doc_staleness_line() -> str | None:
                 except ValueError:
                     continue
                 if (today - reviewed_date).days > _DOC_STALENESS_DATE_DAYS:
-                    stale += 1
+                    stale_date += 1
                 continue
             # Unparseable reviewed_as_of: leave for `episteme docs lint`.
 
+        stale = stale_events + stale_date
         if stale <= 0:
             return None
+        # Name only the threshold class(es) that actually fired.
+        if stale_events and stale_date:
+            thresh = (
+                f">{_DOC_STALENESS_EVENT_LAG} events or "
+                f">{_DOC_STALENESS_DATE_DAYS} days"
+            )
+        elif stale_date:
+            thresh = f">{_DOC_STALENESS_DATE_DAYS} days"
+        else:
+            thresh = f">{_DOC_STALENESS_EVENT_LAG} events"
         return (
             f"doc-staleness: {stale} living docs unreviewed "
-            f">15 events — episteme docs lint"
+            f"{thresh} — episteme docs lint"
         )
     except Exception:
         return None

--- a/src/episteme/adapters/claude.py
+++ b/src/episteme/adapters/claude.py
@@ -189,7 +189,12 @@ def normalize_hook_command(cmd: str) -> str:
     return c
 
 
-def dedupe_hooks_map(hooks: dict) -> dict:
+def dedupe_hooks_map(hooks: object) -> dict:
+    # `object`, not `dict`: this runs against user-controlled settings.json,
+    # where `hooks` can be a non-dict (e.g. `episteme doctor` passes
+    # `settings.get("hooks", {})` verbatim). The isinstance guard is the live
+    # fail-safe; annotating the param `dict` made Pyright flag it as
+    # unreachable dead code (Event 147 v3 generator; Event 148 · smallfix #2).
     if not isinstance(hooks, dict):
         return {}
     out: dict = {}
@@ -340,7 +345,10 @@ def prune_managed_hook_entries(settings: dict, governance_mode: str) -> dict:
     return settings
 
 
-def _is_default_permission_allow_hook(hook: dict) -> bool:
+def _is_default_permission_allow_hook(hook: object) -> bool:
+    # `object`, not `dict`: a settings.json hook list can hold non-dict
+    # elements, so the isinstance guard is a live fail-safe (not dead code —
+    # annotating `dict` made Pyright flag it unreachable). Event 148 · smallfix #2.
     if not isinstance(hook, dict):
         return False
     if str(hook.get("type", "command")) != "command":

--- a/src/episteme/doc_references.py
+++ b/src/episteme/doc_references.py
@@ -178,6 +178,46 @@ _BARE_PATH_RE = re.compile(
 _LINE_SUFFIX_RE = re.compile(r"^(.*\.[A-Za-z0-9]+):\d+(?::\d+)?$")
 _TEMPLATE_RE = re.compile(r"YYYY|(?<![A-Za-z])NN(?![A-Za-z])|MM-DD")
 
+# A GitHub-style ``owner/repo`` slug: two path-name segments. Used only to
+# recognize *external-project* citations (Event 146 false-positive): a path
+# that belongs to an upstream repo named on the same line is not a citation of
+# THIS tree. ``owner`` must NOT be one of our own source roots
+# (:data:`ALLOWLIST_PREFIXES`), so an in-repo path like ``core/hooks/x.py``
+# (owner ``core`` is a real root) is never mistaken for an external slug.
+_SLUG_SEG = r"[A-Za-z0-9][A-Za-z0-9._-]*"
+_EXTERNAL_SLUG_PREFIX_RE = re.compile(rf"^({_SLUG_SEG})/{_SLUG_SEG}/")
+_EXTERNAL_SLUG_BEFORE_RE = re.compile(rf"({_SLUG_SEG})/{_SLUG_SEG}[\s/`'\"(]*$")
+
+
+def _cites_external_repo(line_text: str, raw: str) -> bool:
+    """True if ``raw`` belongs to an upstream project cited by its
+    ``owner/repo`` slug, not to this repo (Event 148 · smallfix #4).
+
+    Two shapes are recognized, both conservative (they only ever suppress a
+    finding, never create one, so the drift baseline cannot grow):
+
+    * **slug-prefixed token** — the token itself begins ``owner/repo/…``
+      (e.g. ``googleapis/release-please/README.md``); as a markdown link this
+      would otherwise be joined onto the citing dir and flagged as a phantom
+      local path.
+    * **slug immediately preceding** — a bare source-root path (``src/foo.ts``)
+      that appears right after an ``owner/repo`` slug on the line
+      (``… facebook/react src/foo.ts``).
+
+    In both shapes the slug ``owner`` must not be one of our allowlisted source
+    roots, so genuine in-repo citations are never suppressed.
+    """
+    tok = raw.strip().strip("\"'")
+    m = _EXTERNAL_SLUG_PREFIX_RE.match(tok)
+    if m is not None and (m.group(1) + "/") not in ALLOWLIST_PREFIXES:
+        return True
+    idx = line_text.find(raw)
+    if idx > 0:
+        mb = _EXTERNAL_SLUG_BEFORE_RE.search(line_text[:idx])
+        if mb is not None and (mb.group(1) + "/") not in ALLOWLIST_PREFIXES:
+            return True
+    return False
+
 
 def extract_references(text: str, citing: str) -> List[Reference]:
     """Return the validatable path/directory citations in ``text``.
@@ -201,26 +241,31 @@ def _scan_line(line: str, citing: str, lineno: int, out: List[Reference]) -> Non
     residual = line
     # Markdown links / images first (link context resolves relative to citing dir).
     for m in _LINK_RE.finditer(line):
-        _consider(m.group(1), citing, lineno, link=True, out=out)
+        _consider(m.group(1), citing, lineno, link=True, out=out, line_text=line)
     residual = _LINK_RE.sub(" ", residual)
     for m in _HTML_SRC_RE.finditer(residual):
-        _consider(m.group(1), citing, lineno, link=True, out=out)
+        _consider(m.group(1), citing, lineno, link=True, out=out, line_text=line)
     residual = _HTML_ANY_ATTR_RE.sub(" ", residual)
     # Inline code spans: only a single whitespace-free token is a citation; a
     # span with spaces is an example command/expression, not a path.
     for m in _INLINE_CODE_RE.finditer(residual):
         content = m.group(1).strip()
         if content and not any(c.isspace() for c in content):
-            _consider(content, citing, lineno, link=False, out=out)
+            _consider(content, citing, lineno, link=False, out=out, line_text=line)
     residual = _INLINE_CODE_RE.sub(" ", residual)
     # Bare prose paths in what remains.
     for m in _BARE_PATH_RE.finditer(residual):
-        _consider(m.group(1), citing, lineno, link=False, out=out)
+        _consider(m.group(1), citing, lineno, link=False, out=out, line_text=line)
 
 
 def _consider(
-    raw: str, citing: str, lineno: int, link: bool, out: List[Reference]
+    raw: str, citing: str, lineno: int, link: bool, out: List[Reference],
+    line_text: str = "",
 ) -> None:
+    # Event 148 · smallfix #4: a path that belongs to an upstream project cited
+    # by its owner/repo slug on the same line is not a citation of THIS tree.
+    if _cites_external_repo(line_text, raw):
+        return
     ref = _classify(raw, citing, link, lineno)
     if ref is not None and not any(
         r.target == ref.target and r.line == ref.line and r.kind == ref.kind

--- a/tests/test_doc_references.py
+++ b/tests/test_doc_references.py
@@ -314,6 +314,57 @@ class FindDriftTests(unittest.TestCase):
             self.assertEqual([], findings)
 
 
+class ExternalRepoCitationGuard(unittest.TestCase):
+    """Event 148 · smallfix #4 (Event 146 finding): a path belonging to an
+    upstream project cited by its ``owner/repo`` slug on the same line is not a
+    citation of THIS tree and must not be flagged as local drift. The guard is
+    conservative — it only suppresses when the slug owner is not one of our own
+    source roots, so real in-repo drift is untouched."""
+
+    def _drift(self, citing, text):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / "docs").mkdir()
+            (root / citing).write_text(text, encoding="utf-8")
+            return dr.find_drift(
+                root, doc_files=[citing], ignored_checker=lambda p: set()
+            )
+
+    def test_slug_prefixed_link_is_not_flagged(self):
+        # Shape A: markdown link to an upstream owner/repo/path. Without the
+        # guard this joins onto docs/ and dangles as a phantom local path.
+        findings = self._drift(
+            "docs/GUIDE.md",
+            "see upstream [readme](googleapis/release-please/README.md) for the flow\n",
+        )
+        self.assertEqual([], findings)
+
+    def test_bare_path_after_external_slug_is_not_flagged(self):
+        # Shape B: a bare source-root path immediately after an owner/repo slug.
+        findings = self._drift(
+            "docs/GUIDE.md",
+            "our reducer mirrors facebook/react src/react-dom/index.js exactly\n",
+        )
+        self.assertEqual([], findings)
+
+    def test_in_repo_path_with_slash_is_still_flagged(self):
+        # Control: owner `core` IS a source root, so this is an in-repo citation
+        # and real drift must still fire.
+        findings = self._drift(
+            "docs/GUIDE.md", "the gate lives in `core/hooks/DOES_NOT_EXIST.py`\n"
+        )
+        self.assertEqual(1, len(findings))
+        self.assertEqual("core/hooks/DOES_NOT_EXIST.py", findings[0].target)
+
+    def test_bare_path_without_preceding_slug_is_still_flagged(self):
+        # Control: same missing path but NO external slug on the line ⇒ drift.
+        findings = self._drift(
+            "docs/GUIDE.md", "config in src/episteme/DOES_NOT_EXIST.py somewhere\n"
+        )
+        self.assertEqual(1, len(findings))
+        self.assertEqual("src/episteme/DOES_NOT_EXIST.py", findings[0].target)
+
+
 class CitingScopeExemptions(unittest.TestCase):
     """Non-authored content (fixtures, scaffolds, install-relative templates,
     append-only ledgers) is excluded from the citing set by a named negative

--- a/tests/test_marker_reaper.py
+++ b/tests/test_marker_reaper.py
@@ -322,6 +322,47 @@ class CliTool(unittest.TestCase):
             self.assertFalse(stale.exists(), "tool must reap the stale marker")
             self.assertIn("marker_cleanup:", proc.stderr)
 
+    def _run_with_stale_marker(self, args):
+        """Run the tool with `args` against a temp home holding one stale
+        marker; return (proc, marker_path). The caller asserts on whether the
+        marker survived (survived ⇒ no sweep ran)."""
+        td = tempfile.mkdtemp()
+        home = Path(td)
+        now = datetime.now(timezone.utc)
+        stale = home / "state" / "fence_pending" / "old.json"
+        stale.parent.mkdir(parents=True, exist_ok=True)
+        stale.write_text(
+            json.dumps({"written_at": (now - timedelta(days=2)).isoformat()}),
+            encoding="utf-8",
+        )
+        env = dict(os.environ, EPISTEME_HOME=str(home))
+        proc = subprocess.run(
+            [sys.executable, str(_REPO_ROOT / "tools" / "fence_marker_cleanup.py"), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        return proc, stale
+
+    def test_help_flag_prints_usage_and_does_not_sweep(self):
+        # Event 148 · smallfix #3: --help must exit 0 without running the sweep.
+        proc, stale = self._run_with_stale_marker(["--help"])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("usage", proc.stdout.lower())
+        self.assertTrue(stale.exists(), "--help must NOT reap markers (no sweep)")
+        self.assertNotIn("vanished=", proc.stderr)  # sweep-summary token, absent ⇒ no sweep
+
+    def test_short_help_flag_does_not_sweep(self):
+        proc, stale = self._run_with_stale_marker(["-h"])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertTrue(stale.exists(), "-h must NOT reap markers (no sweep)")
+
+    def test_unknown_flag_exits_2_and_does_not_sweep(self):
+        proc, stale = self._run_with_stale_marker(["--bogus"])
+        self.assertEqual(proc.returncode, 2, proc.stdout)
+        self.assertTrue(stale.exists(), "unknown flag must NOT reap markers (no sweep)")
+        self.assertNotIn("vanished=", proc.stderr)  # sweep-summary token, absent ⇒ no sweep
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_profile_audit.py
+++ b/tests/test_profile_audit.py
@@ -1028,6 +1028,31 @@ class DisconfirmationClassifierTests(unittest.TestCase):
         text = "the pipeline fails on non-zero exit codes"
         self.assertEqual(pa._classify_disconfirmation(text), "tautological")
 
+    def test_inflected_failure_verbs_are_observable(self):
+        # Event 148 · smallfix #5: the observable lexicon matched base + -s
+        # only, so an author who wrote the observable in an inflected form
+        # (-ed / -ing / -es) was wrongly rejected. Each inflection paired
+        # with a conditional trigger must now classify as fire.
+        cases = [
+            "if the deploy failed on the canary host we roll back",
+            "when the worker is crashing under load, page the on-call",
+            "if the request timed out after the retry budget, mark it dead",
+            "once the process exited non-cleanly, capture the core dump",
+            "if the schema validator rejected the payload, quarantine it",
+            "when the parser throwing on the third field, halt ingestion",
+        ]
+        for text in cases:
+            with self.subTest(text=text):
+                self.assertEqual(pa._classify_disconfirmation(text), "fire")
+
+    def test_base_and_s_forms_still_observable(self):
+        # Regression guard: the widen must be a strict superset — the forms
+        # the old lexicon already matched keep matching.
+        for verb in ("fail", "fails", "crash", "crashes", "exit", "rejects"):
+            text = f"if the job {verb} on the primary shard, abort the run"
+            with self.subTest(verb=verb):
+                self.assertEqual(pa._classify_disconfirmation(text), "fire")
+
 
 class LexiconHitCounterTests(unittest.TestCase):
     def test_single_word_term_counts(self):

--- a/tests/test_session_context_doc_staleness.py
+++ b/tests/test_session_context_doc_staleness.py
@@ -100,6 +100,43 @@ class DocStalenessBanner(unittest.TestCase):
             self.assertIsNotNone(line)
             assert line is not None
             self.assertIn("doc-staleness: 1 living docs", line)
+            # Event 148 · smallfix #1: the date-fallback fired, so the wording
+            # must name the day threshold, not the event threshold.
+            self.assertIn(">45 days", line)
+            self.assertNotIn(">15 events", line)
+
+    def test_event_lag_case_names_event_threshold(self):
+        """When only the event-lag rule fires, the banner says '>15 events'."""
+        with tempfile.TemporaryDirectory() as td:
+            docs = Path(td) / "docs"
+            docs.mkdir()
+            (docs / "EVENTS.md").write_text("E200\n", encoding="utf-8")
+            _write_doc(docs, "A.md", "living", "E100")  # lag 100 > 15 ⇒ stale
+            with _chdir(Path(td)):
+                line = sc._doc_staleness_line()
+            self.assertIsNotNone(line)
+            assert line is not None
+            self.assertIn("doc-staleness: 1 living docs", line)
+            self.assertIn(">15 events", line)
+            self.assertNotIn(">45 days", line)
+
+    def test_mixed_event_and_date_staleness_names_both(self):
+        """Both classes stale ⇒ wording names both thresholds, count is the sum."""
+        old = (datetime.now(timezone.utc) - timedelta(days=100)).strftime("%Y-%m-%d")
+        with tempfile.TemporaryDirectory() as td:
+            docs = Path(td) / "docs"
+            docs.mkdir()
+            (docs / "EVENTS.md").write_text("E200\n", encoding="utf-8")
+            _write_doc(docs, "A.md", "living", "E100")  # event-lag stale
+            _write_doc(docs, "B.md", "living", old)      # date-fallback stale
+            with _chdir(Path(td)):
+                line = sc._doc_staleness_line()
+            self.assertIsNotNone(line)
+            assert line is not None
+            self.assertIn("doc-staleness: 2 living docs", line)
+            self.assertIn(">15 events", line)
+            self.assertIn(">45 days", line)
+            self.assertEqual(line.count("\n"), 0, "must emit exactly one line")
 
     def test_symlinked_doc_skipped(self):
         """Private planning docs are symlinked and lifecycle-exempt."""

--- a/tools/fence_marker_cleanup.py
+++ b/tools/fence_marker_cleanup.py
@@ -17,9 +17,17 @@ to force a sweep out of band.
 
 Prints a one-line summary to stderr and exits 0. Safe to run repeatedly;
 idempotent.
+
+Argument discipline (Event 148 · smallfix #3, closing an Event 146 finding):
+the sweep is destructive (it unlinks marker files), so it must run ONLY on a
+bare invocation. ``-h``/``--help`` prints usage and exits 0 without sweeping;
+any unknown flag or positional exits 2 without sweeping. Previously the tool
+ignored ``sys.argv`` entirely, so ``--help`` (and any typo'd flag) silently ran
+a live sweep.
 """
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -30,7 +38,24 @@ if str(_HOOKS_DIR) not in sys.path:
 import _marker_reaper  # type: ignore  # noqa: E402  # pyright: ignore[reportMissingImports]
 
 
-def main() -> int:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI args. Defines no options, so a bare invocation runs the
+    sweep; ``-h``/``--help`` (exit 0) and any unknown token (exit 2) both
+    short-circuit via ``SystemExit`` before the sweep can start."""
+    parser = argparse.ArgumentParser(
+        prog="fence_marker_cleanup",
+        description=(
+            "Force an out-of-band sweep of orphaned pairing markers "
+            "(cascade + fence pending dirs), TTL-unlinking any marker past "
+            "MARKER_TTL_SECONDS. Takes no arguments; run bare to sweep."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Parse BEFORE any destructive work: --help / unknown-flag must not sweep.
+    _parse_args(sys.argv[1:] if argv is None else argv)
     results = _marker_reaper.reap_all()
     cascade = results["cascade"]
     fence = results["fence"]


### PR DESCRIPTION
Five independent, separately-committed repairs from the E146/E147 deferred-discovery ledger:

1. `session_context.py` — doc-staleness banner now names the threshold(s) that actually fired (">15 events", ">45 days", or both) instead of hardcoding the event wording for date-fallback docs.
2. `tools/fence_marker_cleanup.py` — argparse guard: `--help` exits 0 without sweeping, unknown flags exit 2 without sweeping (E146: `--help` used to run a live sweep); bare invocation unchanged.
3. `adapters/claude.py:194,345` — Pyright unreachable-code flags cleared by widening two param annotations to `object` (branches are NOT dead: they guard user-controlled settings.json input — deviation from the spec's "remove dead branches", documented and reviewer-verified).
4. `doc_references.py` — upstream-repo citations (`owner/repo`-slugged, owner outside the allowlisted source roots) no longer flagged as local dangling paths (E146 FP); real corpus unchanged at 30 findings — baseline neither grew nor shrank.
5. `_specificity.py` — observable failure-verb matching accepts inflected forms (base/-s/-es/-ed/-ing) as a strict superset of the previous lexicon.

Verification: red-green tests per item (+12 subtests); worktree suite 1580 passed + 88 subtests, 0 failed. Independent adversarial review (each item independently reproduced, skip-reasons verified, baseline-growth check): CLEAN (1 minor — the item-4 suppression admits a narrow synthetic FP shape `two-seg-token missing-path`; accepted as the conservative trade-off, documented).