### PR TITLE
chore(docs): stamp 1.9.0 GA into volatile-fact version spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This is the difference between a prompt reminder and a compiler: one asks nicely
 
 `episteme` is **not just a blocker**. The framework's real job is to turn every conflict it resolves into durable know-how that the agent re-applies automatically at the next matching decision.
 
-Here is the loop (v1.0.0 GA shipped · CP1–CP10 green; **<!-- episteme-fact:version -->1.9.0-rc1<!-- /episteme-fact:version -->** — see [`docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md)):
+Here is the loop (v1.0.0 GA shipped · CP1–CP10 green; **<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->** — see [`docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md)):
 
 1. **Detect conflict.** The agent encounters two valid-looking but incompatible approaches for a context it hasn't fully resolved before.
 2. **Decompose, don't average.** The Thinking Framework refuses the "average" answer. It forces the agent to extract *why* the sources conflict and which feature of the context tips the decision.
@@ -460,7 +460,7 @@ The four blueprints (above) and three pillars — Cognitive Blueprints · Append
 - **Arm B · Causal Synthesis** — zero-LLM entity extraction over the deferred-discovery stream produces cluster proposals the framework can act on. Verification window: 60 days.
 - **Arm C · Self-Consistency Convergence** — protocols promote to models that derive disconfirmations structurally. Verification window: 90 days.
 
-The distinction is load-bearing — pillars are settled vocabulary; arms are how the system audits and refines its own outputs across time. Status: **<!-- episteme-fact:version -->1.9.0-rc1<!-- /episteme-fact:version -->**. Arm A substrate shipped (supersede-with-history infrastructure + auto-instrumentation hooks that record operator profile + policy edits to chain streams); Arm A residue resumes opportunistically. **Arm B substrate-facing form formally SUNSET at Event 129** — its premise (a stable model-capability gap) was falsified by the Event 119–120 saturation finding; its operator-facing residue (`core/ptsp/` typed Fact/Inference promotion gate) is retained-and-reachable via `episteme practice trace`. Arm C scoped for a future cycle pending evidence the substrate-gap claim survives.
+The distinction is load-bearing — pillars are settled vocabulary; arms are how the system audits and refines its own outputs across time. Status: **<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->**. Arm A substrate shipped (supersede-with-history infrastructure + auto-instrumentation hooks that record operator profile + policy edits to chain streams); Arm A residue resumes opportunistically. **Arm B substrate-facing form formally SUNSET at Event 129** — its premise (a stable model-capability gap) was falsified by the Event 119–120 saturation finding; its operator-facing residue (`core/ptsp/` typed Fact/Inference promotion gate) is retained-and-reachable via `episteme practice trace`. Arm C scoped for a future cycle pending evidence the substrate-gap claim survives.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 <!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
-# Architecture — The Sovereign Kernel (<!-- episteme-fact:version -->1.9.0-rc1<!-- /episteme-fact:version -->)
+# Architecture — The Sovereign Kernel (<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->)
 
 > Mermaid flowchart. Renders natively on GitHub, Obsidian, and any CommonMark viewer with Mermaid support. **Five** subgraphs trace the full lifecycle from agent intention through the three-pillar kernel — Cognitive Blueprints, Append-Only Hash Chain, Framework Synthesis & Active Guidance — into praxis, the learning loop, and the post-v1.0-RC behavior-conformance extensions (Event 130 — Contract Gate; Event 131 — FAILURE_MODES mode 12 + CALIBRATION_TELEMETRY).
 >
-> **State.** This diagram depicts the **v1.0 RC shipped state** (spec: [`./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md), status *approved (reframed, third pass)* 2026-04-21) plus the v1.2-RC behavior-conformance extensions in Subgraph ⑤. All ten RC checkpoints shipped with paused-review-before-commit discipline. Current head: <!-- episteme-fact:version -->1.9.0-rc1<!-- /episteme-fact:version --> (via release-please; test counts are owned by CI, not this prose). v1.3.0-rc2 stages from this Event's `feat:` commits; release-please regenerates the staging PR automatically — no manual version edit.
+> **State.** This diagram depicts the **v1.0 RC shipped state** (spec: [`./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md), status *approved (reframed, third pass)* 2026-04-21) plus the v1.2-RC behavior-conformance extensions in Subgraph ⑤. All ten RC checkpoints shipped with paused-review-before-commit discipline. Current head: <!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version --> (via release-please; test counts are owned by CI, not this prose). v1.3.0-rc2 stages from this Event's `feat:` commits; release-please regenerates the staging PR automatically — no manual version edit.
 
 ---
 


### PR DESCRIPTION
First live run of the E147 volatile-fact stamper after a release: `episteme sync` rewrote the version spans in README.md and docs/ARCHITECTURE.md from the 1.9.0 manifest. Mechanical, idempotent, no prose changes.