### PR TITLE
fix: Event 148 follow-up — docs CLI cwd-root, rate-override boundary, fatigue short-circuit, Pyright

### DIFF
--- a/core/hooks/_spot_check.py
+++ b/core/hooks/_spot_check.py
@@ -78,7 +78,7 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Iterable, Literal
+from typing import Any, Iterable
 
 _HOOKS_DIR = Path(__file__).resolve().parent
 if str(_HOOKS_DIR) not in sys.path:
@@ -782,11 +782,15 @@ def stats(
 
 def _validate_verdict(
     entry: QueuedEntry,
-    verdicts: dict,
+    verdicts: object,
 ) -> str | None:
     """Return None when the verdict dict is shape-valid; return an
     error string when a required dimension is missing, absent, or
     carries an out-of-enum value."""
+    # `object`, not `dict`: `verdicts` originates in hook/CLI payload input,
+    # where it can be a non-dict. The isinstance guard is the live fail-safe;
+    # annotating the param `dict` made Pyright flag it as unreachable dead code
+    # (precedent: adapters/claude.py commit 8d3991a). Event 148 · follow-up.
     if not isinstance(verdicts, dict):
         return "verdicts must be a dict"
     sv = verdicts.get("surface_validity")

--- a/core/hooks/_spot_check.py
+++ b/core/hooks/_spot_check.py
@@ -165,8 +165,45 @@ def _anchor_path() -> Path:
     return _episteme_home() / "sample_schedule_anchor.json"
 
 
+# Mirror of reasoning_surface_guard._ROOT_WALK_MAX_DEPTH / _interrogation's
+# copy — duplicated per the hooks-stay-self-contained convention.
+_ROOT_WALK_MAX_DEPTH = 64
+
+
+def _canonical_project_root(cwd: Path) -> Path:
+    """Nearest ancestor holding ``.episteme/``, bounded by the repo boundary.
+
+    Mirrors ``_interrogation._canonical_project_root`` /
+    ``reasoning_surface_guard._resolve_episteme_root`` (duplicated per the
+    hooks-stay-self-contained convention): walk UP for a directory holding
+    ``.episteme/``, STOPPING at the first directory carrying a ``.git`` entry
+    (dir in a normal checkout, FILE in a linked worktree) and at the filesystem
+    root. The boundary directory itself is inspected first — a repo root
+    carries both. NEVER cross the boundary into a parent repo.
+
+    Event 148 follow-up — the per-project ``spot_check_rate`` override must
+    resolve the same boundary the Event-148 admission path adopted. Without it
+    the raw ``<cwd>/.episteme/spot_check_rate`` read (a) missed a root override
+    when the op ran from a subdirectory and (b) would, under a naive walk-up,
+    let a nested child repo inherit the parent's sampling rate. Returns ``cwd``
+    unchanged when nothing is found up to the boundary, so the override path
+    names a non-existent file and ``_read_project_override`` falls back to the
+    schedule (raw-cwd behavior preserved on the no-marker path).
+    """
+    probe = cwd.resolve() if cwd.exists() else cwd
+    for _ in range(_ROOT_WALK_MAX_DEPTH):
+        if (probe / ".episteme").is_dir():
+            return probe
+        if (probe / ".git").exists():
+            return cwd
+        if probe.parent == probe:
+            break
+        probe = probe.parent
+    return cwd
+
+
 def _project_override_path(cwd: Path) -> Path:
-    return cwd / ".episteme" / "spot_check_rate"
+    return _canonical_project_root(cwd) / ".episteme" / "spot_check_rate"
 
 
 def _skip_counter_path() -> Path:

--- a/core/hooks/_spot_check.py
+++ b/core/hooks/_spot_check.py
@@ -218,6 +218,14 @@ def _reflective_dir() -> Path:
     return _episteme_home() / "memory" / "reflective"
 
 
+# Mirror of ``_cognitive_budget.HISTORY_FILENAME`` — the approval-history file
+# name. Duplicated (not imported) so the fatigue short-circuit below can stat
+# the file WITHOUT importing the budget module. Kept in sync by convention;
+# ``_cognitive_budget._resolve_path`` joins the same name onto the reflective
+# dir, so the two stay consistent.
+_CB_APPROVAL_HISTORY_FILENAME = "approval_times.jsonl"
+
+
 # ---------------------------------------------------------------------------
 # Rate computation
 # ---------------------------------------------------------------------------
@@ -462,7 +470,24 @@ def _fatigue_active(
     today (``_cognitive_budget`` auto-instrumentation is deferred), so an
     empty stream yields no signal and this gate is a no-op — the hard
     pending cap remains the safety net. Never raises; fails toward *not
-    fatigued* (enqueue) when the budget module is unavailable."""
+    fatigued* (enqueue) when the budget module is unavailable.
+
+    Cheap short-circuit (FIX 3, Event 148 follow-up): because capture is
+    manual today the approvals file is absent or empty on the overwhelming
+    majority of ops. Stat the file — resolved the same way
+    ``_cognitive_budget._resolve_path`` does (reflective dir + history file
+    name) — BEFORE importing the budget module or walking/chain-verifying the
+    stream, and return *not fatigued* immediately when it is absent or empty.
+    This keeps the sampled-op hot path free of the import + chain walk until
+    the stream actually has content."""
+    rdir = reflective_dir if reflective_dir is not None else _reflective_dir()
+    approvals = rdir / _CB_APPROVAL_HISTORY_FILENAME
+    try:
+        if not approvals.is_file() or approvals.stat().st_size == 0:
+            return False
+    except OSError:
+        return False
+
     try:
         from episteme import (  # type: ignore  # pyright: ignore[reportMissingImports]
             _cognitive_budget as cb,
@@ -470,7 +495,6 @@ def _fatigue_active(
     except Exception:
         return False
     try:
-        rdir = reflective_dir if reflective_dir is not None else _reflective_dir()
         window, p50, rate = cb.load_thresholds(
             cwd if cwd is not None else Path.cwd()
         )

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -5873,9 +5873,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     docs_cmd = sub.add_parser("docs", help="Doc/artifact lifecycle — marker lint + generated index")
     docs_sub = docs_cmd.add_subparsers(dest="docs_action", required=True)
-    docs_sub.add_parser("lint", help="Validate lifecycle markers on every tracked docs/*.md (positive system)")
+    d_lint = docs_sub.add_parser("lint", help="Validate lifecycle markers on every tracked docs/*.md (positive system)")
+    d_lint.add_argument("--root", type=Path, default=None, help="Repo root to lint (default: git top-level of the current working directory)")
     d_index = docs_sub.add_parser("index", help="Regenerate the docs/README.md index from lifecycle markers")
     d_index.add_argument("--check", action="store_true", help="Verify the committed index is up to date (CI gate); do not write")
+    d_index.add_argument("--root", type=Path, default=None, help="Repo root to index (default: git top-level of the current working directory)")
 
     kernel = sub.add_parser("kernel", help="Kernel integrity manifest + ledger maintenance operations")
     kernel_sub = kernel.add_subparsers(dest="kernel_action", required=True)
@@ -6664,9 +6666,12 @@ def main(argv: Iterable[str] | None = None) -> int:
     if args.command == "docs":
         from . import doc_lifecycle as _dl
         if args.docs_action == "lint":
-            return _dl.run_lint_cli()
+            return _dl.run_lint_cli(root=getattr(args, "root", None))
         if args.docs_action == "index":
-            return _dl.run_index_cli(check=getattr(args, "check", False))
+            return _dl.run_index_cli(
+                root=getattr(args, "root", None),
+                check=getattr(args, "check", False),
+            )
         return 0
     if args.command == "memory":
         if args.memory_action == "record":

--- a/src/episteme/doc_lifecycle.py
+++ b/src/episteme/doc_lifecycle.py
@@ -498,11 +498,24 @@ def run_index_cli(root: Optional[Path] = None, check: bool = False) -> int:
 
 
 def _repo_root() -> Path:
-    """Resolve the repo root (git top-level, else the package's parents[2])."""
-    here = Path(__file__).resolve()
+    """Resolve the repo root for the CURRENT working directory.
+
+    Anchors ``git rev-parse --show-toplevel`` at :func:`Path.cwd` — NEVER at
+    the package location (``Path(__file__)``). The installed CLI must lint /
+    index the repo the operator is standing in; anchoring at the module would
+    make ``episteme docs lint`` always resolve the episteme package repo and
+    print a false 'clean' against whatever foreign repo the operator actually
+    invoked it from.
+
+    On failure (git absent, or cwd is not inside a working tree) falls back to
+    ``Path.cwd()`` itself — never to the package's ``parents[2]``. A lint that
+    honestly targets cwd (and may find nothing) is strictly safer than one that
+    silently reports a different repo as clean.
+    """
+    cwd = Path.cwd()
     try:
         proc = subprocess.run(
-            ["git", "-C", str(here.parent), "rev-parse", "--show-toplevel"],
+            ["git", "-C", str(cwd), "rev-parse", "--show-toplevel"],
             capture_output=True,
             text=True,
             check=True,
@@ -512,4 +525,4 @@ def _repo_root() -> Path:
             return Path(top)
     except (FileNotFoundError, subprocess.CalledProcessError):
         pass
-    return here.parents[2]
+    return cwd

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -8,6 +8,7 @@ real repo is clean. The fixtures build throwaway git repos so ``tracked_docs``'
 
 from __future__ import annotations
 
+import os
 import subprocess
 import unittest
 from pathlib import Path
@@ -250,6 +251,55 @@ class RepoCorpusTests(unittest.TestCase):
             "doc lifecycle violations in the tracked corpus:\n"
             + dl.format_findings(findings),
         )
+
+
+class RepoRootResolutionTests(unittest.TestCase):
+    """FIX 1 (Event 148 follow-up): ``_repo_root`` anchors the git call at the
+    CURRENT working directory, never the package location, so the installed CLI
+    lints/indexes the repo the operator is standing in. Pre-fix these FAIL: the
+    old ``_repo_root`` anchored at ``Path(__file__)`` and always linted the
+    episteme package repo (clean), so the CLI printed a false 'clean' against a
+    foreign repo carrying a broken doc.
+    """
+
+    def _fixture_with_broken_doc(self, root: Path) -> None:
+        _init_repo(root)
+        # A tracked docs/*.md with no lifecycle marker — a guaranteed failure.
+        _add(root, "docs/BROKEN.md", "# a doc with no lifecycle marker\n")
+
+    def test_run_lint_cli_anchors_at_cwd(self):
+        with TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            self._fixture_with_broken_doc(root)
+            prev = os.getcwd()
+            os.chdir(root)
+            try:
+                rc = dl.run_lint_cli()
+            finally:
+                os.chdir(prev)
+            self.assertEqual(rc, 1, "lint must fail against the cwd fixture")
+
+    def test_run_lint_cli_root_arg_overrides_discovery(self):
+        with TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            self._fixture_with_broken_doc(root)
+            # cwd stays the (clean) episteme repo; --root points at the fixture.
+            rc = dl.run_lint_cli(root=root)
+            self.assertEqual(rc, 1, "--root must override cwd discovery")
+
+    def test_repo_root_falls_back_to_cwd_not_package(self):
+        with TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            # NOT a git repo — resolution must fall back to cwd, never to the
+            # package's parents[2] (the episteme repo).
+            prev = os.getcwd()
+            os.chdir(root)
+            try:
+                resolved = dl._repo_root()
+            finally:
+                os.chdir(prev)
+            self.assertEqual(resolved, root)
+            self.assertNotEqual(resolved, _REPO_ROOT)
 
 
 if __name__ == "__main__":

--- a/tests/test_spot_check.py
+++ b/tests/test_spot_check.py
@@ -717,5 +717,50 @@ class FatigueGate(unittest.TestCase):
             )
 
 
+class ProjectOverrideRootResolution(unittest.TestCase):
+    """FIX 2 (Event 148 follow-up): ``_project_override_path`` mirrors the
+    boundary-aware walk-up now used by the guard / interrogation path. A
+    ``spot_check_rate`` at the project root applies from any subdirectory, and
+    a nested child repo does NOT inherit the parent's override (the ``.git``
+    boundary stops the walk).
+    """
+
+    def _mk(self, base: Path, rel: str, text: str) -> None:
+        p = base / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(text, encoding="utf-8")
+
+    def test_subdir_cwd_sees_root_override(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            (root / ".git").mkdir()
+            self._mk(root, ".episteme/spot_check_rate", "0.5\n")
+            deep = root / "a" / "b" / "c"
+            deep.mkdir(parents=True)
+            # Pre-fix: raw-cwd path -> deep/.episteme/... absent -> None.
+            self.assertAlmostEqual(
+                _spot_check._read_project_override(deep), 0.5
+            )
+
+    def test_nested_child_repo_does_not_see_parent_override(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            (root / ".git").mkdir()
+            self._mk(root, ".episteme/spot_check_rate", "0.5\n")
+            child = root / "child"
+            (child / ".git").mkdir(parents=True)  # child is its own repo
+            # The .git boundary must stop the walk before the parent's marker.
+            self.assertIsNone(_spot_check._read_project_override(child))
+
+    def test_root_cwd_still_sees_own_override(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td).resolve()
+            (root / ".git").mkdir()
+            self._mk(root, ".episteme/spot_check_rate", "0.25\n")
+            self.assertAlmostEqual(
+                _spot_check._read_project_override(root), 0.25
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spot_check.py
+++ b/tests/test_spot_check.py
@@ -717,6 +717,72 @@ class FatigueGate(unittest.TestCase):
             )
 
 
+class FatigueShortCircuit(unittest.TestCase):
+    """FIX 3 (Event 148 follow-up): a ``stat()``-level short-circuit returns
+    False for an absent / empty approvals file WITHOUT importing or walking the
+    cognitive-budget stream — the per-op ``detect_fatigue`` → ``walk_approvals``
+    cost only pays out once the stream actually has content.
+    """
+
+    def _guard_detect_fatigue(self):
+        """Replace ``detect_fatigue`` with a sentinel that must NOT run on the
+        short-circuit path. Returns (call_counter, restore_fn)."""
+        from episteme import _cognitive_budget as cb
+        called = {"n": 0}
+        orig = cb.detect_fatigue
+
+        def _boom(*a, **k):
+            called["n"] += 1
+            raise AssertionError("detect_fatigue must not run on absent/empty file")
+
+        cb.detect_fatigue = _boom
+
+        def _restore():
+            cb.detect_fatigue = orig
+
+        return called, _restore
+
+    def test_absent_file_returns_false_without_detect_fatigue(self):
+        with EphemeralHome() as home:
+            rdir = home / "memory" / "reflective"  # no file at all
+            called, restore = self._guard_detect_fatigue()
+            try:
+                self.assertFalse(_spot_check._fatigue_active(None, rdir))
+            finally:
+                restore()
+            self.assertEqual(called["n"], 0)
+
+    def test_empty_file_returns_false_without_detect_fatigue(self):
+        with EphemeralHome() as home:
+            rdir = home / "memory" / "reflective"
+            rdir.mkdir(parents=True, exist_ok=True)
+            (rdir / "approval_times.jsonl").write_text("", encoding="utf-8")
+            called, restore = self._guard_detect_fatigue()
+            try:
+                self.assertFalse(_spot_check._fatigue_active(None, rdir))
+            finally:
+                restore()
+            self.assertEqual(called["n"], 0)
+
+    def test_nonempty_file_reaches_detect_fatigue(self):
+        with EphemeralHome() as home:
+            from episteme import _cognitive_budget as cb
+            rdir = home / "memory" / "reflective"
+            rdir.mkdir(parents=True, exist_ok=True)
+            # Seed a sub-second approval stream: non-empty file -> short-circuit
+            # passes -> detect_fatigue runs and fires attention_bottleneck.
+            for i in range(5):
+                cb.record_approval(
+                    correlation_id=f"appr-{i}",
+                    blueprint="unknown",
+                    op_class="bash",
+                    elapsed_seconds=0.2,
+                    reason="seeded approval observation for the short-circuit test",
+                    reflective_dir=rdir,
+                )
+            self.assertTrue(_spot_check._fatigue_active(None, rdir))
+
+
 class ProjectOverrideRootResolution(unittest.TestCase):
     """FIX 2 (Event 148 follow-up): ``_project_override_path`` mirrors the
     boundary-aware walk-up now used by the guard / interrogation path. A


### PR DESCRIPTION
Four bounded fixes surfaced by the Event 148 independent reviews and the sanomap adoption lane:

1. **docs CLI root resolution (adoption-blocking):** `episteme docs lint|index` anchored root discovery at the installed module's location, so it silently linted the episteme repo from ANY cwd — a false "clean" for adopting repos. Now cwd-anchored (`git -C $(pwd) rev-parse`) with cwd fallback, plus an explicit `--root PATH` on both subcommands. Red-green: cwd inside a broken fixture repo now fails lint (pre-fix it passed against the wrong repo).
2. **spot-check rate override at the repo boundary:** `<raw cwd>/.episteme/spot_check_rate` → boundary-aware walk-up mirroring `_interrogation._canonical_project_root` (`.git` stop, dir-or-file, depth-cap 64, raw-cwd fallback). Subdir cwds now see the root override; nested child repos do not inherit a parent's.
3. **fatigue gate short-circuit:** `_fatigue_active` stats the approvals file before importing `_cognitive_budget` — absent/empty stream returns False with zero read cost (the review-flagged latent per-op cost once D11 auto-instrumentation lands). Budget-module chain-verify semantics untouched.
4. **Pyright hygiene in `_spot_check.py`:** `_validate_verdict(verdicts: object)` (guard protects hook-payload input; precedent 8d3991a) + unused `Literal` import removed. Behavior-neutral, suite-proven.

Verification: red-green per fix (+9 tests); worktree suite 1615 passed + 88 subtests, 0 failed; `pyright core/hooks/_spot_check.py` 0/0/0. Independent adversarial review: **CLEAN** (2 documented minors: filename constant sync-by-convention — failure direction falls back to the hard cap, not a silent bypass; `--root` on a nonexistent path is loud-fail pre-existing behavior).