### PR TITLE
fix: E148 Fable-direct verification findings — index carrier gap, at-cap surfacing, policy-mirror drift

### DIFF
--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -34,9 +34,22 @@ def _spot_check_line() -> str | None:
     if pending <= 0:
         return None
     noun = "surface" if pending == 1 else "surfaces"
-    return (
-        f"{pending} {noun} flagged for review — run `episteme review`"
-    )
+    line = f"{pending} {noun} flagged for review — run `episteme review`"
+    # Event 148 verification finding — at/over the enqueue cap the samplers
+    # skip silently (audit coverage degrades while only the sidecar counter
+    # records it); say so on the SAME line rather than adding a producer.
+    # Below cap — the normal state — the line is byte-identical to before.
+    try:
+        cap = _spot_check._resolve_pending_cap()
+        if cap and pending >= cap:
+            skipped = _spot_check.read_skip_counter().get("skipped_count", 0)
+            line += (
+                f" — queue AT CAP ({cap}): sampling paused, "
+                f"{skipped} op(s) skipped since last drain"
+            )
+    except Exception:
+        pass
+    return line
 
 
 def _last_session_path() -> Path:

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ hand-edit between the markers; run the command and commit the result.
 <!-- episteme-docs-index:start -->
 - [`ADAPTER_PORTABILITY.md`](./ADAPTER_PORTABILITY.md) · report · Adapter Portability Audit
 - [`ANTHROPIC_MANAGED_AGENTS_BRIDGE.md`](./ANTHROPIC_MANAGED_AGENTS_BRIDGE.md) · living · Anthropic Managed Agents Bridge
-- [`ARCHITECTURE.md`](./ARCHITECTURE.md) · living · Architecture — The Sovereign Kernel (1.9.0-rc1)
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) · living · Architecture — The Sovereign Kernel (1.9.0)
 - [`COMMANDS.md`](./COMMANDS.md) · living · episteme — command reference
 - [`COMPLIANCE_CROSSWALK.md`](./COMPLIANCE_CROSSWALK.md) · living · Compliance Crosswalk — `signed-surface@1.0` → Regulatory Clauses
 - [`CONTRACT_GATE.md`](./CONTRACT_GATE.md) · living · Contract Gate — deterministic contract-test complement to the Reasoning Surface

--- a/docs/THE_WAY_TO_THINK.md
+++ b/docs/THE_WAY_TO_THINK.md
@@ -1,4 +1,4 @@
-<!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E148 -->
 # The Way to Think — 생각의 틀
 
 > *"The product is a way to think when the model can finish your sentences."*
@@ -65,7 +65,7 @@ Validate against the success metric, not effort spent. Distinguish proven facts 
 | Hypothesis evaluation: validated / refined / invalidated | Keeps thinking as a bet, not as a story | (post-action; operator-authored update to the surface chain) |
 
 ### 1.5 Handoff
-Update authoritative docs (`docs/PLAN.md`, `docs/PROGRESS.md`, `docs/NEXT_STEPS.md`). Capture unresolved risks and the exact next action.
+Update authoritative docs: `docs/NEXT_STEPS.md` (REPLACE-form, capped), one `docs/EVENTS.md` index line, and `docs/PLAN.md` when the plan changed. Capture unresolved risks and the exact next action. (Handoff semantics revised at Event 147 — the earlier append-style PROGRESS flow is retired; see MEMORY_CONTRACT.md for the doc lifecycle contract.)
 
 | Cognitive move | What it forces | Artifact field |
 |---|---|---|

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -1638,6 +1638,17 @@ def _sync_user_runtime(governance_mode: str = "balanced") -> None:
     # Deploy-on-merge: refresh release-coupled facts in tracked docs before
     # mounting the runtime, so a synced surface never carries a stale version.
     _stamped = _stamp_volatile_facts(REPO_ROOT)
+    if _stamped:
+        # A stamped span can feed the generated docs index (a doc's H1 may
+        # carry the version), so heal the index in the same breath —
+        # otherwise the stamp itself manufactures index drift (E148
+        # verification finding: the first live stamp left docs/README.md
+        # one line stale). Healing must never block a sync.
+        try:
+            from . import doc_lifecycle as _dl
+            _dl.update_readme_index(REPO_ROOT, _dl.discover_config(REPO_ROOT))
+        except Exception:
+            pass
 
     _claude.sync(governance_mode)
     hermes_synced = _hermes.sync()

--- a/tests/test_doc_lifecycle.py
+++ b/tests/test_doc_lifecycle.py
@@ -252,6 +252,20 @@ class RepoCorpusTests(unittest.TestCase):
             + dl.format_findings(findings),
         )
 
