### PR TITLE
docs: retranslate ko/es/zh READMEs to the Event 149 tangible-first structure

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://github.com/junjslee/episteme/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/junjslee/episteme?include_prereleases&label=release&logo=github"></a>
-  <a href="https://github.com/junjslee/episteme/blob/master/LICENSE"><img alt="License" src="https://img.shields.io/github/license/junjslee/episteme?color=informational"></a>
+  <a href="https://github.com/junjslee/episteme/blob/master/LICENSE"><img alt="License: AGPL-3.0-or-later" src="https://img.shields.io/badge/license-AGPL--3.0--or--later-blue"></a>
   <a href="https://github.com/junjslee/episteme"><img alt="Unique Clones" src="https://img.shields.io/badge/dynamic/json?color=success&label=Unique%20Clones&query=uniques&url=https://gist.githubusercontent.com/junjslee/0a171c9a54b11948bbd1562f4f040465/raw/clone.json&logo=github"></a>
 </p>
 
@@ -20,179 +20,223 @@
 
 <p align="center"><a href="https://epistemekernel.com"><b>epistemekernel.com</b></a></p>
 
-> **episteme es una forma de pensar — 생각의 틀 — un motor epistémico (epistemic engine) que obliga a las decisiones asistidas por IA a ganarse su confianza antes de ejecutarse.**
+> **episteme obliga a un agente de IA a mostrar su razonamiento antes de actuar — y hace que la documentación de tu repositorio deje de mentir sobre tu código.**
 >
