### PR TITLE
feat(hooks): extend marker reaper to GC the four unbounded data-growth sinks (Event 148)

### DIFF
--- a/core/hooks/_marker_reaper.py
+++ b/core/hooks/_marker_reaper.py
@@ -49,8 +49,9 @@ unparseable ``written_at`` (schema drift), for the same reason.
 from __future__ import annotations
 
 import json
+import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -65,6 +66,84 @@ from _fence_synthesis import (  # noqa: E402  # pyright: ignore[reportMissingImp
 from _cascade_synthesis import (  # noqa: E402  # pyright: ignore[reportMissingImports]
     _pending_dir as _cascade_pending_dir,
 )
+
+# ---------------------------------------------------------------------------
+# Event 148 · LOG-GC — data-growth sinks (siblings of the marker sweep)
+# ---------------------------------------------------------------------------
+#
+# The E146 data-growth audit named four machine-local sinks that grow without
+# bound and have no reaper: the per-session advisory dedup markers, the
+# hooks.log invocation log, the home audit.jsonl gate-activity log, and the
+# per-day telemetry ``*-audit.jsonl`` files. This module already owns the
+# proven GC idiom (single shared sweep, silent-on-zero, FileNotFoundError-
+# tolerant at every step, age keyed on the same field the readers use,
+# imported by ``session_context.py`` at SessionStart). Event 148 EXTENDS that
+# idiom with sibling sweeps rather than standing up a second GC mechanism.
+#
+# Rotation safety (VERIFIED, Event 148): every writer of hooks.log
+# (``state_tracker``, ``fence_synthesis``, ``calibration_telemetry``,
+# ``episodic_writer``, ``_arm_a_pre``, ``_arm_a_post``) and the sole writer of
+# ``audit.jsonl`` (``reasoning_surface_guard._write_audit``) opens the file per
+# append with ``open(path, "a")`` — no long-lived handle is held across the
+# SessionStart sweep, so ``os.replace`` (atomic rename) cannot corrupt an
+# in-flight write. A writer racing the rename simply recreates the file on its
+# next append; ``.touch(exist_ok=True)`` after the rename never truncates it.
+#
+# audit.jsonl is NOT hash-chained (``src/episteme/_report.py`` reader:
+# "Raw line reads (no chain verification), consistent with _status.py"), so
+# rotating it cannot break any whole-file integrity check — rotation is safe.
+# Had the readers verified a hash chain spanning the whole file, rotation would
+# have severed it and this sweep would have skipped audit.jsonl and reported the
+# coupling instead; the reader evidence is what licenses rotating it here.
+
+# Age boundary for the per-session advisory dedup markers
+# (``state/advisory_shown/<id>.marker``): 7 days. Env-overridable.
+ADVISORY_SHOWN_TTL_SECONDS = int(
+    os.environ.get("EPISTEME_ADVISORY_SHOWN_TTL_SECONDS") or 7 * 24 * 3600
+)
+# Size caps for the append-only logs. Env-overridable. A file is rotated only
+# when it strictly EXCEEDS its cap (``> cap``), so a file sitting exactly at the
+# cap is left in place.
+HOOKS_LOG_CAP_BYTES = int(
+    os.environ.get("EPISTEME_HOOKS_LOG_CAP_BYTES") or 5 * 1024 * 1024
+)
+AUDIT_LOG_CAP_BYTES = int(
+    os.environ.get("EPISTEME_AUDIT_LOG_CAP_BYTES") or 10 * 1024 * 1024
+)
+# Telemetry ``*-audit.jsonl`` retention: reap files whose mtime is older than
+# 30 days, but ALWAYS keep the newest N regardless of age (so a long-idle
+# framework never loses its most recent calibration window). Both env-overridable.
+TELEMETRY_TTL_SECONDS = int(
+    os.environ.get("EPISTEME_TELEMETRY_TTL_SECONDS") or 30 * 24 * 3600
+)
+TELEMETRY_KEEP_NEWEST = int(
+    os.environ.get("EPISTEME_TELEMETRY_KEEP_NEWEST") or 20
+)
+
+
+def _episteme_home() -> Path:
+    """Resolve the episteme state root, honoring ``EPISTEME_HOME`` — mirrors
+    the resolver the guard / spot-check / pending-marker modules use, so a
+    relocated ``EPISTEME_HOME`` keeps ALL sweep targets under one root and
+    tests that set ``EPISTEME_HOME`` (or patch ``Path.home``) stay isolated
+    from live ``~/.episteme`` state."""
+    return Path(os.environ.get("EPISTEME_HOME") or (Path.home() / ".episteme"))
+
+
+def _advisory_shown_dir() -> Path:
+    return _episteme_home() / "state" / "advisory_shown"
+
+
+def _hooks_log_path() -> Path:
+    return _episteme_home() / "state" / "hooks.log"
+
+
+def _audit_log_path() -> Path:
+    return _episteme_home() / "audit.jsonl"
+
+
+def _telemetry_dir() -> Path:
+    return _episteme_home() / "telemetry"
 
 
 @dataclass
@@ -211,6 +290,290 @@ def format_summary(results: dict[str, ReapResult]) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Event 148 · advisory_shown dedup markers — TTL reap
+# ---------------------------------------------------------------------------
+
+
+def _advisory_age_seconds(path: Path, now: datetime) -> float | None:
+    """Age of one ``advisory_shown`` marker, or ``None`` when it vanished /
+    cannot be assessed. The marker's whole content is the ISO timestamp the
+    guard wrote (``reasoning_surface_guard._should_show_full_surface`` writes
+    ``datetime.now(timezone.utc).isoformat()``), so age is ``now - <content>``
+    — byte-identical semantics to the writer. Falls back to file ``mtime`` when
+    the content is empty or not a parseable timestamp. Never raises."""
+    try:
+        mtime_ts = path.stat().st_mtime
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return None
+    mtime_age = (now - datetime.fromtimestamp(mtime_ts, tz=timezone.utc)).total_seconds()
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return mtime_age
+    if text:
+        try:
+            wdt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            if wdt.tzinfo is None:
+                wdt = wdt.replace(tzinfo=timezone.utc)
+            return (now - wdt).total_seconds()
+        except ValueError:
+            return mtime_age
+    return mtime_age
+
+
+def reap_advisory_shown(
+    now: datetime | None = None,
+    ttl_seconds: int = ADVISORY_SHOWN_TTL_SECONDS,
+    advisory_dir: Path | None = None,
+) -> ReapResult:
+    """Unlink every ``advisory_shown/*.marker`` older than ``ttl_seconds``.
+    One marker per session accumulates forever (the dedup marker is never
+    cleaned by the guard). Missing dir is a no-op; every file step tolerates a
+    vanishing file. Never raises."""
+    result = ReapResult()
+    if now is None:
+        now = datetime.now(timezone.utc)
+    d = advisory_dir if advisory_dir is not None else _advisory_shown_dir()
+    if not d.is_dir():
+        return result
+    try:
+        entries = list(d.glob("*.marker"))
+    except OSError:
+        return result
+    for path in entries:
+        age = _advisory_age_seconds(path, now)
+        if age is None:
+            result.vanished += 1
+            continue
+        if age <= ttl_seconds:
+            result.kept += 1
+            continue
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            result.vanished += 1
+            continue
+        except OSError:
+            result.kept += 1
+            continue
+        result.reaped += 1
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Event 148 · hooks.log + audit.jsonl — size-capped single-generation rotation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RotateResult:
+    """Outcome of one size-capped rotation.
+
+    - ``rotated``      — True iff the file exceeded its cap and was rotated to
+                         ``<name>.1`` (previous ``.1`` discarded).
+    - ``bytes_before`` — size of the file at rotation time (0 when not rotated).
+    """
+
+    rotated: bool = False
+    bytes_before: int = 0
+
+
+def rotate_oversized_log(path: Path, cap_bytes: int) -> RotateResult:
+    """Rotate ``path`` to ``<path>.1`` when it strictly exceeds ``cap_bytes``,
+    keeping exactly ONE archive generation (the prior ``.1`` is atomically
+    replaced by ``os.replace``). Never truncates in place: the live file is
+    renamed, then recreated empty via ``touch(exist_ok=True)`` — safe because
+    every writer opens the log per-append (verified, module docstring), so a
+    writer racing the rename recreates the file itself and the touch does not
+    clobber it. Missing / sub-cap file is a no-op. Never raises."""
+    result = RotateResult()
+    try:
+        size = path.stat().st_size
+    except FileNotFoundError:
+        return result
+    except OSError:
+        return result
+    if size <= cap_bytes:
+        return result
+    archive = path.parent / (path.name + ".1")
+    try:
+        # os.replace atomically overwrites any existing archive, so exactly one
+        # generation is kept without a separate unlink step.
+        os.replace(path, archive)
+    except FileNotFoundError:
+        # Rotated/removed by another actor between stat and replace.
+        return result
+    except OSError:
+        return result
+    try:
+        path.touch(exist_ok=True)
+    except OSError:
+        pass  # a writer will recreate on next append; recreation is best-effort
+    result.rotated = True
+    result.bytes_before = size
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Event 148 · telemetry *-audit.jsonl — age reap with keep-newest-N floor
+# ---------------------------------------------------------------------------
+
+
+def reap_telemetry(
+    now: datetime | None = None,
+    ttl_seconds: int = TELEMETRY_TTL_SECONDS,
+    keep_newest: int = TELEMETRY_KEEP_NEWEST,
+    telemetry_dir: Path | None = None,
+) -> ReapResult:
+    """Reap ``telemetry/*-audit.jsonl`` files whose ``mtime`` is older than
+    ``ttl_seconds``, ALWAYS keeping the newest ``keep_newest`` by mtime
+    regardless of age. ``tier1.jsonl`` does not match the glob and is never
+    touched. Age keys on ``mtime`` because these are per-day append logs with
+    no in-payload age field the readers use. Missing dir is a no-op; every file
+    step tolerates a vanishing file. Never raises."""
+    result = ReapResult()
+    if now is None:
+        now = datetime.now(timezone.utc)
+    d = telemetry_dir if telemetry_dir is not None else _telemetry_dir()
+    if not d.is_dir():
+        return result
+    try:
+        paths = list(d.glob("*-audit.jsonl"))
+    except OSError:
+        return result
+    stamped: list[tuple[float, str, Path]] = []
+    for p in paths:
+        try:
+            mt = p.stat().st_mtime
+        except FileNotFoundError:
+            result.vanished += 1
+            continue
+        except OSError:
+            result.kept += 1
+            continue
+        stamped.append((mt, p.name, p))
+    # Newest first; name breaks mtime ties deterministically.
+    stamped.sort(key=lambda t: (t[0], t[1]), reverse=True)
+    floor = max(keep_newest, 0)
+    # The newest `floor` files are kept unconditionally (the keep-newest-N floor).
+    result.kept += len(stamped[:floor])
+    for mt, _name, p in stamped[floor:]:
+        age = (now - datetime.fromtimestamp(mt, tz=timezone.utc)).total_seconds()
+        if age <= ttl_seconds:
+            result.kept += 1
+            continue
+        try:
+            p.unlink()
+        except FileNotFoundError:
+            result.vanished += 1
+            continue
+        except OSError:
+            result.kept += 1
+            continue
+        result.reaped += 1
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Event 148 · combined sweep + one-line summary (SessionStart carrier)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SweepResult:
+    """Aggregate of every data-growth sweep run once per session."""
+
+    markers: dict[str, ReapResult] = field(default_factory=dict)
+    advisory: ReapResult = field(default_factory=ReapResult)
+    hooks_log: RotateResult = field(default_factory=RotateResult)
+    audit_log: RotateResult = field(default_factory=RotateResult)
+    telemetry: ReapResult = field(default_factory=ReapResult)
+    # Resolved boundaries carried for the summary wording.
+    advisory_ttl_seconds: int = ADVISORY_SHOWN_TTL_SECONDS
+    telemetry_ttl_seconds: int = TELEMETRY_TTL_SECONDS
+    telemetry_keep_newest: int = TELEMETRY_KEEP_NEWEST
+
+
+def sweep_all(now: datetime | None = None) -> SweepResult:
+    """Run every Event 146 + 148 data-growth sweep once. Reads the env-
+    overridable boundaries at call time so a test (or operator) override takes
+    effect without re-import. Never raises past its boundary — each sub-sweep is
+    already fail-tolerant, and this wrapper adds no new IO of its own."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    advisory_ttl = int(
+        os.environ.get("EPISTEME_ADVISORY_SHOWN_TTL_SECONDS")
+        or ADVISORY_SHOWN_TTL_SECONDS
+    )
+    hooks_cap = int(
+        os.environ.get("EPISTEME_HOOKS_LOG_CAP_BYTES") or HOOKS_LOG_CAP_BYTES
+    )
+    audit_cap = int(
+        os.environ.get("EPISTEME_AUDIT_LOG_CAP_BYTES") or AUDIT_LOG_CAP_BYTES
+    )
+    telemetry_ttl = int(
+        os.environ.get("EPISTEME_TELEMETRY_TTL_SECONDS") or TELEMETRY_TTL_SECONDS
+    )
+    telemetry_keep = int(
+        os.environ.get("EPISTEME_TELEMETRY_KEEP_NEWEST") or TELEMETRY_KEEP_NEWEST
+    )
+    return SweepResult(
+        markers=reap_all(now),
+        advisory=reap_advisory_shown(now, advisory_ttl),
+        hooks_log=rotate_oversized_log(_hooks_log_path(), hooks_cap),
+        audit_log=rotate_oversized_log(_audit_log_path(), audit_cap),
+        telemetry=reap_telemetry(now, telemetry_ttl, telemetry_keep),
+        advisory_ttl_seconds=advisory_ttl,
+        telemetry_ttl_seconds=telemetry_ttl,
+        telemetry_keep_newest=telemetry_keep,
+    )
+
+
+def _mb(n: int) -> str:
+    return f"{n / (1024 * 1024):.1f}MB"
+
+
+def format_sweep_summary(sweep: SweepResult) -> str:
+    """One-line summary of everything the sweep changed, as ``; ``-joined
+    segments. Returns "" when nothing was reaped or rotated, so the caller can
+    keep the SessionStart banner silent-on-zero. The marker segment reuses
+    ``format_summary`` so the "N cascade + M fence" wording has one source."""
+    segments: list[str] = []
+    m = sweep.markers
+    if m:
+        marker_reaped = m.get("cascade", ReapResult()).reaped + m.get(
+            "fence", ReapResult()
+        ).reaped
+        if marker_reaped > 0:
+            segments.append(f"marker-gc: {format_summary(m)}")
+    if sweep.advisory.reaped > 0:
+        days = sweep.advisory_ttl_seconds // 86400
+        noun = "marker" if sweep.advisory.reaped == 1 else "markers"
+        segments.append(
+            f"advisory-gc: reaped {sweep.advisory.reaped} dedup {noun} past {days}d TTL"
+        )
+    rot: list[str] = []
+    if sweep.hooks_log.rotated:
+        rot.append(f"hooks.log ({_mb(sweep.hooks_log.bytes_before)})")
+    if sweep.audit_log.rotated:
+        rot.append(f"audit.jsonl ({_mb(sweep.audit_log.bytes_before)})")
+    if rot:
+        segments.append("log-rotate: " + ", ".join(rot))
+    if sweep.telemetry.reaped > 0:
+        days = sweep.telemetry_ttl_seconds // 86400
+        noun = "file" if sweep.telemetry.reaped == 1 else "files"
+        segments.append(
+            f"telemetry-gc: reaped {sweep.telemetry.reaped} audit {noun} past "
+            f"{days}d (kept newest {sweep.telemetry_keep_newest})"
+        )
+    return "; ".join(segments)
+
+
+# ---------------------------------------------------------------------------
 # Test helpers — expose the reused dir resolvers so tests do not have to
 # reach into two private modules.
 # ---------------------------------------------------------------------------
@@ -221,3 +584,19 @@ def cascade_pending_dir_for_tests() -> Path:
 
 def fence_pending_dir_for_tests() -> Path:
     return _fence_pending_dir()
+
+
+def advisory_shown_dir_for_tests() -> Path:
+    return _advisory_shown_dir()
+
+
+def hooks_log_path_for_tests() -> Path:
+    return _hooks_log_path()
+
+
+def audit_log_path_for_tests() -> Path:
+    return _audit_log_path()
+
+
+def telemetry_dir_for_tests() -> Path:
+    return _telemetry_dir()

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -235,13 +235,17 @@ def _reaper_line() -> str | None:
         sys.path.insert(0, str(_hooks_dir))
     try:
         import _marker_reaper  # type: ignore  # pyright: ignore[reportMissingImports]
-        results = _marker_reaper.reap_all()
+        # Event 148 — the sweep now covers all four unbounded data-growth
+        # sinks the E146 audit named (pairing markers + advisory dedup markers
+        # + size-capped hooks.log/audit.jsonl rotation + telemetry reap), not
+        # just the two pairing-marker dirs. format_sweep_summary returns "" when
+        # nothing changed, preserving the silent-on-zero contract.
+        summary = _marker_reaper.format_sweep_summary(_marker_reaper.sweep_all())
     except Exception:
         return None
-    total_reaped = results["cascade"].reaped + results["fence"].reaped
-    if total_reaped <= 0:
+    if not summary:
         return None
-    return f"marker-gc: {_marker_reaper.format_summary(results)}"
+    return summary
 
 
 _DOC_STALENESS_EVENT_LAG = 15

--- a/tests/test_marker_reaper.py
+++ b/tests/test_marker_reaper.py
@@ -364,5 +364,307 @@ class CliTool(unittest.TestCase):
         self.assertNotIn("vanished=", proc.stderr)  # sweep-summary token, absent ⇒ no sweep
 
 
+# ===========================================================================
+# Event 148 · LOG-GC — advisory_shown / hooks.log + audit.jsonl / telemetry
+# ===========================================================================
+
+
+def _write_advisory(d: Path, name: str, written_at: datetime | None) -> Path:
+    """Write an advisory_shown marker whose whole content is an ISO timestamp,
+    mirroring reasoning_surface_guard._should_show_full_surface. When
+    written_at is None the file is empty (age falls back to mtime)."""
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{name}.marker"
+    p.write_text("" if written_at is None else written_at.isoformat(), encoding="utf-8")
+    return p
+
+
+class AdvisoryShownReap(unittest.TestCase):
+    def test_ttl_boundary_just_under_stays_just_over_reaped(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            d = reaper.advisory_shown_dir_for_tests()
+            ttl = reaper.ADVISORY_SHOWN_TTL_SECONDS
+            under = _write_advisory(d, "under", now - timedelta(seconds=ttl - 1))
+            over = _write_advisory(d, "over", now - timedelta(seconds=ttl + 1))
+            res = reaper.reap_advisory_shown(now=now)
+            self.assertTrue(under.exists(), "marker just under 7d TTL must survive")
+            self.assertFalse(over.exists(), "marker just over 7d TTL must be unlinked")
+            self.assertEqual((res.reaped, res.kept), (1, 1))
+
+    def test_age_keyed_on_iso_content_not_mtime(self):
+        # Content says 30 days old, but mtime is fresh (just written). Age must
+        # follow the ISO content, so the marker is reaped despite a fresh mtime.
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            d = reaper.advisory_shown_dir_for_tests()
+            p = _write_advisory(d, "old_content", now - timedelta(days=30))
+            res = reaper.reap_advisory_shown(now=now)
+            self.assertFalse(p.exists())
+            self.assertEqual(res.reaped, 1)
+
+    def test_empty_marker_ages_by_mtime(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            d = reaper.advisory_shown_dir_for_tests()
+            fresh = _write_advisory(d, "empty_fresh", None)
+            stale = _write_advisory(d, "empty_stale", None)
+            old = (now - timedelta(days=8)).timestamp()
+            os.utime(stale, (old, old))
+            res = reaper.reap_advisory_shown(now=now)
+            self.assertTrue(fresh.exists(), "fresh empty marker kept (mtime fallback)")
+            self.assertFalse(stale.exists(), "stale empty marker reaped by mtime")
+            self.assertEqual((res.reaped, res.kept), (1, 1))
+
+    def test_missing_dir_is_noop(self):
+        with _TmpHome():
+            res = reaper.reap_advisory_shown()
+            self.assertEqual((res.reaped, res.kept, res.vanished), (0, 0, 0))
+
+    def test_delete_between_scan_and_unlink_no_exception(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            d = reaper.advisory_shown_dir_for_tests()
+            _write_advisory(d, "racey", now - timedelta(days=10))
+
+            def _boom(self, *a, **k):
+                raise FileNotFoundError(self)
+
+            with patch.object(Path, "unlink", _boom):
+                res = reaper.reap_advisory_shown(now=now)  # must not raise
+            self.assertEqual(res.reaped, 0)
+            self.assertGreaterEqual(res.vanished, 1)
+
+    def test_env_override_ttl(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            d = reaper.advisory_shown_dir_for_tests()
+            p = _write_advisory(d, "twoday", now - timedelta(days=2))
+            prev = os.environ.get("EPISTEME_ADVISORY_SHOWN_TTL_SECONDS")
+            os.environ["EPISTEME_ADVISORY_SHOWN_TTL_SECONDS"] = str(24 * 3600)
+            try:
+                sweep = reaper.sweep_all(now=now)
+            finally:
+                if prev is None:
+                    os.environ.pop("EPISTEME_ADVISORY_SHOWN_TTL_SECONDS", None)
+                else:
+                    os.environ["EPISTEME_ADVISORY_SHOWN_TTL_SECONDS"] = prev
+            self.assertFalse(p.exists(), "2d-old marker reaped under 1d override")
+            self.assertEqual(sweep.advisory.reaped, 1)
+
+
+class LogRotation(unittest.TestCase):
+    def test_cap_boundary_at_cap_not_rotated_over_cap_rotated(self):
+        with _TmpHome():
+            p = reaper.hooks_log_path_for_tests()
+            p.parent.mkdir(parents=True, exist_ok=True)
+            cap = 100
+            # Exactly at cap → not rotated.
+            p.write_bytes(b"x" * cap)
+            res = reaper.rotate_oversized_log(p, cap)
+            self.assertFalse(res.rotated, "file exactly at cap must NOT rotate")
+            self.assertFalse((p.parent / (p.name + ".1")).exists())
+            # One byte over cap → rotated.
+            p.write_bytes(b"x" * (cap + 1))
+            res = reaper.rotate_oversized_log(p, cap)
+            self.assertTrue(res.rotated, "file over cap must rotate")
+            self.assertEqual(res.bytes_before, cap + 1)
+            archive = p.parent / (p.name + ".1")
+            self.assertTrue(archive.exists(), "archive .1 created")
+            self.assertEqual(archive.read_bytes(), b"x" * (cap + 1))
+            self.assertTrue(p.exists(), "live file recreated (empty) after rotate")
+            self.assertEqual(p.stat().st_size, 0)
+
+    def test_single_generation_previous_archive_discarded(self):
+        with _TmpHome():
+            p = reaper.audit_log_path_for_tests()
+            p.parent.mkdir(parents=True, exist_ok=True)
+            cap = 10
+            # First rotation leaves gen-1 content in .1.
+            p.write_bytes(b"AAAAAAAAAAA")  # 11 bytes > cap
+            reaper.rotate_oversized_log(p, cap)
+            archive = p.parent / (p.name + ".1")
+            self.assertEqual(archive.read_bytes(), b"AAAAAAAAAAA")
+            # Second rotation: .1 must hold gen-2, gen-1 discarded (one generation).
+            p.write_bytes(b"BBBBBBBBBBB")
+            reaper.rotate_oversized_log(p, cap)
+            self.assertEqual(archive.read_bytes(), b"BBBBBBBBBBB")
+
+    def test_missing_file_is_noop(self):
+        with _TmpHome():
+            p = reaper.hooks_log_path_for_tests()
+            res = reaper.rotate_oversized_log(p, 5)
+            self.assertFalse(res.rotated)
+            self.assertFalse(p.exists())
+
+    def test_replace_failure_does_not_raise(self):
+        with _TmpHome():
+            p = reaper.hooks_log_path_for_tests()
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"x" * 50)
+
+            def _boom(*a, **k):
+                raise OSError("simulated replace failure")
+
+            with patch("os.replace", _boom):
+                res = reaper.rotate_oversized_log(p, 10)  # must not raise
+            self.assertFalse(res.rotated)
+            self.assertTrue(p.exists(), "live file untouched when replace fails")
+
+
+class TelemetryReap(unittest.TestCase):
+    def _write_tel(self, d: Path, name: str, age_days: float) -> Path:
+        d.mkdir(parents=True, exist_ok=True)
+        p = d / name
+        p.write_text("{}\n", encoding="utf-8")
+        ts = (datetime.now(timezone.utc) - timedelta(days=age_days)).timestamp()
+        os.utime(p, (ts, ts))
+        return p
+
+    def test_old_reaped_recent_kept_by_mtime(self):
+        with _TmpHome():
+            d = reaper.telemetry_dir_for_tests()
+            fresh = self._write_tel(d, "2026-07-01-audit.jsonl", 5)
+            old = self._write_tel(d, "2026-01-01-audit.jsonl", 60)
+            res = reaper.reap_telemetry(keep_newest=0)
+            self.assertTrue(fresh.exists())
+            self.assertFalse(old.exists())
+            self.assertEqual(res.reaped, 1)
+
+    def test_keep_newest_floor_overrides_age(self):
+        # 25 files, ALL 60 days old (all past TTL). keep_newest=20 must preserve
+        # the newest 20 by mtime regardless of age; only 5 oldest are reaped.
+        with _TmpHome():
+            d = reaper.telemetry_dir_for_tests()
+            paths = []
+            for i in range(25):
+                # age decreases with i, so higher i == newer (larger mtime)
+                paths.append(self._write_tel(d, f"f{i:02d}-audit.jsonl", 60 + (25 - i)))
+            res = reaper.reap_telemetry(keep_newest=20)
+            self.assertEqual(res.reaped, 5, "only the 5 oldest past-TTL files reaped")
+            self.assertEqual(res.kept, 20)
+            survivors = sorted(pp.name for pp in d.glob("*-audit.jsonl"))
+            self.assertEqual(len(survivors), 20)
+            # The 5 oldest (lowest i) are gone; newest 20 (i>=5) survive.
+            self.assertNotIn("f00-audit.jsonl", survivors)
+            self.assertIn("f05-audit.jsonl", survivors)
+            self.assertIn("f24-audit.jsonl", survivors)
+
+    def test_tier1_jsonl_never_matched(self):
+        with _TmpHome():
+            d = reaper.telemetry_dir_for_tests()
+            tier1 = d / "tier1.jsonl"
+            d.mkdir(parents=True, exist_ok=True)
+            tier1.write_text("{}\n", encoding="utf-8")
+            old = (datetime.now(timezone.utc) - timedelta(days=365)).timestamp()
+            os.utime(tier1, (old, old))
+            res = reaper.reap_telemetry(keep_newest=0)
+            self.assertTrue(tier1.exists(), "tier1.jsonl must never be reaped")
+            self.assertEqual(res.reaped, 0)
+
+    def test_missing_dir_is_noop(self):
+        with _TmpHome():
+            res = reaper.reap_telemetry()
+            self.assertEqual((res.reaped, res.kept, res.vanished), (0, 0, 0))
+
+    def test_env_overrides(self):
+        with _TmpHome():
+            d = reaper.telemetry_dir_for_tests()
+            self._write_tel(d, "a-audit.jsonl", 3)
+            self._write_tel(d, "b-audit.jsonl", 3)
+            self._write_tel(d, "c-audit.jsonl", 3)
+            prev_ttl = os.environ.get("EPISTEME_TELEMETRY_TTL_SECONDS")
+            prev_keep = os.environ.get("EPISTEME_TELEMETRY_KEEP_NEWEST")
+            os.environ["EPISTEME_TELEMETRY_TTL_SECONDS"] = str(24 * 3600)  # 1d
+            os.environ["EPISTEME_TELEMETRY_KEEP_NEWEST"] = "1"
+            try:
+                sweep = reaper.sweep_all()
+            finally:
+                for k, v in (
+                    ("EPISTEME_TELEMETRY_TTL_SECONDS", prev_ttl),
+                    ("EPISTEME_TELEMETRY_KEEP_NEWEST", prev_keep),
+                ):
+                    if v is None:
+                        os.environ.pop(k, None)
+                    else:
+                        os.environ[k] = v
+            # 3 files, all 3d old (> 1d TTL), keep newest 1 → reap 2.
+            self.assertEqual(sweep.telemetry.reaped, 2)
+            self.assertEqual(sweep.telemetry.kept, 1)
+
+
+class SweepAllAndSummary(unittest.TestCase):
+    def test_never_raises_on_empty_home(self):
+        with _TmpHome():
+            sweep = reaper.sweep_all()  # nothing exists anywhere
+            self.assertEqual(reaper.format_sweep_summary(sweep), "")
+
+    def test_summary_combines_all_active_segments(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            # marker
+            _write_marker(_fence_dir(), "f_stale", now - timedelta(days=2))
+            # advisory
+            _write_advisory(
+                reaper.advisory_shown_dir_for_tests(), "adv", now - timedelta(days=10)
+            )
+            # hooks.log over cap
+            hl = reaper.hooks_log_path_for_tests()
+            hl.parent.mkdir(parents=True, exist_ok=True)
+            hl.write_bytes(b"x" * (5 * 1024 * 1024 + 1))
+            # telemetry old — keep_newest overridden to 0 so the single old
+            # file is past-TTL-reapable (the floor would otherwise preserve it).
+            td = reaper.telemetry_dir_for_tests()
+            td.mkdir(parents=True, exist_ok=True)
+            tp = td / "old-audit.jsonl"
+            tp.write_text("{}\n", encoding="utf-8")
+            oldts = (now - timedelta(days=40)).timestamp()
+            os.utime(tp, (oldts, oldts))
+
+            prev_keep = os.environ.get("EPISTEME_TELEMETRY_KEEP_NEWEST")
+            os.environ["EPISTEME_TELEMETRY_KEEP_NEWEST"] = "0"
+            try:
+                sweep = reaper.sweep_all(now=now)
+            finally:
+                if prev_keep is None:
+                    os.environ.pop("EPISTEME_TELEMETRY_KEEP_NEWEST", None)
+                else:
+                    os.environ["EPISTEME_TELEMETRY_KEEP_NEWEST"] = prev_keep
+            line = reaper.format_sweep_summary(sweep)
+            self.assertIn("marker-gc:", line)
+            self.assertIn("1 fence", line)
+            self.assertIn("advisory-gc:", line)
+            self.assertIn("log-rotate:", line)
+            self.assertIn("hooks.log", line)
+            self.assertIn("telemetry-gc:", line)
+            self.assertIn("kept newest", line)
+
+    def test_reaper_line_silent_on_zero_all_sinks(self):
+        with _TmpHome():
+            self.assertIsNone(sc._reaper_line())
+
+    def test_reaper_line_fires_on_advisory_only(self):
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            _write_advisory(
+                reaper.advisory_shown_dir_for_tests(), "adv", now - timedelta(days=10)
+            )
+            line = sc._reaper_line()
+            assert line is not None
+            self.assertIn("advisory-gc:", line)
+
+    def test_reaper_line_still_reports_markers(self):
+        # Backward-compat: marker-only sweep still produces the marker-gc line.
+        with _TmpHome():
+            now = datetime.now(timezone.utc)
+            _write_marker(_fence_dir(), "f_stale", now - timedelta(days=2))
+            _write_marker(_cascade_dir(), "c_stale", now - timedelta(days=2))
+            line = sc._reaper_line()
+            assert line is not None
+            self.assertIn("marker-gc", line)
+            self.assertIn("1 cascade", line)
+            self.assertIn("1 fence", line)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes the last mechanical items on the E146 data-growth bottleneck list by extending the proven Event 146 reaper (single shared sweep, silent-on-zero, never-raises) — no second GC mechanism (anti-accretion):

- `advisory_shown/` markers: 7-day TTL, aged on the ISO timestamp the guard writes (byte-identical to writer semantics), mtime fallback.
- `hooks.log` (6.2MB live): size-capped rotation at 5MB — rename-then-recreate, one archive generation. Writer safety VERIFIED by reading all six writers (per-append `open(path,'a')`, no long-lived handles).
- `audit.jsonl` (7.8MB live): rotation at 10MB. Chain-coupling claim checked before touching: the stream is NOT hash-chained (`_report.py:409` reads raw lines, no verification) — rotation breaks no integrity check.
- `telemetry/` (32MB, 60+ files): per-file 30-day reap with a keep-newest-20 floor; `tier1.jsonl` preserved (outside the `*-audit.jsonl` glob).

All caps/TTLs are module constants with env overrides. SessionStart emits one summary line only when something was reaped/rotated. Deliberate rule-shape deviation (documented): the sweeps ride the SessionStart carrier only — `tools/fence_marker_cleanup.py` stays marker-scoped per its name/contract.

Verification: 20 new fixture tests incl. mutation-tested cap boundary and keep-newest floor; worktree suite 1635 passed + 88 subtests, 0 failed. Independent adversarial review (rotation race with real writer patterns, chain-coupling verification, off-by-one, latency measurement): CLEAN — 2 documented minors (pathological first-run backlog ~50-100ms, self-healing after one sweep; pre-existing writer EPISTEME_HOME inconsistency, production-safe).