+    def test_docs_index_is_current(self):
+        # E148 verification finding: `docs index --check` existed but no CI
+        # carrier ran it, so the first live volatile-fact stamp (PR #119)
+        # drifted the committed index one line without any gate noticing —
+        # the mechanism-without-carrier (D11) shape again. This test IS the
+        # carrier: the committed docs/README.md generated section must match
+        # a fresh regeneration byte-for-byte.
+        self.assertEqual(
+            dl.run_index_cli(root=_REPO_ROOT, check=True),
+            0,
+            "docs/README.md generated index is stale — run `episteme docs "
+            "index` and commit the result",
+        )
+
 
 class RepoRootResolutionTests(unittest.TestCase):
     """FIX 1 (Event 148 follow-up): ``_repo_root`` anchors the git call at the

--- a/tests/test_session_context_spot_cap.py
+++ b/tests/test_session_context_spot_cap.py
@@ -1,0 +1,81 @@
+"""Event 148 verification finding — at-cap surfacing on the spot-check line.
+
+Covers the extension of ``_spot_check_line()``: below the enqueue cap the
+line is byte-identical to the pre-E148 form; at/over the cap it appends the
+degradation notice (sampling paused + skip counter) so silently skipped
+audit coverage is never invisible. Same producer, no new banner line
+(anti-accretion). Never raises: cap/counter read failures degrade to the
+plain line.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from core.hooks import session_context as sc  # pyright: ignore[reportAttributeAccessIssue]
+
+# The hook resolves `import _spot_check` as a TOP-LEVEL module via the hooks
+# dir on sys.path (hooks run as standalone scripts). Import the same instance
+# here so the patches below hit the module the hook actually uses — patching
+# core.hooks._spot_check targets a different module object and silently
+# leaves the hook reading the live queue.
+_HOOKS_DIR = Path(__file__).resolve().parents[1] / "core" / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+import _spot_check  # noqa: E402  # pyright: ignore[reportMissingImports]
+
+
+class SpotCheckCapLineTests(unittest.TestCase):
+    def test_below_cap_line_unchanged(self):
+        with mock.patch.object(_spot_check, "count_pending", return_value=28), \
+             mock.patch.object(_spot_check, "_resolve_pending_cap", return_value=100):
+            line = sc._spot_check_line()
+        self.assertEqual(
+            line, "28 surfaces flagged for review — run `episteme review`"
+        )
+
+    def test_at_cap_appends_degradation_notice(self):
+        with mock.patch.object(_spot_check, "count_pending", return_value=100), \
+             mock.patch.object(_spot_check, "_resolve_pending_cap", return_value=100), \
+             mock.patch.object(
+                 _spot_check, "read_skip_counter",
+                 return_value={"skipped_count": 7},
+             ):
+            line = sc._spot_check_line()
+        assert line is not None
+        self.assertIn("queue AT CAP (100)", line)
+        self.assertIn("sampling paused", line)
+        self.assertIn("7 op(s) skipped", line)
+
+    def test_over_cap_also_notices(self):
+        with mock.patch.object(_spot_check, "count_pending", return_value=137), \
+             mock.patch.object(_spot_check, "_resolve_pending_cap", return_value=100), \
+             mock.patch.object(
+                 _spot_check, "read_skip_counter",
+                 return_value={"skipped_count": 37},
+             ):
+            line = sc._spot_check_line()
+        assert line is not None
+        self.assertIn("137 surfaces flagged", line)
+        self.assertIn("AT CAP (100)", line)
+
+    def test_cap_read_failure_degrades_to_plain_line(self):
+        with mock.patch.object(_spot_check, "count_pending", return_value=100), \
+             mock.patch.object(
+                 _spot_check, "_resolve_pending_cap",
+                 side_effect=RuntimeError("boom"),
+             ):
+            line = sc._spot_check_line()
+        self.assertEqual(
+            line, "100 surfaces flagged for review — run `episteme review`"
+        )
+
+    def test_zero_pending_stays_silent(self):
+        with mock.patch.object(_spot_check, "count_pending", return_value=0):
+            self.assertIsNone(sc._spot_check_line())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Findings from the operator-requested Fable-direct end-to-end verification of the E147/E148 machinery (live-fire in a sandbox clone + master probes; all six lifecycle gates confirmed working as designed — these are the three gaps the pass found):

1. **Index-freshness carrier gap** (mechanism-without-carrier, the D11 shape recurring inside our own E147 machinery): `docs index --check` existed but nothing ran it — the first live volatile-fact stamp (PR #119) drifted the committed index one line (`1.9.0-rc1` in ARCHITECTURE's extracted title) with the full suite green. Closed three ways: line healed · corpus test is now the carrier (`test_docs_index_is_current`) · `episteme sync` re-runs the index updater whenever stamping changed a doc, so a stamp can never manufacture drift again.
2. **At-cap sampling degradation surfaced**: pending re-accumulated 0→32 within ~2h of a heavy agent session; at cap the samplers skip silently with only the sidecar counter recording it. The existing flagged-surfaces line now appends `queue AT CAP (N): sampling paused, K op(s) skipped` at/over cap — same producer, byte-identical below cap, never raises (5 tests incl. the dual-module-instance patch pitfall). Closes the follow-up the M1 lane explicitly deferred.
3. **Policy-mirror drift**: `THE_WAY_TO_THINK.md §1.5` still quoted the pre-E147 handoff contract (append-style PROGRESS). Aligned + `reviewed_as_of` bumped.

Also verified this pass, no action needed: unmarked/invalid/report-sink/bare-citation gates all fail-then-pass correctly in a sandbox clone · GC idempotent (2nd consecutive SessionStart silent) · SessionStart wall-time 0.27s/0.10s · version facts consistent with the manifest · scaffold references to REQUIREMENTS/PROGRESS/RUN_CONTEXT are LEGITIMATE (templates/project ships them — deletion would have been the fence-check failure).

Suite: **1653 passed + 88 subtests, 0 failed** (+6 new tests). This PR is Fable-verified (red-green + full suite) per the operator's direct-verification instruction for this cycle.