-> Una práctica cognitiva de cinco etapas — **Frame (encuadrar) → Decompose (descomponer) → Execute (ejecutar) → Verify (verificar) → Handoff (entregar)** — anclada en el forzado del System-2 de Kahneman, la Radical Transparency de Dalio, la OODA Orientation de Boyd y el Latticework of Mental Models de Munger. La v2.0 la entrega en tres capas. **Cognición** — la interrogación del investigador senior: descomponer una decisión de carga en afirmaciones clasificadas (`measured / cited / inferred / assumed`), verificar las afirmaciones de carga *en un contexto fresco contra evidencia externa* (el verificador nunca ve el borrador), argumentar la oposición más fuerte, nombrar el eslabón más débil, comprometer por adelantado una condición de refutación. **Estructura** — hooks deterministas que enrutan las formas de decisión, validan el artefacto de veredicto (un veredicto `stop` falla cerrado) y bloquean duro solo las operaciones genuinamente destructivas; la Reasoning Surface firmada por el operador (Ed25519, estructuralmente fuera del alcance del agente) sigue siendo el artefacto de encuadre del lado del operador. **Memoria** — las lecciones de interrogaciones verificadas se vuelven protocolos encadenados por hash y acotados por contexto, que reaparecen en la siguiente decisión coincidente. La división del trabajo la fijó el registro de investigación, no nosotros: los modelos que juzgan sus propios borradores *empeoran*, los chequeos de forma se burlan con tokens con forma de razonamiento, y solo la restricción arquitectónica convierte la conciencia epistémica en conducta.
->
-> El benchmark MIRROR ([arXiv 2604.19809](https://arxiv.org/abs/2604.19809)) zanjó la cuestión empírica: en 16 modelos de 8 laboratorios y ~250.000 instancias, *"proporcionar a los modelos sus propias puntuaciones de calibración no produce ninguna mejora significativa; solo la restricción arquitectónica es efectiva."* La Confident Failure Rate cae de 0,60 a 0,14 bajo restricción arquitectónica externa. **La práctica misma es el producto.** Los artefactos bajo `core/` y `src/episteme/` son geometría de imposición (enforcement geometry) que permite que la práctica sobreviva cuando la *vigilancia como fuerza de voluntad* se derrumba a la potencia de los modelos de frontera.
->
-> **→ [`docs/THE_WAY_TO_THINK.md`](docs/THE_WAY_TO_THINK.md)** — la práctica operacionalizada.
+> Se instala dentro de las herramientas de programación que ya usas (Claude Code hoy; una capa de adaptadores neutral respecto al proveedor para las demás). Antes de cualquier acción de alto impacto — `git push`, un deploy, una migración, eliminar una restricción — el agente debe escribir, en disco, lo que sabe, lo que no sabe, y qué evento observable probaría que está equivocado. Un hook determinista revisa el artefacto y se niega a continuar hasta que sea real (`exit 2`). Las lecciones de decisiones verificadas se vuelven protocolos a prueba de manipulación (tamper-evident) y acotados por contexto, que reaparecen en la siguiente decisión coincidente — así el agente se afina sobre *tu* codebase con el tiempo, y tu documentación se lintea contra tu código igual que tu código se lintea contra tus tests.
+
+**[Qué aspecto tiene ↓](#qué-aspecto-tiene)** · **[Instalación ↓](#instalación)** · **[Las demos ↓](#las-demos)** · **[Cómo se compara ↓](#cómo-se-compara)** · **[Bajo el capó ↓](#bajo-el-capó)** · **[¿Funciona? ↗](docs/EVALUATION_METHOD.md)**
 
 ---
 
-## Por qué los prompts no son la verdad
+## Qué aspecto tiene
 
-Le pides al agente: *"Evalúa si nuestro sistema de memoria con retrieval-augmented (RAG) está realmente mejorando la calidad de las respuestas."*
+Le pides a tu agente: *"Evalúa si nuestro sistema de memoria con retrieval-augmented está mejorando realmente la calidad de las respuestas."*
 
-El agente trata tu prompt como una tarea de medición. Saca métricas de los últimos 30 días, compara muestras de respuestas con-memoria vs sin-memoria, encuentra un 7% de lift positivo en la tasa de thumbs-up, escribe un memo concluyendo "la memoria ayuda; sigamos enviando." Lo lees.
+**Sin episteme** — el agente trata esto como una tarea de medición. Saca 30 días de métricas, encuentra un 7% de lift en la tasa de thumbs-up, y escribe un memo confiado: *"la memoria ayuda; sigamos enviando."* Lo lees. Está equivocado de tres formas, con fluidez:
 
-El agente no hizo las preguntas que tú habrías hecho, si no estuvieras cansado:
+- El thumbs-up rastrea la *confianza* de la respuesta, no su *corrección* — midió un proxy de tu pregunta, no la pregunta.
+- Las respuestas con memoria son un 30% más largas, y la longitud impulsa el thumbs-up de forma independiente — el "lift" podría ser el efecto de la longitud.
+- Nunca se nombró ninguna condición bajo la cual la conclusión se juzgaría errónea — así que no puede serlo.
 
-- **Qué (What)** está midiendo realmente la "calidad" aquí? La métrica que el agente eligió fue la *tasa de thumbs-up*. Pero el thumbs-up correlaciona con la *confianza* de la respuesta, no con su *corrección* — una respuesta confiadamente equivocada con cita de memoria puede puntuar mejor que una respuesta correctamente incierta sin ella. El agente midió un proxy de la pregunta, no la pregunta.
-- **Por qué (Why)** ayudaría la memoria? El mecanismo propuesto es contexto estable entre sesiones. Pero la comparación con/sin no controló la longitud de respuesta — las respuestas con memoria son un 30% más largas en promedio, y la longitud por sí misma correlaciona con thumbs-up. El "lift" podría ser efecto de longitud, no de memoria.
-- **Cómo (How)** sería errónea esta conclusión? Re-corre el experimento controlando longitud de respuesta. Si el lift persiste, la memoria está haciendo trabajo real. Si desaparece, la memoria añade tokens pero no señal. Esa es la condición de refutación que el agente nunca nombró.
+**Con episteme** — antes de que el memo pueda aterrizar, el agente tiene que comprometer esto en disco:
 
-Un agente naïve da una respuesta que suena medida porque el prompt pidió una medición. `episteme` obliga al agente a escribir — en disco, antes de que el memo se entregue — qué mide realmente la medición, qué mecanismo se está reclamando, y qué resultado observable refutaría la afirmación. El acto de escribirlo expone que el proxy no era la pregunta.
-
-Trabajo académico reciente llama a la brecha acumulada entre lo que el agente sabe en contexto, lo que tú pretendes, y lo que tu sistema realmente requiere **Epistemic Drift**. `episteme` cierra esa brecha exigiendo estructuralmente al agente que razone — *qué · por qué · cómo* — antes de actuar.
-
----
-
-## Por qué los prompts no son suficientes
-
-- Un recordatorio en el system prompt **vive solo una llamada**.
-- Una nota en `CLAUDE.md` **se ignora cuando llega el deadline** — tanto los humanos como los agentes lo hacen.
-- **El know-how** — la regla irreduciblemente específica al contexto de *"en esta forma de problema, haz esto"* — no se enseña con mejor redacción. Tiene que ser **extraído, almacenado y re-emergido**.
-
-Y lo más profundo: el agente **ejecuta incluso cuando la solicitud del usuario es incorrecta**. Los usuarios también pueden carecer de profundidad, malinterpretar o partir de premisas erróneas. Un buen sistema *no solo vigila al agente, también valida la pregunta misma del usuario*. Los parches a nivel de prompt no estructuran esta validación bidireccional.
-
----
-
-## La solución — un Thinking Framework a nivel del sistema de archivos
-
-`episteme` intercepta **el momento en que la intención se encuentra con el cambio de estado**. Antes de cualquier operación de alto impacto (`git push`, `npm publish`, `terraform apply`, migraciones de DB, edición de lockfiles) — sin importar *quién* la solicitó (el usuario o el propio agente) — el agente debe proyectar su razonamiento explícitamente en una **Reasoning Surface** de cuatro campos en el disco:
-
-| Campo | Qué debe declarar el agente |
+| Campo | Lo que el agente debe escribir |
 |---|---|
-| **Core Question** | La única pregunta que esta acción realmente intenta responder (contra la question substitution) |
-| **Knowns** | Hechos verificados, citas, mediciones — no suposiciones que suenan bien |
-| **Unknowns** | Vacíos nombrados y clasificables — no un vago *"puede haber riesgos"* |
-| **Assumptions** | Creencias que soportan la carga, marcadas para que puedan ser falsificadas |
-| **Disconfirmation** | El evento observable que *probaría que este plan está mal* — comprometido antes de actuar |
+| **Core Question** | La única pregunta que este trabajo realmente responde — *"¿mejora la memoria la corrección, controlando por longitud?"* |
+| **Knowns** | Hechos verificados con fuentes — no conjeturas que suenan plausibles |
+| **Unknowns** | Vacíos nombrados (*"si el lift sobrevive al control por longitud"*) — un blanco aquí hace fallar el gate |
+| **Assumptions** | Creencias que soportan la carga, marcadas para poder ser falsificadas |
+| **Disconfirmation** | Un observable comprometido de antemano — *"si el lift desaparece al re-ejecutar controlando por longitud, la memoria está añadiendo tokens, no señal"* |
 
-La validación es **estructural**: longitud mínima, prohibición de placeholders perezosos (`none`, `n/a`, `tbd`, `해당 없음`), escaneo normalizado de comandos. Si la surface falta o es vacía, la operación se rechaza con `exit 2`.
+Los tokens perezosos (`none`, `n/a`, `tbd`, `해당 없음`) se rechazan. Las evasivas vagas (*"si surgen problemas"*) se rechazan — solo pasan condiciones de falsación concretas. El acto de escribir la surface es lo que revela que el proxy no era la pregunta. Ese es el producto: **el agente es obligado a pensar de una forma que puedes auditar, antes de que las consecuencias existan.**
 
-**Esta es la diferencia entre un recordatorio de prompt y un compilador: uno pide por favor, el otro se niega a continuar.**
+![episteme — el thinking framework en movimiento](docs/assets/demo_posture.gif)
 
----
+*Grabado desde `scripts/demo_posture.sh` — una eliminación de restricción bloqueada, una reescritura validada, un refactor obligado a declarar su blast radius, y el protocolo sintetizado disparándose en una decisión posterior.*
 
-## ABCD — cuatro Cognitive Blueprints
+## Qué obtienes
 
-Cada operación de alto impacto dispara uno de cuatro Blueprints, cada uno contrarrestando una clase específica de falla:
+- **Un gate de razonamiento en el punto de no retorno.** Los hooks interceptan operaciones de alto impacto y validan la Reasoning Surface estructuralmente — el escaneo normalizado de comandos atrapa formas de evasión (`subprocess.run(['git','push'])`, scripts de shell escritos por el agente, ejecutores envueltos). Surface ausente o hueca → la operación se rechaza. Strict por defecto; el modo advisory es opt-in por proyecto.
+- **Interrogación para decisiones de carga.** La estructura por sí sola no distingue el pensamiento del teatro, así que el gate también acepta un artefacto más fuerte: la decisión descompuesta en afirmaciones, cada afirmación de carga verificada por un **contexto fresco que nunca vio el razonamiento borrador**, la oposición más fuerte argumentada, el eslabón más débil nombrado. Un veredicto `stop` falla cerrado.
+- **Memoria que se acumula en vez de decaer.** Cada lección verificada se vuelve un protocolo encadenado por hash y acotado por contexto — append-only y tamper-evident, así el agente no puede reescribir en silencio lo que aprendió. En la siguiente decisión coincidente el kernel expone el protocolo proactivamente: `[episteme guide] … · overlap 5/6 · Protocol: In context X, do Y`. No tienes que acordarte de preguntar.
+- **Documentación lineada contra la realidad.** Cada doc rastreado lleva un marcador de ciclo de vida legible por máquina (`living / spec-implemented / design-history / report / tombstone`). CI falla cuando un doc nuevo aterriza sin clasificar, cuando un doc living cita uno retirado como si fuera vigente, o cuando un reporte puntual intenta ocupar `docs/`. Las cadenas de versión se estampan desde el manifiesto de release, nunca se copian a mano. Los docs obsoletos afloran al inicio de sesión — en silencio, solo cuando algo está realmente obsoleto. **Una única fuente de verdad (single source of truth), impuesta — no aspirada.**
+- **Un sistema que limpia lo suyo.** Las colas de revisión tienen tope con contrapresión visible, los logs rotan en topes de tamaño, los marcadores expirados y la telemetría vieja se recogen al inicio de sesión. Los artefactos no se apilan; la eliminación es una operación diseñada, no un accidente del descuido.
+- **Una identidad a través de las herramientas.** Tu estilo de trabajo, tu postura de riesgo y tus preferencias de razonamiento viven en markdown gobernado y versionado — sincronizado a cada adaptador con un solo comando. El kernel sobrevive a la herramienta.
 
-- **A · Axiomatic Judgment** — resuelve conflictos entre fuentes creíbles pero incompatibles. Obliga al agente a nombrar *por qué* difieren y *qué característica del contexto actual* decide.
-- **B · Fence Reconstruction** — protege restricciones heredadas. Antes de remover una restricción, su *propósito original* debe ser reconstruido. **La cerca de Chesterton (Chesterton's fence)** aplicada por el sistema de archivos.
-- **C · Consequence Chain** — descompone operaciones irreversibles (efecto de primer orden, de segundo orden, inversión de failure-mode, tasa base, margin of safety).
-- **D · Architectural Cascade** — atrapa refactorizaciones y renombres que dejarían referencias obsoletas. Obliga al agente a enumerar el blast radius completo antes de editar.
+## Instalación
 
-Cada activación de un Blueprint y cada decisión que valida se registra en una **cadena hash a prueba de manipulación (tamper-evident hash chain)**. Esa cadena no es un simple log — es cómo el kernel ofrece **Active Guidance** más tarde: en la siguiente decisión coincidente, el protocolo sintetizado relevante se expone proactivamente, antes de que el agente retroceda a su distribución de entrenamiento.
-
-El resultado: **un Thinking Framework específico de tu proyecto que se acumula**. El agente se afina con tu codebase cada vez que resuelve un conflicto — no porque lo hayas entrenado, sino porque la cadena recordó por ti.
-
----
-
-## Ejecución zero-trust
-
-El [**OWASP Top 10 for Agentic Applications (2026)**](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) — revisado por más de 100 expertos de la industria — identifica prompt injection, goal hijacking, overreach, memory poisoning y unbounded action como las principales clases de riesgo para agentes autónomos. La estructura Knowns / Unknowns / Assumptions / Disconfirmation es un contador *estructural* a cada uno:
-
-| OWASP Agentic Risk (2026) | contador de episteme |
-|---|---|
-| Manipulación directa de objetivos / prompt injection | Core Question declarada antes de la ejecución; las desviaciones afloran como Unknowns |
-| Inyección indirecta de instrucciones | Knowns / Disconfirmation separan el estado confiable del contenido del prompt; el agente se compromete a un resultado falsable antes de actuar sobre la entrada recuperada |
-| Overreach / acción no limitada | Régimen de restricciones declarado en Frame; política reversible-first aplicada |
-| Alucinación fluida | El campo Unknowns no puede quedar vacío; las suposiciones deben nombrarse antes de actuar sobre ellas |
-| Envenenamiento de memoria | Protocolos Pillar 2 hash-chained — append-only, tamper-evident; reescrituras silenciosas de estado previo son detectadas por `verify_chain` |
-| Bucles de planificación infinita | Condición de Disconfirmation requerida; el bucle sale cuando la evidencia se dispara |
-
-Ninguna suposición se confía hasta ser nombrada. Ninguna acción se toma sin la precondición (Knowns) y el régimen de restricciones declarados. El kernel es la capa de verificación entre intención y ejecución.
-
-### Convergencia industrial — 2025–2026
-
-Frameworks y artículos académicos importantes en la misma ventana convergen sobre los mismos patrones arquitectónicos que el kernel envía: checkpoints pre-invocación a nivel del sistema de archivos ([Capsule Security ClawGuard](https://www.businesswire.com/news/home/20260415670902/), 2026), memoria hash-chained tamper-evident ([SSGM](https://arxiv.org/abs/2603.11768) — Lam et al., 2026), alineación basada en razones en lugar de listas de reglas ([Anthropic's Claude Constitution](https://www.anthropic.com/constitution), 2026-01-22), bucle cognitivo de cinco fases con capa de gobernanza ([SCL R-CCAM](https://arxiv.org/abs/2511.17673) — Kim, 2025), e integridad de agente de cinco pilares ([Proofpoint Agent Integrity Framework 2026](https://www.proofpoint.com/us/resources/white-papers/agent-integrity-framework)). El kernel precede a estas publicaciones (CP1 enviado 2026-04-21; v1.0.0 GA 2026-04-28); la convergencia es validación independiente, no linaje. Mapa completo de atribución en [`kernel/REFERENCES.md`](./kernel/REFERENCES.md) bajo *Convergent contemporary work*.
-
----
-
-## Cognitive Arms — v1.1+
-
-Los cuatro Blueprints (arriba) y los tres Pillars — Cognitive Blueprints · Append-Only Hash Chain · Framework Synthesis & Active Guidance — son la *base estructural inmóvil* de v1.0. Los Pillars no se mueven. v1.1 añade **3 Cognitive Arms** que operan encima: motores activos y fluidos que refactorizan el propio conocimiento del kernel a lo largo del tiempo.
-
-- **Arm A · Temporal Integrity** — los protocolos decaen. El retiro confirmado por el operador supersede una regla obsoleta en lugar de sobrescribirla silenciosamente. Ventana de verificación: 30 días después de CP-DECAY-03.
-- **Arm B · Causal Synthesis** — extracción de entidades sin LLM sobre el stream de deferred-discovery produce propuestas de clúster sobre las que el framework puede actuar. Ventana de verificación: 60 días.
-- **Arm C · Self-Consistency Convergence** — los protocolos se promueven a modelos que derivan disconfirmaciones estructuralmente. Ventana de verificación: 90 días.
-
-La distinción es estructural — los Pillars son vocabulario asentado; los Arms son cómo el sistema audita y refina sus propias salidas a lo largo del tiempo. Estado: **v1.4.0-rc1 cortado el 2026-05-23**, 1170 tests + 54 subtests pasando. El sustrato de Arm A ya fue enviado (infraestructura supersede-with-history + hooks de auto-instrumentación que registran ediciones de perfil de operador y de policy a streams de cadena); el residuo de Arm A se reanuda oportunísticamente. **La forma substrate-facing de Arm B fue formalmente SUNSET en Event 129** — su premisa (una brecha estable de capacidad de modelo) fue falsada por el hallazgo de saturación de los Events 119–120. Su residuo operator-facing (`core/ptsp/` typed Fact/Inference promotion gate) se conserva accesible vía `episteme practice trace`. Arm C queda scopeada para un ciclo futuro pendiente de evidencia de que la afirmación de substrate-gap sobrevive.
-
----
-
-## Inicio rápido
-
-### Opción A — Plugin de Claude Code
-
-Dentro de Claude Code:
+**Opción A — plugin de Claude Code (dos comandos, autocontenido):**
 
 ```
 /plugin marketplace add junjslee/episteme
 /plugin install episteme@episteme
 ```
 
-Luego en cualquier shell:
+Los hooks, agentes y skills están vivos en tu sesión; sin pip de por medio.
 
-```bash
-episteme init     # sembrar archivos de memoria personal
-episteme setup    # puntuar estilo de trabajo + perfil cognitivo
-episteme sync     # propagar a Claude Code y Hermes
-episteme doctor   # verificar conexiones
-```
-
-### Opción B — Clonar el kernel directamente
+**Opción B — clonar el kernel (CLI + fuente editable):**
 
 ```bash
 git clone https://github.com/junjslee/episteme ~/episteme
-cd ~/episteme
-pip install -e .
+cd ~/episteme && pip install -e .
 
-episteme init
-episteme setup . --write
-episteme sync
-episteme doctor
+episteme init      # generate personal memory files from templates
+episteme setup .   # score working style + reasoning posture
+episteme sync      # push identity to every adapter
+episteme doctor    # verify wiring
 ```
 
-Onboarding detallado: **[`docs/SETUP.md`](./docs/SETUP.md)**. Referencia completa de comandos: **[`docs/COMMANDS.md`](./docs/COMMANDS.md)**.
+Adoptarlo en un repo existente: `episteme docs lint` fuerza una clasificación de ciclo de vida de cada doc rastreado — esa primera corrida de lint es el inventario honesto que la mayoría de los repos nunca tuvo. Detalles, harnesses de proyecto, y la referencia completa de comandos: [`INSTALL.md`](./INSTALL.md) · [`docs/SETUP.md`](./docs/SETUP.md) · [`docs/COMMANDS.md`](./docs/COMMANDS.md).
 
----
+## Las demos
 
-## Filosofía — doxa · episteme · praxis · 결
+Cada demo envía sus artefactos reales — léelos antes que cualquier filosofía.
 
-El nombre del repositorio viene del griego:
+| Demo | Qué demuestra |
+|---|---|
+| [`demos/04_symbiosis/`](./demos/04_symbiosis/) | **La tesis, desde historia real (2026-04-27, Events 65–67):** el operador propuso un paquete irreversible impulsado por la ansiedad; la revisión adversarial del kernel afloró 3 hallazgos Critical; el camino descompuesto se volvió constitucional en `AGENTS.md`. Agente y humano depurando la intención *del otro*. [`DIFF.md`](./demos/04_symbiosis/DIFF.md) muestra el mundo alternativo lado a lado. |
+| [`demos/03_differential/`](./demos/03_differential/) | **El mismo prompt, framework off vs on.** Off responde *cómo*; on responde *si acaso*. [`DIFF.md`](./demos/03_differential/DIFF.md) nombra los failure modes atrapados. |
+| [`demos/02_debug_slow_endpoint/`](./demos/02_debug_slow_endpoint/) | Una regresión de p95 donde el fluido-pero-erróneo *"añade un cache"* muere en el gate de la Core Question; en su lugar se produce una causa raíz a nivel de esquema. |
+| [`demos/01_attribution-audit/`](./demos/01_attribution-audit/) | La forma canónica de cuatro artefactos (reasoning-surface → decision-trace → verification → handoff) — el kernel auditando sus propias atribuciones. |
+| [`demos/05_contract_gate/`](./demos/05_contract_gate/) | El complemento conductual: los contratos declarados corren al final del turno. |
 
-- **Doxa** (δόξα) — opinión común, la salida fluida producida por defecto. Los 11 failure modes en [`kernel/FAILURE_MODES.md`](./kernel/FAILURE_MODES.md) son una taxonomía de *doxa confundiéndose con episteme*.
-- **Episteme** (ἐπιστήμη) — conocimiento justificado: Knowns concretos, Unknowns nombrados, Disconfirmation falsificable. El precondición para ejecución.
-- **Praxis** (πρᾶξις) — acción informada: efectos que aterrizan con su disciplina autorizante intacta.
+Regraba tú mismo la demo estrella: `scripts/demo_posture.sh` (la receta está en la cabecera del script). El dashboard en vivo se renderiza contra la propia cadena hash del kernel — [`web/README.md`](./web/README.md).
 
-La palabra coreana **결** (*gyeol*) nombra el grano de la madera o piedra — el patrón latente que, seguido, produce forma coherente, y cortado en contra, se fractura. El orden de los campos de la Reasoning Surface es el *gyeol* de la disciplina epistémica: **establecido → abierto → provisional → condición de falsificación**.
+## Cómo se compara
 
----
+| Eje | episteme | Memory APIs (mem0, OpenMemory) | Runtimes de agentes (Agno, opencode) |
+|---|---|---|---|
+| **Qué es** | Capa de gobernanza del razonamiento + identidad sobre tus herramientas existentes | API de memoria embebida en una app | Un runtime que ejecuta agentes |
+| **Dónde vive la identidad** | Markdown/JSON gobernado y versionado — cross-tool | Store de vectores/grafos, por app | System prompt, por sesión |
+| **Know-how** | Extraído en la frontera del sistema de archivos, encadenado por hash, re-expuesto por contexto | Recuperación opaca | Ajustado por prompt, por sesión |
+| **Higiene de docs/estado** | Lineada por ciclo de vida, con GC, con gate de drift en CI | N/A | N/A |
+
+**¿No es esto solo contract testing?** Los contract tests atrapan regresiones *conductuales* — si el código hizo lo que dice el spec. La Reasoning Surface atrapa regresiones *epistemológicas* — si escribimos el spec correcto, encuadramos la pregunta correcta, nombramos lo que nos probaría equivocados. Una suite de tests que pasa no puede decirte que estás resolviendo con fluidez el problema equivocado; esa falla ocurre antes de que el spec exista. episteme envía ambas capas ([`docs/CONTRACT_GATE.md`](./docs/CONTRACT_GATE.md)).
+
+**¿Por qué no puede hacer esto un prompt?** Los prompts son consultivos: viven una sola llamada, se saltan en el deadline, y se desvanecen del contexto. Un hook que sale con código distinto de cero no se puede saltar. El benchmark MIRROR ([arXiv 2604.19809](https://arxiv.org/abs/2604.19809); 16 modelos, 8 laboratorios, ~250k instancias) encontró que mostrar a los modelos su propia calibración no ayuda — *solo la restricción arquitectónica es efectiva* (Confident Failure Rate 0.60 → 0.14). Postura antes que prompt (Posture over prompt).
+
+## Límites honestos
+
+- [`kernel/KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md) nombra cuándo este kernel es la herramienta equivocada. *Una disciplina sin frontera es un credo.*
+- El kernel mide sus propias afirmaciones: el bucle de síntesis de protocolos disparó su propia condición de falsabilidad en 2026-06 (49 días, cero protocolos sintetizados) y fue reconstruido para sintetizar a partir de interrogaciones verificadas — el rastro de auditoría es público ([`kernel/FAILURE_MODES.md`](./kernel/FAILURE_MODES.md), [`docs/EVALUATION_METHOD.md`](./docs/EVALUATION_METHOD.md)). Un kernel que impone disconfirmation sobre tus decisiones te debe lo mismo sobre las suyas.
+- Atribución de cada concepto prestado, y el trabajo de la industria 2025–26 que convergió de forma independiente sobre los mismos patrones: [`kernel/REFERENCES.md`](./kernel/REFERENCES.md).
+
+## Bajo el capó
+
+Estado: **<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->** · La práctica es Frame → Decompose → Execute → Verify → Handoff, anclada en contadores nombrados a failure modes específicos del System-1 (question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence) — la operacionalización completa está en [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md), y los cuatro Cognitive Blueprints (Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade) están especificados en [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
+
+```mermaid
+graph TD
+    subgraph SG1["① The Agentic Mind — Intention"]
+        A["Agent\nGenerating intent for a high-impact op"]
+        B["Reasoning Surface\ncore_question · knowns · unknowns\nassumptions · disconfirmation"]
+        D["Doxa\nFluent hallucination\nnone / n/a / tbd / 해당 없음\n< 15 chars · missing fields"]
+        E["Episteme\nJustified true belief\nconcrete knowns · named unknowns\ndisconfirmation ≥ 15 chars · no placeholders"]
+    end
+
+    subgraph SG2["② The Sovereign Kernel — Interception"]
+        F["Stateful Interceptor\ncore/hooks/reasoning_surface_guard.py\nnormalises cmd · deep-scans agent-written files\ncross-call stateful memory"]
+        G["Hard Block · exit 2\nExecution denied\nAgent forced to re-author surface"]
+        H["PASS · exit 0\nPrecondition satisfied\nExecution admitted to Praxis"]
+    end
+
+    subgraph SG3["③ Praxis & Reality — Execution"]
+        I["Tool Execution\ngit push · bash script.sh · npm publish\nterraform apply · DB migrations · lockfile edits"]
+        J["Observed Outcome\ncore/hooks/calibration_telemetry.py\nexit_code 0 or non-zero · stderr captured"]
+    end
+
+    subgraph SG4["④ 결 · Gyeol — Cognitive Texture & Evolution"]
+        K["Prediction Record\ncorrelation_id stamped at PASS\n~/.episteme/telemetry/YYYY-MM-DD-audit.jsonl"]
+        L["Outcome Record\ncorrelation_id · exit_code · stderr\n~/.episteme/telemetry/YYYY-MM-DD-audit.jsonl"]
+        M["episteme evolve friction\nsrc/episteme/cli.py · _evolve_friction\npairs prediction ↔ outcome by correlation_id\nranks under-named unknowns · flags exit_code ≠ 0"]
+        N["결 · Gyeol\nRefined cognitive grain\nfriction hotspots · calibrated profile axes"]
+        O["Operator Profile\ncore/memory/global/operator_profile.md\nlast_elicited axes updated · confidence rescored"]
+        P["kernel/CONSTITUTION.md\nFour principles recalibrated\nfailure-mode counters sharpened"]
+    end
+
+    A --> B
+    B --> D
+    B --> E
+    D --> F
+    E --> F
+    F --> G
+    F --> H
+    G -.->|"cognitive retry"| A
+    H --> I
+    I --> J
+    E -.->|"correlation_id stamped at PASS"| K
+    J --> L
+    K --> M
+    L --> M
+    M --> N
+    N --> O
+    N --> P
+    O -.->|"posture loop closed"| A
+    P -.->|"posture loop closed"| A
+
+    classDef doxaStyle fill:#c0392b,stroke:#922b21,color:#fff
+    classDef episteStyle fill:#1e8449,stroke:#145a32,color:#fff
+    classDef passStyle fill:#27ae60,stroke:#1e8449,color:#fff
+    classDef praxisStyle fill:#2ecc71,stroke:#27ae60,color:#000
+    classDef gyeolStyle fill:#1a5276,stroke:#154360,color:#fff
+    classDef kernelStyle fill:#6c3483,stroke:#512e5f,color:#fff
+    classDef neutralStyle fill:#2c3e50,stroke:#1a252f,color:#fff
+
+    class D,G doxaStyle
+    class E episteStyle
+    class H,I passStyle
+    class J praxisStyle
+    class K,L,M,N,O,P gyeolStyle
+    class F kernelStyle
+    class A,B neutralStyle
+```
+
+**Doxa** (rojo) — salida fluida pero no validada — es el estado de falla que el kernel existe para prevenir. **Episteme** (verde) — una surface validada — es la precondición para ejecutar. **Praxis** — la acción admitida y su resultado observado. **결 · Gyeol** (azul) — el bucle de calibración que refina el framework a lo largo de los ciclos. Funciona con cualquier stack: el kernel es markdown puro, el perfil JSON plano, la capa de adaptadores (Claude Code, Hermes, OMO/OMX) enchufable.
+
+El kernel mismo — markdown puro, sin código, sin vendor lock-in — empieza en [`kernel/`](./kernel/):
+
+| Archivo | Qué define |
+|---|---|
+| [`SUMMARY.md`](./kernel/SUMMARY.md) | Destilación operativa en 30 líneas |
+| [`CONSTITUTION.md`](./kernel/CONSTITUTION.md) | Afirmación raíz, cuatro principios, failure modes del razonador |
+| [`FAILURE_MODES.md`](./kernel/FAILURE_MODES.md) | Taxonomía completa de 12 modos ↔ artefactos contadores |
+| [`REASONING_SURFACE.md`](./kernel/REASONING_SURFACE.md) | El protocolo Knowns / Unknowns / Assumptions / Disconfirmation |
+| [`MEMORY_ARCHITECTURE.md`](./kernel/MEMORY_ARCHITECTURE.md) | Cinco niveles de memoria (working → reflective) |
+| [`KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md) | Cuándo el kernel es la herramienta equivocada |
+| [`REFERENCES.md`](./kernel/REFERENCES.md) | Atribución + trabajo contemporáneo convergente |
+
+```
+episteme/
+├── kernel/          philosophy (markdown; travels across runtimes)
+├── core/hooks/      deterministic gates + session automation
+├── src/episteme/    CLI + core library (doc lifecycle, sync, telemetry)
+├── adapters/        delivery layers (Claude Code, Hermes, …)
+├── demos/           end-to-end reference deliverables
+├── skills/          reusable operator skills
+├── templates/       project scaffolds
+└── docs/            architecture, contracts, runtime docs — lifecycle-linted
+```
+
+Jerarquía de autoridad: **docs del proyecto > perfil del operador > defaults del kernel > defaults del runtime.** Contrato operativo del repo para agentes: [`AGENTS.md`](./AGENTS.md) · sitemap para LLM: [`llms.txt`](./llms.txt).
 
 ## Lee a continuación
 
-| Tema | Ubicación |
+| Tema | Dónde |
 |---|---|
-| Destilación del kernel en 30 líneas | [`kernel/SUMMARY.md`](./kernel/SUMMARY.md) |
-| Dirección de diseño v1.0 RC | [`docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md) |
-| Los 11 failure modes con sus contraartefactos | [`kernel/FAILURE_MODES.md`](./kernel/FAILURE_MODES.md) |
-| Thinking Framework *OFF vs. ON* sobre el mismo prompt | [`demos/03_differential/`](./demos/03_differential/) |
-| Cuándo el kernel es la herramienta equivocada | [`kernel/KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md) |
-| Atribución de cada concepto prestado | [`kernel/REFERENCES.md`](./kernel/REFERENCES.md) |
-| Contrato operativo del repositorio para agentes | [`AGENTS.md`](./AGENTS.md) |
+| La práctica, operacionalizada | [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md) |
+| Arquitectura + specs de los blueprints | [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) |
+| ¿Funciona? (método de evaluación) | [`docs/EVALUATION_METHOD.md`](./docs/EVALUATION_METHOD.md) |
+| Rutas de instalación (marketplace, CLI, dev) | [`INSTALL.md`](./INSTALL.md) |
+| Ciclo de vida de docs + contratos de memoria | [`docs/MEMORY_CONTRACT.md`](./docs/MEMORY_CONTRACT.md) · [`docs/SYNC_AND_MEMORY.md`](./docs/SYNC_AND_MEMORY.md) |
+| Hooks + governance packs | [`docs/HOOKS.md`](./docs/HOOKS.md) |
+| Postura de seguridad (mapeo OWASP Agentic 2026) | [`docs/COMPLIANCE_CROSSWALK.md`](./docs/COMPLIANCE_CROSSWALK.md) |
+| Personalización | [`docs/CUSTOMIZATION.md`](./docs/CUSTOMIZATION.md) |
+| Índice completo de docs (generado) | [`docs/README.md`](./docs/README.md) |
+
+## Licenciamiento comercial
+
+Para licenciamiento comercial o consultoría, [contáctame](mailto:junseong.lee652@gmail.com).
 
 ---
 
-## Por qué `episteme` — en una frase
-
-**Postura antes que prompt (Posture over prompt).** En lugar de buscar mejor redacción, establece el *marco en el que un agente de IA piensa* a nivel del sistema de archivos. Un Thinking Framework que — como un compilador — puede negarse a continuar. No hace tu agente más inteligente; hace que esa inteligencia *aterrice en tu contexto*.
-
-**Built as a Sovereign Cognitive Kernel — 생각의 틀**.
-
----
-
-> **Note on translation.** This README is a focused-scope Spanish adaptation maintained alongside the canonical English [`README.md`](./README.md). For deepest documentation, demo walkthroughs, and architectural diagrams, refer to the English docs tree. Technical terms (Thinking Framework, Reasoning Surface, Blueprint, Core Question, Chesterton's fence, Pillar 3, flaw_classification, etc.) are kept in English because they are load-bearing kernel vocabulary.
+> **Nota sobre la traducción.** Este README es una traducción al español mantenida junto al [`README.md`](./README.md) canónico en inglés. Para la documentación más profunda, los recorridos de las demos y los diagramas de arquitectura, consulta el árbol de docs en inglés. Los términos de carga del kernel (Reasoning Surface, Core Question, Blueprint, hook, kernel, doxa/episteme/praxis, etc.) se conservan en inglés a propósito.

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://github.com/junjslee/episteme/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/junjslee/episteme?include_prereleases&label=release&logo=github"></a>
-  <a href="https://github.com/junjslee/episteme/blob/master/LICENSE"><img alt="License" src="https://img.shields.io/github/license/junjslee/episteme?color=informational"></a>
+  <a href="https://github.com/junjslee/episteme/blob/master/LICENSE"><img alt="License: AGPL-3.0-or-later" src="https://img.shields.io/badge/license-AGPL--3.0--or--later-blue"></a>
   <a href="https://github.com/junjslee/episteme"><img alt="Unique Clones" src="https://img.shields.io/badge/dynamic/json?color=success&label=Unique%20Clones&query=uniques&url=https://gist.githubusercontent.com/junjslee/0a171c9a54b11948bbd1562f4f040465/raw/clone.json&logo=github"></a>
 </p>
 
@@ -20,222 +20,219 @@
 
 <p align="center"><a href="https://epistemekernel.com"><b>epistemekernel.com</b></a></p>
 
-> **episteme는 사고법입니다 — 생각의 틀 — AI 보조 의사결정이 실행되기 전에 자신의 확신을 스스로 증명하게 만드는 인식 엔진(epistemic engine).**
+> **episteme는 AI 에이전트가 행동하기 전에 자신의 추론을 증명하게 만들고 — 당신 저장소의 문서가 코드에 대해 거짓말하는 것을 멈추게 만든다.**
 >
-> 다섯 단계의 인지 실천 — **Frame(틀잡기) → Decompose(분해) → Execute(실행) → Verify(검증) → Handoff(인계)** — Kahneman의 System-2 강제, Dalio의 Radical Transparency, Boyd의 OODA Orientation, Munger의 Latticework of Mental Models에 닻을 둡니다. v2.0은 이를 세 개의 층으로 전달합니다. **인지(Cognition)** — 시니어 연구자의 심문(interrogation): 하중을 받는 결정을 등급화된 주장들로 분해하고(`measured / cited / inferred / assumed`), 하중을 받는 주장들을 *초안을 본 적 없는 새로운 컨텍스트에서 외부 증거에 대해* 검증하고, 가장 강한 반론을 논증하고, 가장 약한 고리를 지목하고, 반증 조건을 사전에 약속합니다. **구조(Structure)** — 결정의 형태를 라우팅하고, 평결 아티팩트를 검증하며(`stop` 평결은 닫힌 채로 실패), 진짜 파괴적인 작업만 하드 블록하는 결정론적 훅들; 운영자가 서명한 Reasoning Surface(Ed25519, 구조적으로 에이전트의 손이 닿지 않는)는 운영자 측 프레이밍 아티팩트로 남습니다. **기억(Memory)** — 검증된 심문에서 나온 교훈이 해시 체인으로 연결된 컨텍스트 범위의 프로토콜이 되어, 다음 일치하는 결정에서 다시 떠오릅니다. 이 분업은 우리가 아니라 연구 기록이 정한 것입니다: 자기 초안을 스스로 판정하는 모델은 *더 나빠지고*, 형식 검사는 추론 모양의 토큰에 뚫리며, 오직 아키텍처적 제약만이 인식적 자각을 행동으로 바꿉니다.
->
-> MIRROR 벤치마크([arXiv 2604.19809](https://arxiv.org/abs/2604.19809))가 경험적 질문을 결론지었습니다: 8개 랩 16개 모델, 약 250,000개 인스턴스에서 *"모델에게 자신의 캘리브레이션 점수를 제공하는 것은 유의미한 개선을 주지 않는다; 오직 아키텍처적 제약만이 효과적이다."* Confident Failure Rate는 외부 아키텍처적 제약 하에서 0.60에서 0.14로 떨어집니다. **실천 자체가 제품입니다.** `core/`와 `src/episteme/` 아래의 산물들은, 프론티어 모델 강도에서 *의지력으로서의 경계심* 이 무너질 때 실천이 살아남도록 하는 강제 기하학(enforcement geometry)입니다.
->
-> **→ [`docs/THE_WAY_TO_THINK.md`](docs/THE_WAY_TO_THINK.md)** — 운영화된 실천.
+> 이미 쓰고 있는 코딩 도구 안에 설치된다 (오늘은 Claude Code; 나머지는 벤더 중립 어댑터 레이어). 모든 고위험 행동 이전에 — `git push`, 배포, 마이그레이션, 제약 삭제 — 에이전트는 디스크 위에, 자신이 아는 것, 모르는 것, 그리고 어떤 관측 가능한 사건이 자신을 틀렸다고 증명할지를 적어야 한다. 결정론적 훅이 그 아티팩트를 검사하고, 그것이 진짜가 되기 전까지 진행을 거부한다(`exit 2`). 검증된 결정에서 나온 교훈은 변조가 드러나는(tamper-evident) 컨텍스트 범위 프로토콜이 되어 다음 일치하는 결정에서 다시 떠오른다 — 그래서 에이전트는 시간이 지나며 *당신의* 코드베이스에 더 예리해지고, 당신의 문서는 코드가 테스트에 대해 린트되는 것과 똑같은 방식으로 코드에 대해 린트된다.
+
+**[실제 모습 ↓](#실제-모습)** · **[설치 ↓](#설치)** · **[데모 ↓](#데모)** · **[어떻게 비교되는가 ↓](#어떻게-비교되는가)** · **[내부 구조 ↓](#내부-구조)** · **[작동하는가? ↗](docs/EVALUATION_METHOD.md)**
 
 ---
 
-## 왜 프롬프트만으로는 사고법을 강제할 수 없는가
+## 실제 모습
 
-[`docs/THE_WAY_TO_THINK.md`](docs/THE_WAY_TO_THINK.md)에 명시된 실천은 모든 고위험 의사결정당 여섯 가지 인지 행위를 명명합니다 — Core Question, 구분 맵(Knowns/Unknowns/Assumptions), Signal-vs-Noise 필터, because-chain, hypothesis-as-bet, disconfirmation conditions. 각 행위는 명명된 System-1 실패 모드(question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence — Kahneman)에 대한 구조적 반례입니다. 프롬프트는 이 행위들을 *요청*할 수는 있지만, 프롬프트는 권고일 뿐입니다: 한 번의 호출만 살고, 마감 앞에서 무시되며, 컨텍스트에서 사라집니다. 프론티어 모델은 표면적으로 순응하면서 그 아래의 인지 행위들을 건너뜁니다 — 유창하게, 자신감 있게. 그리고 운영자는 검토를 멈춥니다. 정확히 이것이 실천이 존재하는 이유의 실패 모드입니다.
+당신이 에이전트에게 묻는다: *"우리의 검색-증강 메모리(retrieval-augmented memory) 시스템이 실제로 응답 품질을 개선하고 있는지 평가해줘."*
 
-구체적 예시. 당신이 에이전트에게 말한다: *"우리가 도입한 RAG(검색-증강 메모리) 시스템이 실제로 응답 품질을 개선했는지 평가해줘."*
+**episteme 없이** — 에이전트는 이것을 측정 잡무로 취급한다. 30일치 메트릭을 끌어와 thumbs-up 비율에서 7%의 lift를 발견하고, 자신감 있는 메모를 쓴다: *"메모리는 도움이 된다; 계속 출하하라."* 당신은 그것을 읽는다. 그것은 세 가지 방식으로, 유창하게 틀렸다:
 
-에이전트는 당신의 프롬프트를 측정 과제로 받아들인다. 지난 30일 메트릭을 끌어와 메모리-사용 / 메모리-미사용 응답 샘플을 비교한다. thumbs-up 비율에서 7%의 양(+)의 lift를 발견한다. "메모리 시스템 효과 있음; 계속 출하" 라는 결론의 메모를 쓴다. 당신은 그것을 읽는다.
+- Thumbs-up은 응답의 *정확성*이 아니라 *확신도*를 추적한다 — 에이전트는 질문 자체가 아니라 질문의 대리지표(proxy)를 측정했다.
+- 메모리 응답은 30% 더 길고, 길이는 독립적으로 thumbs-up을 끌어올린다 — 그 "lift"는 길이 효과일 수 있다.
+- 결론이 틀렸다고 판정될 조건이 한 번도 명명되지 않았다 — 그래서 그것은 틀릴 수가 없다.
 
-에이전트는 당신이 피곤하지 않았다면 당연히 던졌을 질문들을 묻지 않았다:
+**episteme와 함께** — 메모가 착지하기 전에, 에이전트는 이것을 디스크에 커밋해야 한다:
 
-- **무엇 (What)** 이 "품질"로 측정되고 있는가? 에이전트가 고른 메트릭은 *thumbs-up 비율* 이다. 하지만 thumbs-up은 응답의 *정확성* 이 아니라 응답의 *확신도* 와 상관한다 — 메모리 인용이 붙은 자신감 있게 *틀린* 답이, 메모리 없이 정직하게 *불확실한* 답보다 높은 점수를 받는다. 에이전트는 질문 자체가 아니라 질문의 *대리지표(proxy)* 를 측정했다.
-- **왜 (Why)** 메모리가 도움이 되는가? 주장되는 메커니즘은 세션 간 안정적인 컨텍스트 보존이다. 그러나 메모리-사용 / 미사용 비교는 응답 길이를 통제하지 않았다 — 메모리 시스템의 응답은 평균 30% 더 길고, 길이 자체가 thumbs-up과 독립적으로 상관된다. "lift" 는 메모리 효과가 아니라 길이 효과일 수 있다.
-- **어떻게 (How)** 이 결론이 틀렸음이 드러나는가? 응답 길이를 통제한 채 다시 돌려본다. lift가 유지되면 결론은 살아있다. 사라지면 메모리는 토큰만 늘렸지 신호는 더하지 않은 것이다. 그것이 에이전트가 명명하지 않은 반증 조건이다.
-
-순진한 에이전트는 프롬프트가 측정을 요청했기 때문에 측정처럼 들리는 답을 준다. `episteme`는 메모가 제출되기 전에 — *디스크에* — 측정이 실제로 무엇을 측정하는지, 어떤 메커니즘이 주장되는지, 어떤 관측 가능한 결과가 그 주장을 반증할지 적도록 강제한다. 적는 행위 자체가 그 대리지표가 질문이 아니었음을 표면화한다.
-
-최근 학계에서는 에이전트와 사용자가 반복적 상호작용을 거치며 에이전트가 맥락에서 실제로 아는 것, 당신이 의도한 것, 시스템의 실제 상태 사이에 누적되는 간격을 **Epistemic Drift (인식론적 표류)** 라고 부른다. 한 번의 큰 실수가 아니라 수많은 작은 엇나감의 누적 — 자정 무렵 당신이 에이전트의 답에 고개를 끄덕이고 프로덕션에 반영한 그 순간, 드리프트는 이미 수십 번 일어난 후다. `episteme`는 에이전트가 행동하기 전에 *무엇 · 왜 · 어떻게* 를 구조적으로 추론하도록 요구함으로써 그 간격을 닫는다.
-
----
-
-## 왜 프롬프트만으로는 부족한가
-
-수많은 대응책이 *더 나은 프롬프트*를 제안한다. 그것도 해결책이긴 하지만, 얕다:
-
-- 시스템 프롬프트의 주의사항은 **한 번의 호출만 산다**. 다음 세션에서는 없는 것과 같다.
-- `CLAUDE.md`에 적어둔 규칙은 **마감이 닥치면 무시된다**. 인간도 그렇고, 에이전트도 그렇다.
-- **노하우** — *"이런 모양의 문제에는 이렇게"* 라는 환원 불가능하게 맥락-특정적인 규칙 — 은 문구를 아무리 잘 써도 가르쳐지지 않는다. **추출되고, 저장되고, 다시 표면화**되어야 한다.
-
-더 깊은 문제는 이거다. 에이전트가 **당신 자신의 요청이 틀렸을 때도 그대로 수행한다는 것**. 사용자도 지식의 깊이가 부족할 수 있고, 오해할 수 있고, 잘못된 전제로 질문할 수 있다. 좋은 시스템은 *에이전트만 감시하는 게 아니라 사용자의 질문 자체도 검증*해야 한다. 프롬프트 수준의 대응책은 이 양방향 검증을 구조화하지 못한다.
-
----
-
-## 해법 — 파일 시스템 수준의 Thinking Framework
-
-`episteme`는 **의도가 상태 변화와 만나는 순간**을 가로챈다. `git push`, `npm publish`, `terraform apply`, DB 마이그레이션, lockfile 편집 등 모든 고위험 작업 이전에 — 그 작업을 *누가 요청했든* (당신이든, 에이전트 스스로든) — 에이전트는 디스크 위에 자신의 추론을 명시적으로 투영해야 한다.
-
-네 개의 필드를 가진 **Reasoning Surface**가 그 형식이다:
-
-| 필드 | 에이전트가 기록해야 하는 것 |
+| 필드 | 에이전트가 반드시 기록해야 하는 것 |
 |---|---|
-| **Core Question** | 이 작업이 *실제로 답하려는* 단 하나의 질문 (question substitution 실패모드 대응) |
-| **Knowns** | 검증된 사실, 출처, 측정값 — 그럴듯한 추측이 아니다 |
-| **Unknowns** | 이름 붙여진, 분류 가능한 결손 — *"리스크가 있을 수 있음"* 같은 모호함이 아니다 |
-| **Assumptions** | 하중을 지탱하는 신념, *반증 가능하도록* 명시 |
-| **Disconfirmation** | 이 계획이 틀렸음을 증명할 *관찰 가능한 사건* — 행동 전에 사전 약속 |
+| **Core Question** | 이 작업이 실제로 답하는 단 하나의 질문 — *"길이를 통제했을 때, 메모리가 정확성을 개선하는가?"* |
+| **Knowns** | 출처가 있는 검증된 사실 — 그럴듯하게 들리는 추측이 아니다 |
+| **Unknowns** | 명명된 결손(*"길이 통제 후에도 lift가 살아남는지"*) — 여기가 비면 게이트가 실패한다 |
+| **Assumptions** | 하중을 지탱하는 신념, 반증될 수 있도록 표시됨 |
+| **Disconfirmation** | 사전 약속된 관측 대상 — *"길이를 통제해 다시 돌렸을 때 lift가 사라지면, 메모리는 신호가 아니라 토큰을 더하고 있는 것이다"* |
 
-유효성은 **구조적으로** 검증된다. 최소 콘텐츠 길이, 게으른 플레이스홀더 금지 (`none`, `n/a`, `tbd`, `해당 없음`), 우회 명령어 패턴 스캔. 표면이 없거나 공허하면 작업은 `exit 2`로 거부된다.
+게으른 토큰(`none`, `n/a`, `tbd`, `해당 없음`)은 거부된다. 모호한 회피 표현(*"문제가 생기면"*)은 거부된다 — 오직 구체적인 반증 조건만 통과한다. surface를 적는 행위 자체가 그 대리지표가 질문이 아니었음을 드러낸다. 그것이 제품이다: **에이전트는 결과가 존재하기 전에, 당신이 감사할 수 있는 방식으로 사고하도록 강제된다.**
 
-특히 Disconfirmation 필드는 단순한 "위험 목록"이 아니다. 이 계획이 틀렸음을 증명할 **구체적이고 관찰 가능한 사건**을 행동 전에 *사전 약속*하도록 강제한다. 과학철학의 핵심 원칙인 **Robust Falsifiability (강건한 반증 가능성)** 을 파일 시스템 수준에서 기계적으로 집행한다 — Strict Mode는 `"if issues arise"` 같은 조건부 공허 문구를 탐지해 거부하고, `"p95 latency > 500ms for 5 min, Grafana dashboard api-latency"` 같은 관찰 가능 조건만 통과시킨다. 반증될 수 없는 계획은 에픽스테메가 아니라 독사(doxa)다.
+![episteme — 움직이는 thinking framework](docs/assets/demo_posture.gif)
 
-**이것이 프롬프트 리마인더와 컴파일러의 차이다: 하나는 부탁하고, 하나는 진행을 거부한다.**
+*`scripts/demo_posture.sh`로 녹화됨 — 차단된 제약 제거, 검증된 재작성, 자신의 blast radius를 선언하도록 강제된 리팩터, 그리고 이후 결정에서 발화하는 합성된 프로토콜.*
 
----
+## 무엇을 얻는가
 
-## ABCD — 네 개의 Cognitive Blueprints
+- **돌아올 수 없는 지점에 놓인 추론 게이트.** 훅이 고위험 작업을 가로채고 Reasoning Surface를 구조적으로 검증한다 — 정규화된 명령어 스캔이 우회 형태(`subprocess.run(['git','push'])`, 에이전트가 작성한 셸 스크립트, 래핑된 실행기)를 잡아낸다. surface가 없거나 공허하면 → 작업이 거부된다. 기본은 strict; advisory 모드는 프로젝트별 opt-in이다.
+- **하중을 받는 결정을 위한 심문(interrogation).** 구조만으로는 사고와 연극을 구분할 수 없다. 그래서 게이트는 더 강한 아티팩트도 받아들인다: 결정을 주장들로 분해하고, 하중을 받는 각 주장을 **초안 추론을 본 적 없는 새로운 컨텍스트**가 검증하며, 가장 강한 반론을 논증하고, 가장 약한 고리를 지목한다. `stop` 평결은 닫힌 채로 실패한다.
+- **부패하는 대신 축적되는 기억.** 검증된 모든 교훈은 해시 체인으로 연결된, 컨텍스트 범위 프로토콜이 된다 — append-only이고 변조가 드러나므로(tamper-evident), 에이전트는 배운 것을 몰래 다시 쓸 수 없다. 다음 일치하는 결정에서 커널은 프로토콜을 선제적으로 표면화한다: `[episteme guide] … · overlap 5/6 · Protocol: In context X, do Y`. 당신이 물어보기를 기억할 필요가 없다.
+- **현실에 대해 린트되는 문서.** 추적되는 모든 문서는 기계가 읽을 수 있는 생명주기 마커(`living / spec-implemented / design-history / report / tombstone`)를 지닌다. 새 문서가 분류되지 않은 채 착지하거나, living 문서가 폐기된 문서를 현행인 양 인용하거나, 특정 시점 보고서가 `docs/`에 눌러앉으려 하면 CI가 실패한다. 버전 문자열은 릴리스 매니페스트에서 찍히며, 손으로 복사하지 않는다. 낡은 문서는 세션 시작 시 표면화된다 — 조용히, 실제로 낡았을 때만. **단일 진리 원천(single source of truth), 열망이 아니라 강제된 것.**
+- **스스로 뒤처리를 하는 시스템.** 검토 큐는 가시적 백프레셔와 함께 상한이 걸리고, 로그는 크기 상한에서 순환하며, 만료된 마커와 오래된 텔레메트리는 세션 시작 시 수거된다. 아티팩트는 쌓이지 않는다; 삭제는 방치의 사고가 아니라 설계된 작업이다.
+- **도구를 가로지르는 하나의 정체성.** 당신의 작업 스타일, 리스크 자세, 추론 선호는 거버넌스가 적용된 버전 관리 마크다운에 산다 — 한 번의 명령으로 모든 어댑터에 동기화된다. 커널은 도구보다 오래 산다.
 
-모든 고위험 작업이 같은 종류의 검증을 필요로 하는 건 아니다. `episteme`는 네 개의 **Cognitive Blueprints**를 가지고 있고, 각각은 특정 실패 유형에 대응한다:
+## 설치
 
-- **A · Axiomatic Judgment** — 신뢰할 만하지만 서로 모순되는 출처들 사이의 갈등을 해소한다. 에이전트가 *왜* 두 출처가 충돌하는지, *현재 맥락의 어떤 특징이* 선택을 결정하는지 명명하도록 강제한다.
-- **B · Fence Reconstruction** — 물려받은 제약을 보호한다. 제약을 제거하기 전에 그 *원래 목적*이 먼저 재구성되어야 한다. **Chesterton's fence**가 파일 시스템에 의해 강제되는 것이다.
-- **C · Consequence Chain** — 되돌릴 수 없는 작업을 분해한다. 1차 효과, 2차 효과, 실패 모드 역상(inversion), 기저율(base rate) 참조, 안전 여유(margin of safety).
-- **D · Architectural Cascade** — 리팩터링과 이름 변경 중 끊어진 참조를 남기는 경우를 잡아낸다. 편집 전에 전체 파급 반경(blast radius)을 열거하도록 에이전트에게 강제한다.
-
-각 Blueprint가 발화할 때마다, 그리고 그것이 검증한 모든 결정은 **변조 불가능한 해시 체인(tamper-evident hash chain)에 커밋된다**. 그 체인은 단순한 로그가 아니다. 커널이 나중에 **Active Guidance**를 제공하는 방식이다: 다음 매칭 결정 시점에, 관련된 합성 프로토콜이 에이전트가 훈련 분포로 되돌아가기 전에 선제적으로 표면화된다.
-
-결과는 **축적되는 프로젝트-맞춤 Thinking Framework**다. 에이전트는 갈등을 해결할 때마다 당신의 코드베이스에 대해 더 예리해진다 — 당신이 훈련시켜서가 아니라, 체인이 기억했기 때문에.
-
----
-
-## 프로토콜 합성 — 커널이 시간을 건너 당신을 돕는 방식
-
-`episteme`가 단순한 차단기에 그치지 않는 지점이 여기다. 해결된 모든 갈등은 **재사용 가능한 프로토콜로 추출된다**:
-
-1. **갈등 감지.** 에이전트가 완전히 해결되지 않은 맥락에 대해 유효해 보이지만 양립 불가능한 두 접근을 만난다.
-2. **평균 내지 말고, 분해하라.** Thinking Framework는 평균 답을 거부한다. 출처가 *왜* 충돌하는지, 맥락의 어떤 특징이 저울을 기울이는지 추출하도록 강제한다.
-3. **Context-fit 프로토콜 합성.** 해결된 *"맥락 X에서는 Y를 하라"* 규칙이 append-only, 해시 체인으로 연결된 지식 저장소에 커밋된다. 변조 불가능이므로 에이전트는 배운 교훈을 몰래 다시 쓸 수 없다.
-4. **능동적으로 가이드하라.** 다음 매칭 결정에서 — 몇 주 뒤든, 세션이나 도구를 건너서든 — 커널은 프로토콜을 **선제적으로** 표면화한다. 당신이 기억해서 물어볼 필요가 없다.
-5. **자기 유지보수하라.** 에이전트가 드리프트(낡은 설정, 폐기된 API, 핵심 로직 불일치)를 발견하면, *patch vs. refactor*의 정직한 평가를 강제하고, 이동하기 전에 전체 파급 반경을 동기화하도록 요구한다.
-
-지식 저장소는 메모리인 척하는 벡터 스토어가 아니다. **구조적이고, 사람이 읽을 수 있으며, 버전 관리되는 아티팩트** — 당신이 읽고, 편집하고, 포크하고, 어댑터(Claude Code, Cursor, Hermes, 미래의 도구) 사이에서 마이그레이션할 수 있다.
-
-합성된 프로토콜들은 단순한 캐시 항목이 아니라 **Knowledge Sanctuaries (지식의 성소)** 다 — 당신의 코드베이스가 시간을 건너 자신에게 전달하는 국지적 진리의 보존소. 변조 불가능하고(Pillar 2 해시 체인), 교리화되지 않으며(맥락-서명과 묶여 있어 오직 매칭 컨텍스트에서만 재활성화), 새로운 증거가 들어오면 진화한다(오래된 프로토콜은 supersedes 관계로 갱신되지, 덮어쓰여지지 않는다). 성소라고 부르는 이유: 이 지식은 무분별한 LLM 평균값으로부터 보호되어야 하며, *현재 이 프로젝트에서 실제로 작동한다고 입증된 규칙만* 이 공간에 머문다.
-
-**커널은 도구보다 오래 산다.**
-
----
-
-## Cognitive Arms — v1.1+
-
-위의 네 Blueprint와 세 Pillar — Cognitive Blueprints · Append-Only Hash Chain · Framework Synthesis & Active Guidance — 는 v1.0의 *변하지 않는 구조적 기반*이다. Pillar는 움직이지 않는다. v1.1은 그 위에서 동작하는 **3 Cognitive Arms**를 더한다 — 시간이 흐르면서 커널 자신의 지식을 재구성하는 유체적·능동적 엔진들이다.
-
-- **Arm A · Temporal Integrity** — 프로토콜은 부패한다. 운영자가 확인한 retire가 낡은 규칙을 조용히 덮어쓰지 않고 supersede한다. 검증 윈도우: CP-DECAY-03 이후 30일.
-- **Arm B · Causal Synthesis** — deferred-discovery 스트림에 대한 zero-LLM 엔티티 추출이 프레임워크가 작동할 수 있는 클러스터 제안을 만들어낸다. 검증 윈도우: 60일.
-- **Arm C · Self-Consistency Convergence** — 프로토콜이 disconfirmation을 구조적으로 도출하는 모델로 승격된다. 검증 윈도우: 90일.
-
-이 구분은 하중을 지탱한다 — Pillar는 정착된 어휘이고, Arm은 시스템이 자기 출력을 시간을 건너 감사하고 다듬는 방식이다. 상태: **v1.4.0-rc1이 2026-05-23에 cut되었고**, 1170 테스트 + 54 subtests 통과. Arm A 기반(supersede-with-history 인프라 + operator profile / policy 편집을 chain stream에 자동 기록하는 hook)이 출하되었으며, Arm A 잔여 작업은 기회주의적으로 재개된다. **Arm B의 substrate-facing 형태는 Event 129에서 공식 SUNSET** — 그 전제(안정적 모델 능력 격차)는 Event 119–120 saturation finding에 의해 반증되었다. Operator-facing 잔여물(`core/ptsp/` typed Fact/Inference 승급 게이트)은 `episteme practice trace`로 도달 가능한 상태로 보존된다. Arm C는 substrate-gap 주장이 살아남는다는 증거를 기다리며 미래 사이클로 스코프되었다.
-
----
-
-## 빠른 시작
-
-### 옵션 A — Claude Code 플러그인 마켓플레이스로 설치
-
-Claude Code 안에서:
+**옵션 A — Claude Code 플러그인 (명령 두 개, 자기완결형):**
 
 ```
 /plugin marketplace add junjslee/episteme
 /plugin install episteme@episteme
 ```
 
-그 후 아무 셸에서나:
+훅, 에이전트, 스킬이 당신의 세션에서 살아난다; pip은 관여하지 않는다.
 
-```bash
-episteme init     # 개인 메모리 파일 시드
-episteme setup    # 작업 스타일 + 인지 프로파일 점수화
-episteme sync     # Claude Code와 Hermes로 전파
-episteme doctor   # 연결 확인
-```
-
-### 옵션 B — 커널을 직접 클론
+**옵션 B — 커널 클론 (CLI + 편집 가능한 소스):**
 
 ```bash
 git clone https://github.com/junjslee/episteme ~/episteme
-cd ~/episteme
-pip install -e .
+cd ~/episteme && pip install -e .
 
-episteme init
-episteme setup . --write
-episteme sync
-episteme doctor
+episteme init      # generate personal memory files from templates
+episteme setup .   # score working style + reasoning posture
+episteme sync      # push identity to every adapter
+episteme doctor    # verify wiring
 ```
 
-심화 온보딩: **[`docs/SETUP.md`](./docs/SETUP.md)**. 전체 명령: **[`docs/COMMANDS.md`](./docs/COMMANDS.md)**.
+기존 저장소에 도입하기: `episteme docs lint`는 추적되는 모든 문서의 생명주기 분류를 강제한다 — 그 첫 lint 실행이 대부분의 저장소가 한 번도 가져본 적 없는 정직한 목록이다. 세부 사항, 프로젝트 하네스, 전체 명령 레퍼런스: [`INSTALL.md`](./INSTALL.md) · [`docs/SETUP.md`](./docs/SETUP.md) · [`docs/COMMANDS.md`](./docs/COMMANDS.md).
 
----
+## 데모
 
-## 제로 트러스트 실행
+모든 데모는 실제 아티팩트를 함께 출하한다 — 어떤 철학보다 먼저 그것들을 읽어라.
 
-[**OWASP Top 10 for Agentic Applications (2026)**](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) — 100명 이상의 업계 전문가가 동료 검토한 자율 에이전트의 주요 위험 분류 — 는 prompt injection, goal hijacking, overreach, memory poisoning, unbounded action을 핵심 위험 클래스로 식별한다. Knowns / Unknowns / Assumptions / Disconfirmation 구조는 각각에 대한 *구조적* 반박이다:
-
-| OWASP Agentic Risk (2026) | episteme의 반박 |
+| 데모 | 무엇을 증명하는가 |
 |---|---|
-| 직접 목표 조작 / prompt injection | 실행 전 Core Question 선언; 이탈은 Unknowns로 표면화 |
-| 간접 명령 주입 | Knowns / Disconfirmation이 신뢰 가능한 상태와 prompt 내용을 분리; 검색된 입력에 따라 행동하기 전 falsifiable한 결과에 commit |
-| Overreach / unbounded action | Frame에서 제약 체제 선언; reversible-first 정책 강제 |
-| 유창한 환각 | Unknowns 필드는 비워둘 수 없음; 행동 전 가정은 명명되어야 함 |
-| 메모리 오염 | Pillar 2 hash-chained protocols — append-only, tamper-evident; 사전 상태의 침묵 재작성은 `verify_chain`이 감지 |
-| 무한 계획 루프 | Disconfirmation 조건 필수; 증거 발화 시 루프 종료 |
+| [`demos/04_symbiosis/`](./demos/04_symbiosis/) | **실제 역사에서 나온 논지 (2026-04-27, Events 65–67):** 운영자가 불안에 이끌린 비가역적 묶음을 제안했고; 커널의 적대적 검토가 3개의 Critical 발견을 표면화했으며; 분해된 경로가 `AGENTS.md`에서 헌법이 되었다. 에이전트와 인간이 *서로의* 의도를 디버깅한다. [`DIFF.md`](./demos/04_symbiosis/DIFF.md)가 그 대안 세계를 나란히 보여준다. |
+| [`demos/03_differential/`](./demos/03_differential/) | **같은 프롬프트, 프레임워크 off vs on.** off는 *어떻게*에 답하고; on은 *~인지 여부*에 답한다. [`DIFF.md`](./demos/03_differential/DIFF.md)가 잡아낸 실패 모드를 명명한다. |
+| [`demos/02_debug_slow_endpoint/`](./demos/02_debug_slow_endpoint/) | 유창하게-틀린 *"캐시를 추가하라"*가 Core Question 게이트에서 죽고; 대신 스키마 수준의 근본 원인이 산출되는 p95 회귀. |
+| [`demos/01_attribution-audit/`](./demos/01_attribution-audit/) | 정본 4-아티팩트 형태 (reasoning-surface → decision-trace → verification → handoff) — 커널이 자신의 귀속(attribution)을 감사한다. |
+| [`demos/05_contract_gate/`](./demos/05_contract_gate/) | 행동적 보완물: 선언된 계약이 턴 종료 시 실행된다. |
 
-명명되지 않은 가정은 신뢰되지 않는다. 전제조건(Knowns)과 제약 체제가 선언되지 않은 한 어떤 행동도 취해지지 않는다. 커널은 의도와 실행 사이의 검증 레이어다.
+히어로 데모를 직접 다시 녹화하기: `scripts/demo_posture.sh` (레시피는 스크립트 헤더에). 라이브 대시보드는 커널 자신의 해시 체인에 대해 렌더링된다 — [`web/README.md`](./web/README.md).
 
-### 업계 수렴 — 2025–2026
+## 어떻게 비교되는가
 
-같은 시기의 주요 프레임워크와 학술 논문이 커널이 출하한 동일한 아키텍처 패턴으로 수렴하고 있다: 파일 시스템 수준의 사전 호출 체크포인트 ([Capsule Security ClawGuard](https://www.businesswire.com/news/home/20260415670902/), 2026), hash-chained tamper-evident memory ([SSGM](https://arxiv.org/abs/2603.11768) — Lam et al., 2026), 규칙 목록 대신 이유 기반 정렬 ([Anthropic Claude Constitution](https://www.anthropic.com/constitution), 2026-01-22), 거버넌스 레이어를 갖춘 5단계 인지 루프 ([SCL R-CCAM](https://arxiv.org/abs/2511.17673) — Kim, 2025), 5-pillar agent integrity ([Proofpoint Agent Integrity Framework 2026](https://www.proofpoint.com/us/resources/white-papers/agent-integrity-framework)). 커널은 이러한 출판물보다 앞선다 (CP1 2026-04-21 출하; v1.0.0 GA 2026-04-28); 수렴은 독립적 검증이지 계보가 아니다. 전체 attribution map은 [`kernel/REFERENCES.md`](./kernel/REFERENCES.md) *Convergent contemporary work* 섹션 참조.
+| 축 | episteme | Memory API (mem0, OpenMemory) | Agent 런타임 (Agno, opencode) |
+|---|---|---|---|
+| **무엇인가** | 기존 도구 위에 얹는 추론 거버넌스 + 정체성 레이어 | 앱에 내장된 Memory API | 에이전트를 실행하는 런타임 |
+| **정체성이 사는 곳** | 거버넌스가 적용된 버전 관리 마크다운/JSON — 도구 간 공유 | 벡터/그래프 스토어, 앱마다 | 시스템 프롬프트, 세션마다 |
+| **노하우** | 파일 시스템 경계에서 추출되고, 해시 체인으로 연결되며, 컨텍스트에 의해 다시 표면화됨 | 불투명한 검색 | 프롬프트 튜닝, 세션마다 |
+| **문서/상태 위생** | 생명주기 린트, GC, CI에서 드리프트 게이트 | N/A | N/A |
 
----
+**이건 그냥 계약 테스트(contract testing) 아닌가?** 계약 테스트는 *행동적* 회귀를 잡는다 — 코드가 스펙이 말한 대로 했는가. Reasoning Surface는 *인식론적* 회귀를 잡는다 — 우리가 올바른 스펙을 썼는가, 올바른 질문을 프레이밍했는가, 우리를 틀렸다고 증명할 것을 명명했는가. 통과하는 테스트 스위트는 당신이 잘못된 문제를 유창하게 풀고 있다는 것을 알려줄 수 없다; 그 실패는 스펙이 존재하기 전에 일어난다. episteme는 두 레이어를 모두 출하한다([`docs/CONTRACT_GATE.md`](./docs/CONTRACT_GATE.md)).
 
-## 이 아키텍처가 해결하는 실패 모드
+**왜 프롬프트로는 이걸 할 수 없는가?** 프롬프트는 권고다: 한 번의 호출만 살고, 마감에서 건너뛰어지며, 컨텍스트에서 사라진다. non-zero로 종료하는 훅은 건너뛸 수 없다. MIRROR 벤치마크([arXiv 2604.19809](https://arxiv.org/abs/2604.19809); 16개 모델, 8개 랩, 약 25만 인스턴스)는 모델에게 자신의 캘리브레이션을 보여주는 것이 도움이 되지 않음을 발견했다 — *오직 아키텍처적 제약만이 효과적이다* (Confident Failure Rate 0.60 → 0.14). 프롬프트가 아니라 자세(Posture over prompt).
 
-`kernel/FAILURE_MODES.md`는 11가지 명명된 실패 모드를 정의한다 — **Kahneman**의 6가지 추론 모드(WYSIATI, question substitution, anchoring, narrative fallacy, planning fallacy, overconfidence)에 3가지 거버넌스 모드(Chesterton's fence, Goodhart drift, Ashby variety mismatch)와 v1.0 RC의 2가지 추가 모드(framework-as-Doxa, cascade-theater)를 더한 것이다.
+## 정직한 한계
 
-각 모드는 구체적 반박 아티팩트에 매핑된다:
+- [`kernel/KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md)는 이 커널이 틀린 도구일 때를 명명한다. *경계 없는 규율은 신조다.*
+- 커널은 자신의 주장을 스스로 측정한다: 프로토콜 합성 루프는 2026-06에 자신의 반증 가능성 조건을 발화시켰고 (49일, 합성된 프로토콜 0개), 검증된 심문에서 합성하도록 재구축되었다 — 감사 기록은 공개되어 있다([`kernel/FAILURE_MODES.md`](./kernel/FAILURE_MODES.md), [`docs/EVALUATION_METHOD.md`](./docs/EVALUATION_METHOD.md)). 당신의 결정에 disconfirmation을 강제하는 커널은 자신에게도 같은 것을 빚지고 있다.
+- 차용한 모든 개념에 대한 귀속, 그리고 같은 패턴으로 독립적으로 수렴한 2025–26 업계 작업: [`kernel/REFERENCES.md`](./kernel/REFERENCES.md).
 
-| 실패 모드 | 반박 아티팩트 |
+## 내부 구조
+
+상태: **<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->** · 실천은 Frame → Decompose → Execute → Verify → Handoff이며, 특정 System-1 실패 모드(question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence)에 대한 명명된 반례에 근거한다 — 전체 운영화는 [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md)이고, 네 개의 Cognitive Blueprint(Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade)는 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)에 명세되어 있다.
+
+```mermaid
+graph TD
+    subgraph SG1["① The Agentic Mind — Intention"]
+        A["Agent\nGenerating intent for a high-impact op"]
+        B["Reasoning Surface\ncore_question · knowns · unknowns\nassumptions · disconfirmation"]
+        D["Doxa\nFluent hallucination\nnone / n/a / tbd / 해당 없음\n< 15 chars · missing fields"]
+        E["Episteme\nJustified true belief\nconcrete knowns · named unknowns\ndisconfirmation ≥ 15 chars · no placeholders"]
+    end
+
+    subgraph SG2["② The Sovereign Kernel — Interception"]
+        F["Stateful Interceptor\ncore/hooks/reasoning_surface_guard.py\nnormalises cmd · deep-scans agent-written files\ncross-call stateful memory"]
+        G["Hard Block · exit 2\nExecution denied\nAgent forced to re-author surface"]
+        H["PASS · exit 0\nPrecondition satisfied\nExecution admitted to Praxis"]
+    end
+
+    subgraph SG3["③ Praxis & Reality — Execution"]
+        I["Tool Execution\ngit push · bash script.sh · npm publish\nterraform apply · DB migrations · lockfile edits"]
+        J["Observed Outcome\ncore/hooks/calibration_telemetry.py\nexit_code 0 or non-zero · stderr captured"]
+    end
+
+    subgraph SG4["④ 결 · Gyeol — Cognitive Texture & Evolution"]
+        K["Prediction Record\ncorrelation_id stamped at PASS\n~/.episteme/telemetry/YYYY-MM-DD-audit.jsonl"]
+        L["Outcome Record\ncorrelation_id · exit_code · stderr\n~/.episteme/telemetry/YYYY-MM-DD-audit.jsonl"]
+        M["episteme evolve friction\nsrc/episteme/cli.py · _evolve_friction\npairs prediction ↔ outcome by correlation_id\nranks under-named unknowns · flags exit_code ≠ 0"]
+        N["결 · Gyeol\nRefined cognitive grain\nfriction hotspots · calibrated profile axes"]
+        O["Operator Profile\ncore/memory/global/operator_profile.md\nlast_elicited axes updated · confidence rescored"]
+        P["kernel/CONSTITUTION.md\nFour principles recalibrated\nfailure-mode counters sharpened"]
+    end
+
+    A --> B
+    B --> D
+    B --> E
+    D --> F
+    E --> F
+    F --> G
+    F --> H
+    G -.->|"cognitive retry"| A
+    H --> I
+    I --> J
+    E -.->|"correlation_id stamped at PASS"| K
+    J --> L
+    K --> M
+    L --> M
+    M --> N
+    N --> O
+    N --> P
+    O -.->|"posture loop closed"| A
+    P -.->|"posture loop closed"| A
+
+    classDef doxaStyle fill:#c0392b,stroke:#922b21,color:#fff
+    classDef episteStyle fill:#1e8449,stroke:#145a32,color:#fff
+    classDef passStyle fill:#27ae60,stroke:#1e8449,color:#fff
+    classDef praxisStyle fill:#2ecc71,stroke:#27ae60,color:#000
+    classDef gyeolStyle fill:#1a5276,stroke:#154360,color:#fff
+    classDef kernelStyle fill:#6c3483,stroke:#512e5f,color:#fff
+    classDef neutralStyle fill:#2c3e50,stroke:#1a252f,color:#fff
+
+    class D,G doxaStyle
+    class E episteStyle
+    class H,I passStyle
+    class J praxisStyle
+    class K,L,M,N,O,P gyeolStyle
+    class F kernelStyle
+    class A,B neutralStyle
+```
+
+**Doxa**(빨강) — 유창하지만 검증되지 않은 출력 — 은 커널이 막기 위해 존재하는 실패 상태다. **Episteme**(초록) — 검증된 surface — 는 실행의 전제조건이다. **Praxis** — 인가된 행동과 그 관측된 결과. **결 · Gyeol**(파랑) — 사이클을 가로질러 프레임워크를 다듬는 캘리브레이션 루프. 어떤 스택과도 작동한다: 커널은 순수 마크다운, 프로파일은 평범한 JSON, 어댑터 레이어(Claude Code, Hermes, OMO/OMX)는 플러그형이다.
+
+커널 자체는 — 순수 마크다운, 코드 없음, 벤더 종속 없음 — [`kernel/`](./kernel/)에서 시작한다:
+
+| 파일 | 무엇을 정의하는가 |
 |---|---|
-| WYSIATI (맥락에 있는 것만으로 추론) | Reasoning Surface의 Unknowns 필드 |
-| Question substitution (쉬운 질문으로 치환) | Frame 단계의 Core Question 요구 |
-| Anchoring (첫 프레이밍 고착) | Disconfirmation 필드 |
-| Chesterton's fence (제약을 이해 없이 제거) | Blueprint B Fence Reconstruction |
-| Cascade-theater (파급 동기화 연기) | Blueprint D + Layer 3 entity grounding |
+| [`SUMMARY.md`](./kernel/SUMMARY.md) | 30줄 운영 증류 |
+| [`CONSTITUTION.md`](./kernel/CONSTITUTION.md) | 뿌리 주장, 네 원칙, 추론자 실패 모드 |
+| [`FAILURE_MODES.md`](./kernel/FAILURE_MODES.md) | 전체 12-모드 분류학 ↔ 반례 아티팩트 |
+| [`REASONING_SURFACE.md`](./kernel/REASONING_SURFACE.md) | Knowns / Unknowns / Assumptions / Disconfirmation 프로토콜 |
+| [`MEMORY_ARCHITECTURE.md`](./kernel/MEMORY_ARCHITECTURE.md) | 다섯 기억 계층 (working → reflective) |
+| [`KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md) | 커널이 틀린 도구일 때 |
+| [`REFERENCES.md`](./kernel/REFERENCES.md) | 귀속 + 수렴하는 동시대 작업 |
 
-반박이 제거되거나 우회될 때는 어떤 모드가 이제 보호받지 못하는지 *명명되어야 한다*. 답이 "없음"이라면 그 반박은 자리값을 하고 있지 않았던 것이다.
+```
+episteme/
+├── kernel/          philosophy (markdown; travels across runtimes)
+├── core/hooks/      deterministic gates + session automation
+├── src/episteme/    CLI + core library (doc lifecycle, sync, telemetry)
+├── adapters/        delivery layers (Claude Code, Hermes, …)
+├── demos/           end-to-end reference deliverables
+├── skills/          reusable operator skills
+├── templates/       project scaffolds
+└── docs/            architecture, contracts, runtime docs — lifecycle-linted
+```
 
-자세히: **[`kernel/FAILURE_MODES.md`](./kernel/FAILURE_MODES.md)**.
+권한 계층: **프로젝트 문서 > 운영자 프로파일 > 커널 기본값 > 런타임 기본값.** 에이전트를 위한 저장소 운영 계약: [`AGENTS.md`](./AGENTS.md) · LLM 사이트맵: [`llms.txt`](./llms.txt).
 
----
-
-## 철학 — doxa · episteme · praxis · 결
-
-저장소 이름은 그리스어에서 왔다:
-
-- **Doxa** (δόξα) — 기본으로 산출되는 유창한 의견. 위 11가지 실패 모드는 *doxa가 자신을 episteme로 착각하는* 분류학이다.
-- **Episteme** (ἐπιστήμη) — 정당화된 지식: 구체적 Knowns, 명명된 Unknowns, 반증 가능한 Disconfirmation. 실행의 전제조건이자 이 저장소의 이름.
-- **Praxis** (πρᾶξις) — 숙지된 행동: 인가한 규율이 그대로 유지된 채 착지하는 효과.
-
-한국어 **결**(*gyeol*)은 나무나 돌의 결 — 따를 때 일관된 형태를 낳고, 거슬러 자를 때 균열하는 — 잠재적 패턴-구조다. Reasoning Surface의 필드 순서 (Knowns → Unknowns → Assumptions → Disconfirmation)가 바로 인식론적 규율의 결이다: **정착된 → 열려있는 → 잠정적 → 반증 조건**.
-
----
-
-## 더 읽기
+## 다음으로 읽을거리
 
 | 주제 | 위치 |
 |---|---|
-| 커널 30줄 증류 | [`kernel/SUMMARY.md`](./kernel/SUMMARY.md) |
-| v1.0 RC 설계 방향 | [`docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md) |
-| 커널이 산출하는 4-아티팩트 예시 | [`demos/01_attribution-audit/`](./demos/01_attribution-audit/) |
-| Thinking Framework *OFF vs. ON* 비교 | [`demos/03_differential/`](./demos/03_differential/) |
-| Hook 레퍼런스 + governance packs | [`docs/HOOKS.md`](./docs/HOOKS.md) |
-| 커널이 *틀린 도구*일 때 | [`kernel/KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md) |
-| 차용한 모든 개념의 1차 출처 | [`kernel/REFERENCES.md`](./kernel/REFERENCES.md) |
-| 에이전트 저장소 운영 계약 | [`AGENTS.md`](./AGENTS.md) |
+| 운영화된 실천 | [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md) |
+| 아키텍처 + 블루프린트 명세 | [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) |
+| 작동하는가? (평가 방법) | [`docs/EVALUATION_METHOD.md`](./docs/EVALUATION_METHOD.md) |
+| 설치 경로 (마켓플레이스, CLI, 개발) | [`INSTALL.md`](./INSTALL.md) |
+| 문서 생명주기 + 기억 계약 | [`docs/MEMORY_CONTRACT.md`](./docs/MEMORY_CONTRACT.md) · [`docs/SYNC_AND_MEMORY.md`](./docs/SYNC_AND_MEMORY.md) |
+| 훅 + 거버넌스 팩 | [`docs/HOOKS.md`](./docs/HOOKS.md) |
+| 보안 자세 (OWASP Agentic 2026 매핑) | [`docs/COMPLIANCE_CROSSWALK.md`](./docs/COMPLIANCE_CROSSWALK.md) |
+| 개인 맞춤 설정 | [`docs/CUSTOMIZATION.md`](./docs/CUSTOMIZATION.md) |
+| 전체 문서 색인 (생성됨) | [`docs/README.md`](./docs/README.md) |
 
----
+## 상업용 라이선스
 
-## 왜 `episteme`인가 — 한 문장으로
-
-**프롬프트가 아니라 자세(Posture over prompt).** 더 좋은 문구를 찾는 대신, AI 에이전트가 *생각하는 방식의 틀*을 파일 시스템 수준에 세운다. 컴파일러처럼 거부할 수 있는 Thinking Framework. 당신의 에이전트를 더 똑똑하게 만드는 것이 아니라, 그 똑똑함이 *당신의 맥락에* 착지하게 만든다.
-
-**Built as a Sovereign Cognitive Kernel — 생각의 틀**.
+상업용 라이선스 또는 컨설팅은 [연락 주세요](mailto:junseong.lee652@gmail.com).

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://github.com/junjslee/episteme/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/junjslee/episteme?include_prereleases&label=release&logo=github"></a>
-  <a href="https://github.com/junjslee/episteme/blob/master/LICENSE"><img alt="License" src="https://img.shields.io/github/license/junjslee/episteme?color=informational"></a>
+  <a href="https://github.com/junjslee/episteme/blob/master/LICENSE"><img alt="License: AGPL-3.0-or-later" src="https://img.shields.io/badge/license-AGPL--3.0--or--later-blue"></a>
   <a href="https://github.com/junjslee/episteme"><img alt="Unique Clones" src="https://img.shields.io/badge/dynamic/json?color=success&label=Unique%20Clones&query=uniques&url=https://gist.githubusercontent.com/junjslee/0a171c9a54b11948bbd1562f4f040465/raw/clone.json&logo=github"></a>
 </p>
 
@@ -20,179 +20,223 @@
 
 <p align="center"><a href="https://epistemekernel.com"><b>epistemekernel.com</b></a></p>
 
-> **episteme 是一种思考方式 —— 생각의 틀 —— 一台让 AI 辅助决策在落地之前先挣得自身置信度的认识引擎（epistemic engine）。**
+> **episteme 让 AI 代理在行动之前先展示它的推理 —— 并让你仓库里的文档不再对你的代码撒谎。**
 >
-> 一套五阶段的认知实践 —— **Frame（立框）→ Decompose（分解）→ Execute（执行）→ Verify（验证）→ Handoff（交接）** —— 锚定于 Kahneman 的 System-2 强制、Dalio 的 Radical Transparency、Boyd 的 OODA Orientation、Munger 的 Latticework of Mental Models。v2.0 把它交付为三层。**认知（Cognition）** —— 资深研究者式的审问（interrogation）：把承重决策分解为分级的主张（`measured / cited / inferred / assumed`），在*从未见过草稿的全新上下文中、针对外部证据*验证承重主张，论证最强的反方立场，指出最薄弱的一环，并预先承诺一个反证条件。**结构（Structure）** —— 确定性 hooks：路由决策形态、校验裁决工件（`stop` 裁决以关闭状态失败）、只对真正破坏性的操作硬阻断；由操作者签名的 Reasoning Surface（Ed25519，在结构上位于代理无法触及之处）仍是操作者侧的立框工件。**记忆（Memory）** —— 来自已验证审问的经验教训成为哈希链接、按上下文限定的协议，在下一个匹配的决策处重新浮现。这套分工不是我们定的，而是研究记录定的：评判自己草稿的模型会*变得更差*，形式检查会被推理形状的 token 攻破，只有架构性约束能把认识上的自觉转化为行为。
->
-> MIRROR 基准（[arXiv 2604.19809](https://arxiv.org/abs/2604.19809)）了结了这个经验问题：在 8 个实验室的 16 个模型、约 250,000 个实例上，*"向模型提供其自身的校准分数不会带来显著改善；只有架构性约束才有效。"* 在外部架构性约束下，Confident Failure Rate 从 0.60 降到 0.14。**实践本身就是产品。** `core/` 与 `src/episteme/` 之下的产物，是让实践在前沿模型强度下、当*作为意志力的警惕*崩溃时仍能存活的强制几何（enforcement geometry）。
->
-> **→ [`docs/THE_WAY_TO_THINK.md`](docs/THE_WAY_TO_THINK.md)** —— 被操作化的实践。
+> 它安装进你已经在用的编码工具里（今天是 Claude Code；其余通过一个厂商中立的适配器层）。在任何高影响操作之前 —— `git push`、一次部署、一次迁移、删除一条约束 —— 代理必须在磁盘上写下：它知道什么、不知道什么、以及什么可观测事件会证明它错了。一个确定性 hook 检查这个工件，在它变得真实之前拒绝继续（`exit 2`）。来自已验证决策的经验教训成为防篡改（tamper-evident）、按上下文限定的协议，在下一个匹配的决策处重新浮现 —— 于是代理随时间对*你的*代码库变得更敏锐，而你的文档会像你的代码对照测试被 lint 一样，对照你的代码被 lint。
+
+**[它是什么样子 ↓](#它是什么样子)** · **[安装 ↓](#安装)** · **[演示 ↓](#演示)** · **[如何对比 ↓](#如何对比)** · **[底层原理 ↓](#底层原理)** · **[它有效吗？ ↗](docs/EVALUATION_METHOD.md)**
 
 ---
 
-## 为什么 prompt 不是真理
+## 它是什么样子
 
-你对代理说：*"评估我们的 retrieval-augmented memory（RAG）系统是否真的在提升响应质量。"*
+你问你的代理：*"评估我们的 retrieval-augmented memory 系统是否真的在提升响应质量。"*
 
-代理把你的 prompt 当作测量任务。它从过去 30 天的指标里取数据，对比有/无记忆系统的响应样本，发现 thumbs-up 率上有 7% 的正向 lift，写出一份备忘录结论："记忆系统有效；继续推进。"你读完它。
+**没有 episteme 时** —— 代理把这当作一件测量杂务。它取来 30 天的指标，发现 thumbs-up 率有 7% 的 lift，然后写下一份自信的备忘录：*"记忆有帮助；继续推进。"* 你读了它。它以三种方式、流畅地错着：
 
-代理没有问你在不那么疲惫的时候本来会问的问题：
+- Thumbs-up 追踪的是响应的*自信度*，不是*正确性* —— 它测量的是问题的代理指标（proxy），不是问题本身。
+- 带记忆的响应长 30%，而长度会独立地拉高 thumbs-up —— 那个 "lift" 可能是长度效应。
+- 从未命名过任何一个能判定结论为错的条件 —— 所以它无法被判错。
 
-- **什么 (What)** 在这里被当作"质量"测量了？代理选的指标是 *thumbs-up 率*。但 thumbs-up 与响应的*自信度*相关，而不是与响应的*正确性*相关——一个带记忆引用的、自信地错误的答案，会比一个正确地保留了不确定性的答案得到更高的分数。代理测量的是问题的*代理指标（proxy）*，不是问题本身。
-- **为什么 (Why)** 记忆系统会有帮助？声称的机制是跨会话的稳定上下文。但有/无对比没有控制响应长度——带记忆的响应平均长 30%，而长度本身就与 thumbs-up 独立相关。所谓的 "lift" 可能是长度效应，而不是记忆效应。
-- **怎么 (How)** 这个结论会被证明是错的？在控制响应长度后重跑。如果 lift 仍然存在，结论成立。如果消失了，那记忆只是加了 token，没有加信号。那就是代理从未明示的反证条件。
+**有 episteme 时** —— 在备忘录落地之前，代理必须把这些提交到磁盘：
 
-天真的代理因为 prompt 要求测量，就给出听起来像测量的答案。`episteme` 强制代理在备忘录提交之前——在磁盘上——写下：测量实际在测什么、声称的是什么机制、什么可观察的结果会推翻这个声称。写下来这个行为本身把"代理指标不等于问题本身"这件事浮上来。
-
-近期学术工作把代理在上下文中实际所知、你的意图、与系统真实状态之间累积的差距称为 **Epistemic Drift（认识论漂移）**。`episteme` 通过结构化地要求代理在行动前推理 *什么 · 为什么 · 怎么* 来弥合这个差距。
-
----
-
-## 为什么 prompt 还不够
-
-- 系统提示里的提醒**只活一次调用**。下一次会话里它就不存在了。
-- `CLAUDE.md` 里写的规则**一到 deadline 就会被忽视**——人类如此，代理也如此。
-- **Know-how**——*"在这种形状的问题里，这样做"* 这种不可还原地依赖上下文的规则——无法靠更好的措辞来教。它必须被**提取、存储、再次显现**。
-
-更深的问题是：代理**即便在用户自己的请求是错的时候，也照样执行**。用户也可能缺乏深度、产生误解、从错误的前提出发。好的系统*不止监督代理，还要验证用户的提问本身*。Prompt 层的补丁无法结构化这种双向验证。
-
----
-
-## 解法——在文件系统层的 Thinking Framework
-
-`episteme` 拦截**意图遇见状态变更的那一刻**。在任何高影响操作（`git push`、`npm publish`、`terraform apply`、DB 迁移、lockfile 编辑）之前——无论这个请求是*谁*发出的（用户本人，还是代理自己）——代理都必须把自己的推理明确地投射到磁盘上的一个四字段 **Reasoning Surface** 里：
-
-| 字段 | 代理必须声明的内容 |
+| 字段 | 代理必须写下的内容 |
 |---|---|
-| **Core Question** | 这个动作**真正在回答**的那一个问题（对抗 question substitution）|
-| **Knowns** | 已核实的事实、引用、测量值——不是听起来合理的猜测 |
-| **Unknowns** | 已命名、可分类的缺口——不是含糊的 *"可能有风险"* |
+| **Core Question** | 这项工作真正回答的那一个问题 —— *"在控制长度后，记忆是否提升正确性？"* |
+| **Knowns** | 有出处的已核实事实 —— 不是听起来合理的猜测 |
+| **Unknowns** | 已命名的缺口（*"lift 在长度控制后是否还在"*）—— 这里留空就会让 gate 失败 |
 | **Assumptions** | 承重的信念，标注出来以便被证伪 |
-| **Disconfirmation** | 能*证明此计划错了*的可观测事件——在行动前预先承诺 |
+| **Disconfirmation** | 预先承诺的可观测量 —— *"如果在控制长度的重跑下 lift 消失，那记忆加的是 token，不是信号"* |
 
-有效性**结构化**校验：最小内容长度、禁止懒惰占位符（`none`、`n/a`、`tbd`、`해당 없음`）、规范化命令扫描。如果 surface 缺失或空洞，操作以 `exit 2` 被拒绝。
+懒惰的 token（`none`、`n/a`、`tbd`、`해당 없음`）被拒绝。含糊的搪塞（*"如果出现问题"*）被拒绝 —— 只有具体的证伪条件才能通过。写下 surface 这个行为本身，就揭示了那个代理指标并不是问题本身。这就是产品：**在后果存在之前，代理被强制以一种你可以审计的方式思考。**
 
-**这就是 prompt 提醒和编译器的区别：一个在请求，一个在拒绝推进。**
+![episteme —— 运转中的 thinking framework](docs/assets/demo_posture.gif)
 
----
+*录制自 `scripts/demo_posture.sh` —— 一次被阻断的约束移除、一次通过验证的重写、一次被强制声明其 blast radius 的重构，以及在之后的决策上触发的合成协议。*
 
-## ABCD——四个 Cognitive Blueprints
+## 你会得到什么
 
-每个高影响操作会触发四个 Blueprint 之一，每一个都对应一类特定的失败模式：
+- **一道设在不可回头之处的推理 gate。** Hooks 拦截高影响操作，并在结构上校验 Reasoning Surface —— 规范化命令扫描能抓住各种绕过形态（`subprocess.run(['git','push'])`、代理编写的 shell 脚本、被包装的执行器）。surface 缺失或空洞 → 操作被拒绝。默认 strict；advisory 模式按项目 opt-in。
+- **对承重决策的审问。** 单靠结构无法区分思考与表演，所以 gate 还接受一种更强的工件：把决策分解为主张，每个承重主张都由一个**从未见过草稿推理的全新上下文**来验证，论证最强的反方，指出最薄弱的一环。`stop` 裁决以关闭状态失败。
+- **会累积而非衰减的记忆。** 每一条已验证的教训都成为哈希链接、按上下文限定的协议 —— append-only 且防篡改，因此代理无法悄悄改写它学到的东西。在下一个匹配的决策处，kernel 会主动浮现该协议：`[episteme guide] … · overlap 5/6 · Protocol: In context X, do Y`。你不必记得去问。
+- **对照现实被 lint 的文档。** 每个被跟踪的文档都带着机器可读的生命周期标记（`living / spec-implemented / design-history / report / tombstone`）。当一个新文档未经分类就落地、当一个 living 文档把已退役的文档当作现行来引用、或当一份时点报告试图强占 `docs/` 时，CI 都会失败。版本字符串从 release 清单中盖印，绝不手抄。陈旧的文档在会话开始时浮现 —— 悄无声息，只在确实陈旧时。**单一事实来源（single source of truth），是被强制的，而非仅仅被向往。**
+- **一个会自己收拾的系统。** 审查队列有上限并带可见的背压，日志在大小上限处轮转，过期标记和旧遥测在会话开始时被回收。工件不会堆积；删除是一项被设计的操作，不是疏忽的意外。
+- **跨工具的单一身份。** 你的工作风格、风险姿态和推理偏好，都活在受治理、带版本的 markdown 里 —— 一条命令即可同步到每个适配器。kernel 比工具活得更久。
 
-- **A · Axiomatic Judgment** — 解决可信但相互矛盾的信息源之间的冲突。强制代理说出*为什么*它们有冲突，以及*当前上下文的哪个特征*做出选择。
-- **B · Fence Reconstruction** — 保护继承下来的约束。在移除某个约束之前，必须先重建它的*原始目的*。**Chesterton's fence** 被文件系统强制执行。
-- **C · Consequence Chain** — 分解不可逆操作（一阶效应、二阶效应、failure-mode 反转、基准率、margin of safety）。
-- **D · Architectural Cascade** — 捕捉那些会留下陈旧引用的重构和重命名。在编辑之前，强制代理枚举完整的 blast radius。
+## 安装
 
-每一次 Blueprint 触发、以及它所验证的每一个决定，都会被提交到一条**防篡改的哈希链（tamper-evident hash chain）**。这条链不是日志——它是 kernel 之后提供 **Active Guidance** 的方式：在下一次匹配的决策点，相关的合成 protocol 会在代理退回到训练分布之前，**主动**浮现出来。
-
-结果是**随你的项目不断累积的 Thinking Framework**。每次代理解决一次冲突，它对你的代码库都变得更敏锐——不是因为你训练它，而是因为链替你记住了。
-
----
-
-## 零信任执行
-
-[**OWASP Top 10 for Agentic Applications (2026)**](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) — 由 100 多位业界专家同行评议 — 将 prompt injection、goal hijacking、overreach、memory poisoning、unbounded action 列为自主代理的主要风险类别。Knowns / Unknowns / Assumptions / Disconfirmation 结构对每一项都是*结构性*反制：
-
-| OWASP Agentic Risk (2026) | episteme 的反制 |
-|---|---|
-| 直接目标操纵 / prompt injection | 执行前声明 Core Question；偏差以 Unknowns 形式浮现 |
-| 间接指令注入 | Knowns / Disconfirmation 将可信状态与 prompt 内容分离；代理在依据检索到的输入行动之前承诺一个可证伪的结果 |
-| Overreach / unbounded action | 在 Frame 中声明约束规则；强制 reversible-first 策略 |
-| 流畅幻觉 | Unknowns 字段不可为空；行动前必须命名假设 |
-| 内存投毒 | Pillar 2 hash-chained protocols — append-only、tamper-evident；对先前状态的静默重写由 `verify_chain` 检测 |
-| 无限规划循环 | Disconfirmation 条件必填；证据触发时循环退出 |
-
-未命名的假设不被信任。未声明前提条件 (Knowns) 与约束规则之前不采取任何行动。kernel 是意图与执行之间的验证层。
-
-### 业界收敛 — 2025–2026
-
-同一时间窗内的主要框架与学术论文，正向 kernel 已交付的相同架构模式收敛：文件系统层的 pre-invocation checkpoint ([Capsule Security ClawGuard](https://www.businesswire.com/news/home/20260415670902/), 2026)、hash-chained 防篡改内存 ([SSGM](https://arxiv.org/abs/2603.11768) — Lam et al., 2026)、基于理由而非规则清单的对齐 ([Anthropic Claude Constitution](https://www.anthropic.com/constitution), 2026-01-22)、带治理层的五阶段认知循环 ([SCL R-CCAM](https://arxiv.org/abs/2511.17673) — Kim, 2025)、五支柱 agent integrity ([Proofpoint Agent Integrity Framework 2026](https://www.proofpoint.com/us/resources/white-papers/agent-integrity-framework))。kernel 早于这些出版物 (CP1 于 2026-04-21 交付；v1.0.0 GA 于 2026-04-28)；这种收敛是独立验证，并非血统。完整 attribution map 见 [`kernel/REFERENCES.md`](./kernel/REFERENCES.md) 中 *Convergent contemporary work* 章节。
-
----
-
-## Cognitive Arms — v1.1+
-
-上述四个 Blueprint 和三个 Pillar — Cognitive Blueprints · Append-Only Hash Chain · Framework Synthesis & Active Guidance — 是 v1.0 *不变的结构基础*。Pillar 不会移动。v1.1 在其之上加入了 **3 Cognitive Arms**：随着时间推移、不断重构 kernel 自身知识的流动型主动引擎。
-
-- **Arm A · Temporal Integrity** — 协议会衰退。经操作员确认的 retire 会 supersede 一条陈旧规则，而不是静默覆盖它。验证窗口：CP-DECAY-03 之后 30 天。
-- **Arm B · Causal Synthesis** — 对 deferred-discovery 流进行零-LLM 实体抽取，产生 framework 可以据此行动的聚类提案。验证窗口：60 天。
-- **Arm C · Self-Consistency Convergence** — 协议升级为以结构化方式推导 disconfirmation 的模型。验证窗口：90 天。
-
-这个区分承载结构性意义 — Pillar 是已沉淀的术语，Arm 是系统跨越时间审计和打磨自己输出的方式。状态：**v1.4.0-rc1 于 2026-05-23 切出**，1170 tests + 54 subtests 通过。Arm A 基础设施已交付（supersede-with-history 基础设施 + 将 operator profile / policy 编辑自动记录到 chain stream 的 hook）；Arm A 剩余工作伺机恢复。**Arm B substrate-facing 形态在 Event 129 正式 SUNSET** — 其前提（稳定的模型能力差距）已被 Event 119–120 饱和发现证伪。其 operator-facing 残留（`core/ptsp/` typed Fact/Inference 提升门）通过 `episteme practice trace` 保留可达。Arm C 已 scope 到未来周期，等待 substrate-gap 主张存活的证据。
-
----
-
-## 快速开始
-
-### 方式 A — Claude Code 插件市场
-
-在 Claude Code 里：
+**方式 A —— Claude Code 插件（两条命令，自包含）：**
 
 ```
 /plugin marketplace add junjslee/episteme
 /plugin install episteme@episteme
 ```
 
-然后在任意 shell：
+Hooks、代理和 skills 在你的会话中即刻生效；不涉及 pip。
 
-```bash
-episteme init     # 从模板种子化个人记忆文件
-episteme setup    # 对工作风格 + 认知风格进行打分
-episteme sync     # 传播到 Claude Code 和 Hermes
-episteme doctor   # 验证连接
-```
-
-### 方式 B — 直接克隆 kernel
+**方式 B —— 克隆 kernel（CLI + 可编辑源码）：**
 
 ```bash
 git clone https://github.com/junjslee/episteme ~/episteme
-cd ~/episteme
-pip install -e .
+cd ~/episteme && pip install -e .
 
-episteme init
-episteme setup . --write
-episteme sync
-episteme doctor
+episteme init      # generate personal memory files from templates
+episteme setup .   # score working style + reasoning posture
+episteme sync      # push identity to every adapter
+episteme doctor    # verify wiring
 ```
 
-更深入的 onboarding：**[`docs/SETUP.md`](./docs/SETUP.md)**。完整命令参考：**[`docs/COMMANDS.md`](./docs/COMMANDS.md)**。
+在既有仓库中采用：`episteme docs lint` 会强制对每个被跟踪的文档做一次生命周期分类 —— 那第一次 lint 运行，就是大多数仓库从未拥有过的诚实清单。细节、项目 harness 与完整命令参考：[`INSTALL.md`](./INSTALL.md) · [`docs/SETUP.md`](./docs/SETUP.md) · [`docs/COMMANDS.md`](./docs/COMMANDS.md)。
 
----
+## 演示
 
-## 哲学——doxa · episteme · praxis · 결
+每个演示都随附它真实的工件 —— 在任何哲学之前先读它们。
 
-仓库名来自希腊语：
+| 演示 | 它证明了什么 |
+|---|---|
+| [`demos/04_symbiosis/`](./demos/04_symbiosis/) | **来自真实历史的论点（2026-04-27，Events 65–67）：** 操作者提出了一个由焦虑驱动的不可逆捆绑包；kernel 的对抗式审查浮现出 3 个 Critical 发现；被分解后的路径在 `AGENTS.md` 中成为了宪法。代理与人类在调试*彼此的*意图。[`DIFF.md`](./demos/04_symbiosis/DIFF.md) 把那个另一种世界并排展示出来。 |
+| [`demos/03_differential/`](./demos/03_differential/) | **同一个 prompt，框架 off vs on。** off 回答*怎么做*；on 回答*该不该*。[`DIFF.md`](./demos/03_differential/DIFF.md) 点名了被抓住的 failure modes。 |
+| [`demos/02_debug_slow_endpoint/`](./demos/02_debug_slow_endpoint/) | 一次 p95 回归，流畅却错误的*"加个 cache"* 死在 Core Question gate 上；取而代之产出的是一个 schema 层面的根因。 |
+| [`demos/01_attribution-audit/`](./demos/01_attribution-audit/) | 正典的四工件形态（reasoning-surface → decision-trace → verification → handoff）—— kernel 在审计它自己的归属。 |
+| [`demos/05_contract_gate/`](./demos/05_contract_gate/) | 行为层面的补充：声明的契约在回合结束时运行。 |
 
-- **Doxa** (δόξα) — 默认产出的流畅意见。[`kernel/FAILURE_MODES.md`](./kernel/FAILURE_MODES.md) 里的 11 个 failure mode 是一个*把 doxa 误认为 episteme* 的分类学。
-- **Episteme** (ἐπιστήμη) — 可辩护的知识：具体的 Knowns、被命名的 Unknowns、可证伪的 Disconfirmation。执行的前置条件。
-- **Praxis** (πρᾶξις) — 带着授权纪律的行动：效果落地时纪律完好无损。
+自己重新录制这段主打演示：`scripts/demo_posture.sh`（配方在脚本头部）。实时仪表板对照 kernel 自己的哈希链渲染 —— [`web/README.md`](./web/README.md)。
 
-韩语 **결**（*gyeol*）命名木材或石头的纹理——潜在的模式结构，顺着它切会形成连贯的形态，逆着它切则会断裂。Reasoning Surface 的字段顺序正是认识论纪律的 *gyeol*：**已确立 → 开放 → 暂定 → 证伪条件**。
+## 如何对比
 
----
+| 维度 | episteme | Memory APIs (mem0, OpenMemory) | Agent 运行时 (Agno, opencode) |
+|---|---|---|---|
+| **它是什么** | 架在你现有工具之上的推理治理 + 身份层 | 嵌入某个应用里的记忆 API | 一个执行代理的运行时 |
+| **身份住在哪里** | 受治理、带版本的 markdown/JSON —— 跨工具 | 向量/图存储，按应用 | 系统提示，按会话 |
+| **Know-how** | 在文件系统边界处抽取、哈希链接、按上下文重新浮现 | 不透明的检索 | 按会话做 prompt 调优 |
+| **文档/状态卫生** | 生命周期 lint、GC、CI 中做 drift 门控 | N/A | N/A |
 
-## 下一步阅读
+**这不就是 contract testing 吗？** 契约测试抓的是*行为*回归 —— 代码有没有照 spec 说的做。Reasoning Surface 抓的是*认识论*回归 —— 我们有没有写对 spec、框对问题、说清楚什么会证明我们错了。一个通过的测试套件无法告诉你，你正在流畅地解决错误的问题；那种失败发生在 spec 存在之前。episteme 交付两层（[`docs/CONTRACT_GATE.md`](./docs/CONTRACT_GATE.md)）。
+
+**为什么 prompt 做不到这个？** Prompt 是建议性的：只活一次调用，一到 deadline 就被跳过，然后从上下文里消失。一个以非零退出的 hook 无法被跳过。MIRROR 基准（[arXiv 2604.19809](https://arxiv.org/abs/2604.19809)；16 个模型、8 个实验室、约 25 万个实例）发现，向模型展示它自己的校准并没有帮助 —— *只有架构性约束才有效*（Confident Failure Rate 0.60 → 0.14）。姿态高于 prompt（Posture over prompt）。
+
+## 诚实的边界
+
+- [`kernel/KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md) 点名了这个 kernel 何时是错的工具。*没有边界的纪律，只是一种信条。*
+- kernel 会度量它自己的主张：协议合成循环在 2026-06 触发了它自己的可证伪条件（49 天，零条合成协议），随后被重建为从已验证的审问中合成 —— 审计轨迹是公开的（[`kernel/FAILURE_MODES.md`](./kernel/FAILURE_MODES.md)、[`docs/EVALUATION_METHOD.md`](./docs/EVALUATION_METHOD.md)）。一个对你的决策强制 disconfirmation 的 kernel，也欠你对它自己做同样的事。
+- 对每一个借用概念的归属，以及 2025–26 年独立收敛到相同模式的业界工作：[`kernel/REFERENCES.md`](./kernel/REFERENCES.md)。
+
+## 底层原理
+
+状态：**<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->** · 这套实践是 Frame → Decompose → Execute → Verify → Handoff，锚定于针对特定 System-1 failure modes（question substitution、WYSIATI、anchoring、narrative fallacy、planning fallacy、overconfidence）的具名反制 —— 完整的操作化在 [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md)，四个 Cognitive Blueprints（Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade）在 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) 中给出规格。
+
+```mermaid
+graph TD
+    subgraph SG1["① The Agentic Mind — Intention"]
+        A["Agent\nGenerating intent for a high-impact op"]
+        B["Reasoning Surface\ncore_question · knowns · unknowns\nassumptions · disconfirmation"]
+        D["Doxa\nFluent hallucination\nnone / n/a / tbd / 해당 없음\n< 15 chars · missing fields"]
+        E["Episteme\nJustified true belief\nconcrete knowns · named unknowns\ndisconfirmation ≥ 15 chars · no placeholders"]
+    end
+
+    subgraph SG2["② The Sovereign Kernel — Interception"]
+        F["Stateful Interceptor\ncore/hooks/reasoning_surface_guard.py\nnormalises cmd · deep-scans agent-written files\ncross-call stateful memory"]
+        G["Hard Block · exit 2\nExecution denied\nAgent forced to re-author surface"]
+        H["PASS · exit 0\nPrecondition satisfied\nExecution admitted to Praxis"]
+    end
+
+    subgraph SG3["③ Praxis & Reality — Execution"]
+        I["Tool Execution\ngit push · bash script.sh · npm publish\nterraform apply · DB migrations · lockfile edits"]
+        J["Observed Outcome\ncore/hooks/calibration_telemetry.py\nexit_code 0 or non-zero · stderr captured"]
+    end
+
+    subgraph SG4["④ 결 · Gyeol — Cognitive Texture & Evolution"]
+        K["Prediction Record\ncorrelation_id stamped at PASS\n~/.episteme/telemetry/YYYY-MM-DD-audit.jsonl"]
+        L["Outcome Record\ncorrelation_id · exit_code · stderr\n~/.episteme/telemetry/YYYY-MM-DD-audit.jsonl"]
+        M["episteme evolve friction\nsrc/episteme/cli.py · _evolve_friction\npairs prediction ↔ outcome by correlation_id\nranks under-named unknowns · flags exit_code ≠ 0"]
+        N["결 · Gyeol\nRefined cognitive grain\nfriction hotspots · calibrated profile axes"]
+        O["Operator Profile\ncore/memory/global/operator_profile.md\nlast_elicited axes updated · confidence rescored"]
+        P["kernel/CONSTITUTION.md\nFour principles recalibrated\nfailure-mode counters sharpened"]
+    end
+
+    A --> B
+    B --> D
+    B --> E
+    D --> F
+    E --> F
+    F --> G
+    F --> H
+    G -.->|"cognitive retry"| A
+    H --> I
+    I --> J
+    E -.->|"correlation_id stamped at PASS"| K
+    J --> L
+    K --> M
+    L --> M
+    M --> N
+    N --> O
+    N --> P
+    O -.->|"posture loop closed"| A
+    P -.->|"posture loop closed"| A
+
+    classDef doxaStyle fill:#c0392b,stroke:#922b21,color:#fff
+    classDef episteStyle fill:#1e8449,stroke:#145a32,color:#fff
+    classDef passStyle fill:#27ae60,stroke:#1e8449,color:#fff
+    classDef praxisStyle fill:#2ecc71,stroke:#27ae60,color:#000
+    classDef gyeolStyle fill:#1a5276,stroke:#154360,color:#fff
+    classDef kernelStyle fill:#6c3483,stroke:#512e5f,color:#fff
+    classDef neutralStyle fill:#2c3e50,stroke:#1a252f,color:#fff
+
+    class D,G doxaStyle
+    class E episteStyle
+    class H,I passStyle
+    class J praxisStyle
+    class K,L,M,N,O,P gyeolStyle
+    class F kernelStyle
+    class A,B neutralStyle
+```
+
+**Doxa**（红色）—— 流畅但未经验证的输出 —— 是 kernel 存在以阻止的失败状态。**Episteme**（绿色）—— 一个经过验证的 surface —— 是执行的前置条件。**Praxis** —— 被准入的行动及其被观测到的结果。**결 · Gyeol**（蓝色）—— 跨越周期打磨框架的校准循环。适用于任何技术栈：kernel 是纯 markdown，profile 是普通 JSON，适配器层（Claude Code、Hermes、OMO/OMX）可插拔。
+
+kernel 本身 —— 纯 markdown，无代码，无厂商锁定 —— 从 [`kernel/`](./kernel/) 开始：
+
+| 文件 | 它定义了什么 |
+|---|---|
+| [`SUMMARY.md`](./kernel/SUMMARY.md) | 30 行的运行蒸馏 |
+| [`CONSTITUTION.md`](./kernel/CONSTITUTION.md) | 根主张、四条原则、推理者 failure modes |
+| [`FAILURE_MODES.md`](./kernel/FAILURE_MODES.md) | 完整的 12 模式分类学 ↔ 反制工件 |
+| [`REASONING_SURFACE.md`](./kernel/REASONING_SURFACE.md) | Knowns / Unknowns / Assumptions / Disconfirmation 协议 |
+| [`MEMORY_ARCHITECTURE.md`](./kernel/MEMORY_ARCHITECTURE.md) | 五个记忆层级（working → reflective） |
+| [`KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md) | kernel 何时是错的工具 |
+| [`REFERENCES.md`](./kernel/REFERENCES.md) | 归属 + 收敛的同期工作 |
+
+```
+episteme/
+├── kernel/          philosophy (markdown; travels across runtimes)
+├── core/hooks/      deterministic gates + session automation
+├── src/episteme/    CLI + core library (doc lifecycle, sync, telemetry)
+├── adapters/        delivery layers (Claude Code, Hermes, …)
+├── demos/           end-to-end reference deliverables
+├── skills/          reusable operator skills
+├── templates/       project scaffolds
+└── docs/            architecture, contracts, runtime docs — lifecycle-linted
+```
+
+权威层级：**项目文档 > 操作者 profile > kernel 默认值 > 运行时默认值。** 仓库对代理的运营契约：[`AGENTS.md`](./AGENTS.md) · 面向 LLM 的站点地图：[`llms.txt`](./llms.txt)。
+
+## 继续阅读
 
 | 主题 | 位置 |
 |---|---|
-| Kernel 30 行蒸馏 | [`kernel/SUMMARY.md`](./kernel/SUMMARY.md) |
-| v1.0 RC 设计方向 | [`docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md) |
-| 11 个 failure mode 及其反制 artifact | [`kernel/FAILURE_MODES.md`](./kernel/FAILURE_MODES.md) |
-| 同一个 prompt，Thinking Framework *关 vs. 开* | [`demos/03_differential/`](./demos/03_differential/) |
-| 何时 kernel 是错的工具 | [`kernel/KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md) |
-| 每一个借用概念的出处 | [`kernel/REFERENCES.md`](./kernel/REFERENCES.md) |
-| 仓库对代理的运营契约 | [`AGENTS.md`](./AGENTS.md) |
+| 被操作化的实践 | [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md) |
+| 架构 + blueprint 规格 | [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) |
+| 它有效吗？（评估方法） | [`docs/EVALUATION_METHOD.md`](./docs/EVALUATION_METHOD.md) |
+| 安装路径（marketplace、CLI、开发） | [`INSTALL.md`](./INSTALL.md) |
+| 文档生命周期 + 记忆契约 | [`docs/MEMORY_CONTRACT.md`](./docs/MEMORY_CONTRACT.md) · [`docs/SYNC_AND_MEMORY.md`](./docs/SYNC_AND_MEMORY.md) |
+| Hooks + governance packs | [`docs/HOOKS.md`](./docs/HOOKS.md) |
+| 安全姿态（OWASP Agentic 2026 映射） | [`docs/COMPLIANCE_CROSSWALK.md`](./docs/COMPLIANCE_CROSSWALK.md) |
+| 个性化定制 | [`docs/CUSTOMIZATION.md`](./docs/CUSTOMIZATION.md) |
+| 完整文档索引（生成的） | [`docs/README.md`](./docs/README.md) |
+
+## 商业授权
+
+如需商业授权或咨询，[联系我](mailto:junseong.lee652@gmail.com)。
 
 ---
 
-## 为什么是 `episteme`——一句话
-
-**姿态高于 prompt（Posture over prompt）**。不是寻找更好的措辞，而是在文件系统层面建立 *AI 代理思考的框架*。一个可以像编译器那样*拒绝继续推进*的 Thinking Framework。它不是让你的代理更聪明——而是让这份聪明*落地到你的上下文里*。
-
-**Built as a Sovereign Cognitive Kernel — 생각의 틀**.
-
----
-
-> **Note on translation.** This README is a focused-scope Chinese adaptation maintained alongside the canonical English [`README.md`](./README.md). For deepest documentation, demo walkthroughs, and architectural diagrams, refer to the English docs tree. Technical terms (Thinking Framework, Reasoning Surface, Blueprint, Core Question, Chesterton's fence, Pillar 3, flaw_classification, etc.) are kept in English because they are load-bearing kernel vocabulary.
+> **关于翻译的说明。** 本 README 是与权威英文版 [`README.md`](./README.md) 一同维护的中文翻译。若需最深入的文档、演示走查与架构图，请参阅英文文档树。承重的 kernel 术语（Reasoning Surface、Core Question、Blueprint、hook、kernel、doxa/episteme/praxis 等）刻意保留英文。


### PR DESCRIPTION
The three translations still mirrored the pre-E149 528-line README. Each is now a faithful translation of the current tangible-first structure — one commit per language.

Verification: heading parity 9=9=9=9 across all four files (same order, 1:1 mapping) · version span byte-identical exactly once per file · header block diffs only in the bold self-link (plus a stale license badge in the old translations, corrected) · Mermaid/node labels + code blocks verbatim per convention · suite unaffected (1641+88 in worktree env) · doc_references: zero new dangling (stash-diffed against baseline).

Korean phrasings needing the (already-ledgered) native-review pass are listed in the lane report — e.g. 실제 모습 / 출하하다 / load-bearing renderings.