### PR TITLE
feat(hooks): SessionStart sync self-heal — updates reach every project without remembering to re-sync

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 
 <p align="center">
   <a href="https://github.com/junjslee/episteme/releases"><img alt="Latest Release" src="https://img.shields.io/github/v/release/junjslee/episteme?include_prereleases&label=release&logo=github"></a>
-  <a href="https://github.com/junjslee/episteme/blob/master/LICENSE"><img alt="License" src="https://img.shields.io/github/license/junjslee/episteme?color=informational"></a>
+  <a href="https://github.com/junjslee/episteme/blob/master/LICENSE"><img alt="License: AGPL-3.0-or-later" src="https://img.shields.io/badge/license-AGPL--3.0--or--later-blue"></a>
   <a href="https://github.com/junjslee/episteme"><img alt="Unique Clones" src="https://img.shields.io/badge/dynamic/json?color=success&label=Unique%20Clones&query=uniques&url=https://gist.githubusercontent.com/junjslee/0a171c9a54b11948bbd1562f4f040465/raw/clone.json&logo=github"></a>
 </p>
 
@@ -20,222 +20,219 @@
 
 <p align="center"><a href="https://epistemekernel.com"><b>epistemekernel.com</b></a></p>
 
-> **episteme는 사고법입니다 — 생각의 틀 — AI 보조 의사결정이 실행되기 전에 자신의 확신을 스스로 증명하게 만드는 인식 엔진(epistemic engine).**
+> **episteme는 AI 에이전트가 행동하기 전에 자신의 추론을 증명하게 만들고 — 당신 저장소의 문서가 코드에 대해 거짓말하는 것을 멈추게 만든다.**
 >
-> 다섯 단계의 인지 실천 — **Frame(틀잡기) → Decompose(분해) → Execute(실행) → Verify(검증) → Handoff(인계)** — Kahneman의 System-2 강제, Dalio의 Radical Transparency, Boyd의 OODA Orientation, Munger의 Latticework of Mental Models에 닻을 둡니다. v2.0은 이를 세 개의 층으로 전달합니다. **인지(Cognition)** — 시니어 연구자의 심문(interrogation): 하중을 받는 결정을 등급화된 주장들로 분해하고(`measured / cited / inferred / assumed`), 하중을 받는 주장들을 *초안을 본 적 없는 새로운 컨텍스트에서 외부 증거에 대해* 검증하고, 가장 강한 반론을 논증하고, 가장 약한 고리를 지목하고, 반증 조건을 사전에 약속합니다. **구조(Structure)** — 결정의 형태를 라우팅하고, 평결 아티팩트를 검증하며(`stop` 평결은 닫힌 채로 실패), 진짜 파괴적인 작업만 하드 블록하는 결정론적 훅들; 운영자가 서명한 Reasoning Surface(Ed25519, 구조적으로 에이전트의 손이 닿지 않는)는 운영자 측 프레이밍 아티팩트로 남습니다. **기억(Memory)** — 검증된 심문에서 나온 교훈이 해시 체인으로 연결된 컨텍스트 범위의 프로토콜이 되어, 다음 일치하는 결정에서 다시 떠오릅니다. 이 분업은 우리가 아니라 연구 기록이 정한 것입니다: 자기 초안을 스스로 판정하는 모델은 *더 나빠지고*, 형식 검사는 추론 모양의 토큰에 뚫리며, 오직 아키텍처적 제약만이 인식적 자각을 행동으로 바꿉니다.
->
-> MIRROR 벤치마크([arXiv 2604.19809](https://arxiv.org/abs/2604.19809))가 경험적 질문을 결론지었습니다: 8개 랩 16개 모델, 약 250,000개 인스턴스에서 *"모델에게 자신의 캘리브레이션 점수를 제공하는 것은 유의미한 개선을 주지 않는다; 오직 아키텍처적 제약만이 효과적이다."* Confident Failure Rate는 외부 아키텍처적 제약 하에서 0.60에서 0.14로 떨어집니다. **실천 자체가 제품입니다.** `core/`와 `src/episteme/` 아래의 산물들은, 프론티어 모델 강도에서 *의지력으로서의 경계심* 이 무너질 때 실천이 살아남도록 하는 강제 기하학(enforcement geometry)입니다.
->
-> **→ [`docs/THE_WAY_TO_THINK.md`](docs/THE_WAY_TO_THINK.md)** — 운영화된 실천.
+> 이미 쓰고 있는 코딩 도구 안에 설치된다 (오늘은 Claude Code; 나머지는 벤더 중립 어댑터 레이어). 모든 고위험 행동 이전에 — `git push`, 배포, 마이그레이션, 제약 삭제 — 에이전트는 디스크 위에, 자신이 아는 것, 모르는 것, 그리고 어떤 관측 가능한 사건이 자신을 틀렸다고 증명할지를 적어야 한다. 결정론적 훅이 그 아티팩트를 검사하고, 그것이 진짜가 되기 전까지 진행을 거부한다(`exit 2`). 검증된 결정에서 나온 교훈은 변조가 드러나는(tamper-evident) 컨텍스트 범위 프로토콜이 되어 다음 일치하는 결정에서 다시 떠오른다 — 그래서 에이전트는 시간이 지나며 *당신의* 코드베이스에 더 예리해지고, 당신의 문서는 코드가 테스트에 대해 린트되는 것과 똑같은 방식으로 코드에 대해 린트된다.
+
+**[실제 모습 ↓](#실제-모습)** · **[설치 ↓](#설치)** · **[데모 ↓](#데모)** · **[어떻게 비교되는가 ↓](#어떻게-비교되는가)** · **[내부 구조 ↓](#내부-구조)** · **[작동하는가? ↗](docs/EVALUATION_METHOD.md)**
 
 ---
 
-## 왜 프롬프트만으로는 사고법을 강제할 수 없는가
+## 실제 모습
 
-[`docs/THE_WAY_TO_THINK.md`](docs/THE_WAY_TO_THINK.md)에 명시된 실천은 모든 고위험 의사결정당 여섯 가지 인지 행위를 명명합니다 — Core Question, 구분 맵(Knowns/Unknowns/Assumptions), Signal-vs-Noise 필터, because-chain, hypothesis-as-bet, disconfirmation conditions. 각 행위는 명명된 System-1 실패 모드(question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence — Kahneman)에 대한 구조적 반례입니다. 프롬프트는 이 행위들을 *요청*할 수는 있지만, 프롬프트는 권고일 뿐입니다: 한 번의 호출만 살고, 마감 앞에서 무시되며, 컨텍스트에서 사라집니다. 프론티어 모델은 표면적으로 순응하면서 그 아래의 인지 행위들을 건너뜁니다 — 유창하게, 자신감 있게. 그리고 운영자는 검토를 멈춥니다. 정확히 이것이 실천이 존재하는 이유의 실패 모드입니다.
+당신이 에이전트에게 묻는다: *"우리의 검색-증강 메모리(retrieval-augmented memory) 시스템이 실제로 응답 품질을 개선하고 있는지 평가해줘."*
 
-구체적 예시. 당신이 에이전트에게 말한다: *"우리가 도입한 RAG(검색-증강 메모리) 시스템이 실제로 응답 품질을 개선했는지 평가해줘."*
+**episteme 없이** — 에이전트는 이것을 측정 잡무로 취급한다. 30일치 메트릭을 끌어와 thumbs-up 비율에서 7%의 lift를 발견하고, 자신감 있는 메모를 쓴다: *"메모리는 도움이 된다; 계속 출하하라."* 당신은 그것을 읽는다. 그것은 세 가지 방식으로, 유창하게 틀렸다:
 
-에이전트는 당신의 프롬프트를 측정 과제로 받아들인다. 지난 30일 메트릭을 끌어와 메모리-사용 / 메모리-미사용 응답 샘플을 비교한다. thumbs-up 비율에서 7%의 양(+)의 lift를 발견한다. "메모리 시스템 효과 있음; 계속 출하" 라는 결론의 메모를 쓴다. 당신은 그것을 읽는다.
+- Thumbs-up은 응답의 *정확성*이 아니라 *확신도*를 추적한다 — 에이전트는 질문 자체가 아니라 질문의 대리지표(proxy)를 측정했다.
+- 메모리 응답은 30% 더 길고, 길이는 독립적으로 thumbs-up을 끌어올린다 — 그 "lift"는 길이 효과일 수 있다.
+- 결론이 틀렸다고 판정될 조건이 한 번도 명명되지 않았다 — 그래서 그것은 틀릴 수가 없다.
 
-에이전트는 당신이 피곤하지 않았다면 당연히 던졌을 질문들을 묻지 않았다:
+**episteme와 함께** — 메모가 착지하기 전에, 에이전트는 이것을 디스크에 커밋해야 한다:
 
-- **무엇 (What)** 이 "품질"로 측정되고 있는가? 에이전트가 고른 메트릭은 *thumbs-up 비율* 이다. 하지만 thumbs-up은 응답의 *정확성* 이 아니라 응답의 *확신도* 와 상관한다 — 메모리 인용이 붙은 자신감 있게 *틀린* 답이, 메모리 없이 정직하게 *불확실한* 답보다 높은 점수를 받는다. 에이전트는 질문 자체가 아니라 질문의 *대리지표(proxy)* 를 측정했다.
-- **왜 (Why)** 메모리가 도움이 되는가? 주장되는 메커니즘은 세션 간 안정적인 컨텍스트 보존이다. 그러나 메모리-사용 / 미사용 비교는 응답 길이를 통제하지 않았다 — 메모리 시스템의 응답은 평균 30% 더 길고, 길이 자체가 thumbs-up과 독립적으로 상관된다. "lift" 는 메모리 효과가 아니라 길이 효과일 수 있다.
-- **어떻게 (How)** 이 결론이 틀렸음이 드러나는가? 응답 길이를 통제한 채 다시 돌려본다. lift가 유지되면 결론은 살아있다. 사라지면 메모리는 토큰만 늘렸지 신호는 더하지 않은 것이다. 그것이 에이전트가 명명하지 않은 반증 조건이다.
-
-순진한 에이전트는 프롬프트가 측정을 요청했기 때문에 측정처럼 들리는 답을 준다. `episteme`는 메모가 제출되기 전에 — *디스크에* — 측정이 실제로 무엇을 측정하는지, 어떤 메커니즘이 주장되는지, 어떤 관측 가능한 결과가 그 주장을 반증할지 적도록 강제한다. 적는 행위 자체가 그 대리지표가 질문이 아니었음을 표면화한다.
-
-최근 학계에서는 에이전트와 사용자가 반복적 상호작용을 거치며 에이전트가 맥락에서 실제로 아는 것, 당신이 의도한 것, 시스템의 실제 상태 사이에 누적되는 간격을 **Epistemic Drift (인식론적 표류)** 라고 부른다. 한 번의 큰 실수가 아니라 수많은 작은 엇나감의 누적 — 자정 무렵 당신이 에이전트의 답에 고개를 끄덕이고 프로덕션에 반영한 그 순간, 드리프트는 이미 수십 번 일어난 후다. `episteme`는 에이전트가 행동하기 전에 *무엇 · 왜 · 어떻게* 를 구조적으로 추론하도록 요구함으로써 그 간격을 닫는다.
-
----
-
-## 왜 프롬프트만으로는 부족한가
-
-수많은 대응책이 *더 나은 프롬프트*를 제안한다. 그것도 해결책이긴 하지만, 얕다:
-
-- 시스템 프롬프트의 주의사항은 **한 번의 호출만 산다**. 다음 세션에서는 없는 것과 같다.
-- `CLAUDE.md`에 적어둔 규칙은 **마감이 닥치면 무시된다**. 인간도 그렇고, 에이전트도 그렇다.
-- **노하우** — *"이런 모양의 문제에는 이렇게"* 라는 환원 불가능하게 맥락-특정적인 규칙 — 은 문구를 아무리 잘 써도 가르쳐지지 않는다. **추출되고, 저장되고, 다시 표면화**되어야 한다.
-
-더 깊은 문제는 이거다. 에이전트가 **당신 자신의 요청이 틀렸을 때도 그대로 수행한다는 것**. 사용자도 지식의 깊이가 부족할 수 있고, 오해할 수 있고, 잘못된 전제로 질문할 수 있다. 좋은 시스템은 *에이전트만 감시하는 게 아니라 사용자의 질문 자체도 검증*해야 한다. 프롬프트 수준의 대응책은 이 양방향 검증을 구조화하지 못한다.
-
----
-
-## 해법 — 파일 시스템 수준의 Thinking Framework
-
-`episteme`는 **의도가 상태 변화와 만나는 순간**을 가로챈다. `git push`, `npm publish`, `terraform apply`, DB 마이그레이션, lockfile 편집 등 모든 고위험 작업 이전에 — 그 작업을 *누가 요청했든* (당신이든, 에이전트 스스로든) — 에이전트는 디스크 위에 자신의 추론을 명시적으로 투영해야 한다.
-
-네 개의 필드를 가진 **Reasoning Surface**가 그 형식이다:
-
-| 필드 | 에이전트가 기록해야 하는 것 |
+| 필드 | 에이전트가 반드시 기록해야 하는 것 |
 |---|---|
-| **Core Question** | 이 작업이 *실제로 답하려는* 단 하나의 질문 (question substitution 실패모드 대응) |
-| **Knowns** | 검증된 사실, 출처, 측정값 — 그럴듯한 추측이 아니다 |
-| **Unknowns** | 이름 붙여진, 분류 가능한 결손 — *"리스크가 있을 수 있음"* 같은 모호함이 아니다 |
-| **Assumptions** | 하중을 지탱하는 신념, *반증 가능하도록* 명시 |
-| **Disconfirmation** | 이 계획이 틀렸음을 증명할 *관찰 가능한 사건* — 행동 전에 사전 약속 |
+| **Core Question** | 이 작업이 실제로 답하는 단 하나의 질문 — *"길이를 통제했을 때, 메모리가 정확성을 개선하는가?"* |
+| **Knowns** | 출처가 있는 검증된 사실 — 그럴듯하게 들리는 추측이 아니다 |
+| **Unknowns** | 명명된 결손(*"길이 통제 후에도 lift가 살아남는지"*) — 여기가 비면 게이트가 실패한다 |
+| **Assumptions** | 하중을 지탱하는 신념, 반증될 수 있도록 표시됨 |
+| **Disconfirmation** | 사전 약속된 관측 대상 — *"길이를 통제해 다시 돌렸을 때 lift가 사라지면, 메모리는 신호가 아니라 토큰을 더하고 있는 것이다"* |
 
-유효성은 **구조적으로** 검증된다. 최소 콘텐츠 길이, 게으른 플레이스홀더 금지 (`none`, `n/a`, `tbd`, `해당 없음`), 우회 명령어 패턴 스캔. 표면이 없거나 공허하면 작업은 `exit 2`로 거부된다.
+게으른 토큰(`none`, `n/a`, `tbd`, `해당 없음`)은 거부된다. 모호한 회피 표현(*"문제가 생기면"*)은 거부된다 — 오직 구체적인 반증 조건만 통과한다. surface를 적는 행위 자체가 그 대리지표가 질문이 아니었음을 드러낸다. 그것이 제품이다: **에이전트는 결과가 존재하기 전에, 당신이 감사할 수 있는 방식으로 사고하도록 강제된다.**
 
-특히 Disconfirmation 필드는 단순한 "위험 목록"이 아니다. 이 계획이 틀렸음을 증명할 **구체적이고 관찰 가능한 사건**을 행동 전에 *사전 약속*하도록 강제한다. 과학철학의 핵심 원칙인 **Robust Falsifiability (강건한 반증 가능성)** 을 파일 시스템 수준에서 기계적으로 집행한다 — Strict Mode는 `"if issues arise"` 같은 조건부 공허 문구를 탐지해 거부하고, `"p95 latency > 500ms for 5 min, Grafana dashboard api-latency"` 같은 관찰 가능 조건만 통과시킨다. 반증될 수 없는 계획은 에픽스테메가 아니라 독사(doxa)다.
+![episteme — 움직이는 thinking framework](docs/assets/demo_posture.gif)
 
-**이것이 프롬프트 리마인더와 컴파일러의 차이다: 하나는 부탁하고, 하나는 진행을 거부한다.**
+*`scripts/demo_posture.sh`로 녹화됨 — 차단된 제약 제거, 검증된 재작성, 자신의 blast radius를 선언하도록 강제된 리팩터, 그리고 이후 결정에서 발화하는 합성된 프로토콜.*
 
----
+## 무엇을 얻는가
 
-## ABCD — 네 개의 Cognitive Blueprints
+- **돌아올 수 없는 지점에 놓인 추론 게이트.** 훅이 고위험 작업을 가로채고 Reasoning Surface를 구조적으로 검증한다 — 정규화된 명령어 스캔이 우회 형태(`subprocess.run(['git','push'])`, 에이전트가 작성한 셸 스크립트, 래핑된 실행기)를 잡아낸다. surface가 없거나 공허하면 → 작업이 거부된다. 기본은 strict; advisory 모드는 프로젝트별 opt-in이다.
+- **하중을 받는 결정을 위한 심문(interrogation).** 구조만으로는 사고와 연극을 구분할 수 없다. 그래서 게이트는 더 강한 아티팩트도 받아들인다: 결정을 주장들로 분해하고, 하중을 받는 각 주장을 **초안 추론을 본 적 없는 새로운 컨텍스트**가 검증하며, 가장 강한 반론을 논증하고, 가장 약한 고리를 지목한다. `stop` 평결은 닫힌 채로 실패한다.
+- **부패하는 대신 축적되는 기억.** 검증된 모든 교훈은 해시 체인으로 연결된, 컨텍스트 범위 프로토콜이 된다 — append-only이고 변조가 드러나므로(tamper-evident), 에이전트는 배운 것을 몰래 다시 쓸 수 없다. 다음 일치하는 결정에서 커널은 프로토콜을 선제적으로 표면화한다: `[episteme guide] … · overlap 5/6 · Protocol: In context X, do Y`. 당신이 물어보기를 기억할 필요가 없다.
+- **현실에 대해 린트되는 문서.** 추적되는 모든 문서는 기계가 읽을 수 있는 생명주기 마커(`living / spec-implemented / design-history / report / tombstone`)를 지닌다. 새 문서가 분류되지 않은 채 착지하거나, living 문서가 폐기된 문서를 현행인 양 인용하거나, 특정 시점 보고서가 `docs/`에 눌러앉으려 하면 CI가 실패한다. 버전 문자열은 릴리스 매니페스트에서 찍히며, 손으로 복사하지 않는다. 낡은 문서는 세션 시작 시 표면화된다 — 조용히, 실제로 낡았을 때만. **단일 진리 원천(single source of truth), 열망이 아니라 강제된 것.**
+- **스스로 뒤처리를 하는 시스템.** 검토 큐는 가시적 백프레셔와 함께 상한이 걸리고, 로그는 크기 상한에서 순환하며, 만료된 마커와 오래된 텔레메트리는 세션 시작 시 수거된다. 아티팩트는 쌓이지 않는다; 삭제는 방치의 사고가 아니라 설계된 작업이다.
+- **도구를 가로지르는 하나의 정체성.** 당신의 작업 스타일, 리스크 자세, 추론 선호는 거버넌스가 적용된 버전 관리 마크다운에 산다 — 한 번의 명령으로 모든 어댑터에 동기화된다. 커널은 도구보다 오래 산다.
 
-모든 고위험 작업이 같은 종류의 검증을 필요로 하는 건 아니다. `episteme`는 네 개의 **Cognitive Blueprints**를 가지고 있고, 각각은 특정 실패 유형에 대응한다:
+## 설치
 
-- **A · Axiomatic Judgment** — 신뢰할 만하지만 서로 모순되는 출처들 사이의 갈등을 해소한다. 에이전트가 *왜* 두 출처가 충돌하는지, *현재 맥락의 어떤 특징이* 선택을 결정하는지 명명하도록 강제한다.
-- **B · Fence Reconstruction** — 물려받은 제약을 보호한다. 제약을 제거하기 전에 그 *원래 목적*이 먼저 재구성되어야 한다. **Chesterton's fence**가 파일 시스템에 의해 강제되는 것이다.
-- **C · Consequence Chain** — 되돌릴 수 없는 작업을 분해한다. 1차 효과, 2차 효과, 실패 모드 역상(inversion), 기저율(base rate) 참조, 안전 여유(margin of safety).
-- **D · Architectural Cascade** — 리팩터링과 이름 변경 중 끊어진 참조를 남기는 경우를 잡아낸다. 편집 전에 전체 파급 반경(blast radius)을 열거하도록 에이전트에게 강제한다.
-
-각 Blueprint가 발화할 때마다, 그리고 그것이 검증한 모든 결정은 **변조 불가능한 해시 체인(tamper-evident hash chain)에 커밋된다**. 그 체인은 단순한 로그가 아니다. 커널이 나중에 **Active Guidance**를 제공하는 방식이다: 다음 매칭 결정 시점에, 관련된 합성 프로토콜이 에이전트가 훈련 분포로 되돌아가기 전에 선제적으로 표면화된다.
-
-결과는 **축적되는 프로젝트-맞춤 Thinking Framework**다. 에이전트는 갈등을 해결할 때마다 당신의 코드베이스에 대해 더 예리해진다 — 당신이 훈련시켜서가 아니라, 체인이 기억했기 때문에.
-
----
-
-## 프로토콜 합성 — 커널이 시간을 건너 당신을 돕는 방식
-
-`episteme`가 단순한 차단기에 그치지 않는 지점이 여기다. 해결된 모든 갈등은 **재사용 가능한 프로토콜로 추출된다**:
-
-1. **갈등 감지.** 에이전트가 완전히 해결되지 않은 맥락에 대해 유효해 보이지만 양립 불가능한 두 접근을 만난다.
-2. **평균 내지 말고, 분해하라.** Thinking Framework는 평균 답을 거부한다. 출처가 *왜* 충돌하는지, 맥락의 어떤 특징이 저울을 기울이는지 추출하도록 강제한다.
-3. **Context-fit 프로토콜 합성.** 해결된 *"맥락 X에서는 Y를 하라"* 규칙이 append-only, 해시 체인으로 연결된 지식 저장소에 커밋된다. 변조 불가능이므로 에이전트는 배운 교훈을 몰래 다시 쓸 수 없다.
-4. **능동적으로 가이드하라.** 다음 매칭 결정에서 — 몇 주 뒤든, 세션이나 도구를 건너서든 — 커널은 프로토콜을 **선제적으로** 표면화한다. 당신이 기억해서 물어볼 필요가 없다.
-5. **자기 유지보수하라.** 에이전트가 드리프트(낡은 설정, 폐기된 API, 핵심 로직 불일치)를 발견하면, *patch vs. refactor*의 정직한 평가를 강제하고, 이동하기 전에 전체 파급 반경을 동기화하도록 요구한다.
-
-지식 저장소는 메모리인 척하는 벡터 스토어가 아니다. **구조적이고, 사람이 읽을 수 있으며, 버전 관리되는 아티팩트** — 당신이 읽고, 편집하고, 포크하고, 어댑터(Claude Code, Cursor, Hermes, 미래의 도구) 사이에서 마이그레이션할 수 있다.
-
-합성된 프로토콜들은 단순한 캐시 항목이 아니라 **Knowledge Sanctuaries (지식의 성소)** 다 — 당신의 코드베이스가 시간을 건너 자신에게 전달하는 국지적 진리의 보존소. 변조 불가능하고(Pillar 2 해시 체인), 교리화되지 않으며(맥락-서명과 묶여 있어 오직 매칭 컨텍스트에서만 재활성화), 새로운 증거가 들어오면 진화한다(오래된 프로토콜은 supersedes 관계로 갱신되지, 덮어쓰여지지 않는다). 성소라고 부르는 이유: 이 지식은 무분별한 LLM 평균값으로부터 보호되어야 하며, *현재 이 프로젝트에서 실제로 작동한다고 입증된 규칙만* 이 공간에 머문다.
-
-**커널은 도구보다 오래 산다.**
-
----
-
-## Cognitive Arms — v1.1+
-
-위의 네 Blueprint와 세 Pillar — Cognitive Blueprints · Append-Only Hash Chain · Framework Synthesis & Active Guidance — 는 v1.0의 *변하지 않는 구조적 기반*이다. Pillar는 움직이지 않는다. v1.1은 그 위에서 동작하는 **3 Cognitive Arms**를 더한다 — 시간이 흐르면서 커널 자신의 지식을 재구성하는 유체적·능동적 엔진들이다.
-
-- **Arm A · Temporal Integrity** — 프로토콜은 부패한다. 운영자가 확인한 retire가 낡은 규칙을 조용히 덮어쓰지 않고 supersede한다. 검증 윈도우: CP-DECAY-03 이후 30일.
-- **Arm B · Causal Synthesis** — deferred-discovery 스트림에 대한 zero-LLM 엔티티 추출이 프레임워크가 작동할 수 있는 클러스터 제안을 만들어낸다. 검증 윈도우: 60일.
-- **Arm C · Self-Consistency Convergence** — 프로토콜이 disconfirmation을 구조적으로 도출하는 모델로 승격된다. 검증 윈도우: 90일.
-
-이 구분은 하중을 지탱한다 — Pillar는 정착된 어휘이고, Arm은 시스템이 자기 출력을 시간을 건너 감사하고 다듬는 방식이다. 상태: **v1.4.0-rc1이 2026-05-23에 cut되었고**, 1170 테스트 + 54 subtests 통과. Arm A 기반(supersede-with-history 인프라 + operator profile / policy 편집을 chain stream에 자동 기록하는 hook)이 출하되었으며, Arm A 잔여 작업은 기회주의적으로 재개된다. **Arm B의 substrate-facing 형태는 Event 129에서 공식 SUNSET** — 그 전제(안정적 모델 능력 격차)는 Event 119–120 saturation finding에 의해 반증되었다. Operator-facing 잔여물(`core/ptsp/` typed Fact/Inference 승급 게이트)은 `episteme practice trace`로 도달 가능한 상태로 보존된다. Arm C는 substrate-gap 주장이 살아남는다는 증거를 기다리며 미래 사이클로 스코프되었다.
-
----
-
-## 빠른 시작
-
-### 옵션 A — Claude Code 플러그인 마켓플레이스로 설치
-
-Claude Code 안에서:
+**옵션 A — Claude Code 플러그인 (명령 두 개, 자기완결형):**
 
 ```
 /plugin marketplace add junjslee/episteme
 /plugin install episteme@episteme
 ```
 
-그 후 아무 셸에서나:
+훅, 에이전트, 스킬이 당신의 세션에서 살아난다; pip은 관여하지 않는다.
 
-```bash
-episteme init     # 개인 메모리 파일 시드
-episteme setup    # 작업 스타일 + 인지 프로파일 점수화
-episteme sync     # Claude Code와 Hermes로 전파
-episteme doctor   # 연결 확인
-```
-
-### 옵션 B — 커널을 직접 클론
+**옵션 B — 커널 클론 (CLI + 편집 가능한 소스):**
 
 ```bash
 git clone https://github.com/junjslee/episteme ~/episteme
-cd ~/episteme
-pip install -e .
+cd ~/episteme && pip install -e .
 
-episteme init
-episteme setup . --write
-episteme sync
-episteme doctor
+episteme init      # generate personal memory files from templates
+episteme setup .   # score working style + reasoning posture
+episteme sync      # push identity to every adapter
+episteme doctor    # verify wiring
 ```
 
-심화 온보딩: **[`docs/SETUP.md`](./docs/SETUP.md)**. 전체 명령: **[`docs/COMMANDS.md`](./docs/COMMANDS.md)**.
+기존 저장소에 도입하기: `episteme docs lint`는 추적되는 모든 문서의 생명주기 분류를 강제한다 — 그 첫 lint 실행이 대부분의 저장소가 한 번도 가져본 적 없는 정직한 목록이다. 세부 사항, 프로젝트 하네스, 전체 명령 레퍼런스: [`INSTALL.md`](./INSTALL.md) · [`docs/SETUP.md`](./docs/SETUP.md) · [`docs/COMMANDS.md`](./docs/COMMANDS.md).
 
----
+## 데모
 
-## 제로 트러스트 실행
+모든 데모는 실제 아티팩트를 함께 출하한다 — 어떤 철학보다 먼저 그것들을 읽어라.
 
-[**OWASP Top 10 for Agentic Applications (2026)**](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) — 100명 이상의 업계 전문가가 동료 검토한 자율 에이전트의 주요 위험 분류 — 는 prompt injection, goal hijacking, overreach, memory poisoning, unbounded action을 핵심 위험 클래스로 식별한다. Knowns / Unknowns / Assumptions / Disconfirmation 구조는 각각에 대한 *구조적* 반박이다:
-
-| OWASP Agentic Risk (2026) | episteme의 반박 |
+| 데모 | 무엇을 증명하는가 |
 |---|---|
-| 직접 목표 조작 / prompt injection | 실행 전 Core Question 선언; 이탈은 Unknowns로 표면화 |
-| 간접 명령 주입 | Knowns / Disconfirmation이 신뢰 가능한 상태와 prompt 내용을 분리; 검색된 입력에 따라 행동하기 전 falsifiable한 결과에 commit |
-| Overreach / unbounded action | Frame에서 제약 체제 선언; reversible-first 정책 강제 |
-| 유창한 환각 | Unknowns 필드는 비워둘 수 없음; 행동 전 가정은 명명되어야 함 |
-| 메모리 오염 | Pillar 2 hash-chained protocols — append-only, tamper-evident; 사전 상태의 침묵 재작성은 `verify_chain`이 감지 |
-| 무한 계획 루프 | Disconfirmation 조건 필수; 증거 발화 시 루프 종료 |
+| [`demos/04_symbiosis/`](./demos/04_symbiosis/) | **실제 역사에서 나온 논지 (2026-04-27, Events 65–67):** 운영자가 불안에 이끌린 비가역적 묶음을 제안했고; 커널의 적대적 검토가 3개의 Critical 발견을 표면화했으며; 분해된 경로가 `AGENTS.md`에서 헌법이 되었다. 에이전트와 인간이 *서로의* 의도를 디버깅한다. [`DIFF.md`](./demos/04_symbiosis/DIFF.md)가 그 대안 세계를 나란히 보여준다. |
+| [`demos/03_differential/`](./demos/03_differential/) | **같은 프롬프트, 프레임워크 off vs on.** off는 *어떻게*에 답하고; on은 *~인지 여부*에 답한다. [`DIFF.md`](./demos/03_differential/DIFF.md)가 잡아낸 실패 모드를 명명한다. |
+| [`demos/02_debug_slow_endpoint/`](./demos/02_debug_slow_endpoint/) | 유창하게-틀린 *"캐시를 추가하라"*가 Core Question 게이트에서 죽고; 대신 스키마 수준의 근본 원인이 산출되는 p95 회귀. |
+| [`demos/01_attribution-audit/`](./demos/01_attribution-audit/) | 정본 4-아티팩트 형태 (reasoning-surface → decision-trace → verification → handoff) — 커널이 자신의 귀속(attribution)을 감사한다. |
+| [`demos/05_contract_gate/`](./demos/05_contract_gate/) | 행동적 보완물: 선언된 계약이 턴 종료 시 실행된다. |
 
-명명되지 않은 가정은 신뢰되지 않는다. 전제조건(Knowns)과 제약 체제가 선언되지 않은 한 어떤 행동도 취해지지 않는다. 커널은 의도와 실행 사이의 검증 레이어다.
+히어로 데모를 직접 다시 녹화하기: `scripts/demo_posture.sh` (레시피는 스크립트 헤더에). 라이브 대시보드는 커널 자신의 해시 체인에 대해 렌더링된다 — [`web/README.md`](./web/README.md).
 
-### 업계 수렴 — 2025–2026
+## 어떻게 비교되는가
 
-같은 시기의 주요 프레임워크와 학술 논문이 커널이 출하한 동일한 아키텍처 패턴으로 수렴하고 있다: 파일 시스템 수준의 사전 호출 체크포인트 ([Capsule Security ClawGuard](https://www.businesswire.com/news/home/20260415670902/), 2026), hash-chained tamper-evident memory ([SSGM](https://arxiv.org/abs/2603.11768) — Lam et al., 2026), 규칙 목록 대신 이유 기반 정렬 ([Anthropic Claude Constitution](https://www.anthropic.com/constitution), 2026-01-22), 거버넌스 레이어를 갖춘 5단계 인지 루프 ([SCL R-CCAM](https://arxiv.org/abs/2511.17673) — Kim, 2025), 5-pillar agent integrity ([Proofpoint Agent Integrity Framework 2026](https://www.proofpoint.com/us/resources/white-papers/agent-integrity-framework)). 커널은 이러한 출판물보다 앞선다 (CP1 2026-04-21 출하; v1.0.0 GA 2026-04-28); 수렴은 독립적 검증이지 계보가 아니다. 전체 attribution map은 [`kernel/REFERENCES.md`](./kernel/REFERENCES.md) *Convergent contemporary work* 섹션 참조.
+| 축 | episteme | Memory API (mem0, OpenMemory) | Agent 런타임 (Agno, opencode) |
+|---|---|---|---|
+| **무엇인가** | 기존 도구 위에 얹는 추론 거버넌스 + 정체성 레이어 | 앱에 내장된 Memory API | 에이전트를 실행하는 런타임 |
+| **정체성이 사는 곳** | 거버넌스가 적용된 버전 관리 마크다운/JSON — 도구 간 공유 | 벡터/그래프 스토어, 앱마다 | 시스템 프롬프트, 세션마다 |
+| **노하우** | 파일 시스템 경계에서 추출되고, 해시 체인으로 연결되며, 컨텍스트에 의해 다시 표면화됨 | 불투명한 검색 | 프롬프트 튜닝, 세션마다 |
+| **문서/상태 위생** | 생명주기 린트, GC, CI에서 드리프트 게이트 | N/A | N/A |
 
----
+**이건 그냥 계약 테스트(contract testing) 아닌가?** 계약 테스트는 *행동적* 회귀를 잡는다 — 코드가 스펙이 말한 대로 했는가. Reasoning Surface는 *인식론적* 회귀를 잡는다 — 우리가 올바른 스펙을 썼는가, 올바른 질문을 프레이밍했는가, 우리를 틀렸다고 증명할 것을 명명했는가. 통과하는 테스트 스위트는 당신이 잘못된 문제를 유창하게 풀고 있다는 것을 알려줄 수 없다; 그 실패는 스펙이 존재하기 전에 일어난다. episteme는 두 레이어를 모두 출하한다([`docs/CONTRACT_GATE.md`](./docs/CONTRACT_GATE.md)).
 
-## 이 아키텍처가 해결하는 실패 모드
+**왜 프롬프트로는 이걸 할 수 없는가?** 프롬프트는 권고다: 한 번의 호출만 살고, 마감에서 건너뛰어지며, 컨텍스트에서 사라진다. non-zero로 종료하는 훅은 건너뛸 수 없다. MIRROR 벤치마크([arXiv 2604.19809](https://arxiv.org/abs/2604.19809); 16개 모델, 8개 랩, 약 25만 인스턴스)는 모델에게 자신의 캘리브레이션을 보여주는 것이 도움이 되지 않음을 발견했다 — *오직 아키텍처적 제약만이 효과적이다* (Confident Failure Rate 0.60 → 0.14). 프롬프트가 아니라 자세(Posture over prompt).
 
-`kernel/FAILURE_MODES.md`는 11가지 명명된 실패 모드를 정의한다 — **Kahneman**의 6가지 추론 모드(WYSIATI, question substitution, anchoring, narrative fallacy, planning fallacy, overconfidence)에 3가지 거버넌스 모드(Chesterton's fence, Goodhart drift, Ashby variety mismatch)와 v1.0 RC의 2가지 추가 모드(framework-as-Doxa, cascade-theater)를 더한 것이다.
+## 정직한 한계
 
-각 모드는 구체적 반박 아티팩트에 매핑된다:
+- [`kernel/KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md)는 이 커널이 틀린 도구일 때를 명명한다. *경계 없는 규율은 신조다.*
+- 커널은 자신의 주장을 스스로 측정한다: 프로토콜 합성 루프는 2026-06에 자신의 반증 가능성 조건을 발화시켰고 (49일, 합성된 프로토콜 0개), 검증된 심문에서 합성하도록 재구축되었다 — 감사 기록은 공개되어 있다([`kernel/FAILURE_MODES.md`](./kernel/FAILURE_MODES.md), [`docs/EVALUATION_METHOD.md`](./docs/EVALUATION_METHOD.md)). 당신의 결정에 disconfirmation을 강제하는 커널은 자신에게도 같은 것을 빚지고 있다.
+- 차용한 모든 개념에 대한 귀속, 그리고 같은 패턴으로 독립적으로 수렴한 2025–26 업계 작업: [`kernel/REFERENCES.md`](./kernel/REFERENCES.md).
 
-| 실패 모드 | 반박 아티팩트 |
+## 내부 구조
+
+상태: **<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->** · 실천은 Frame → Decompose → Execute → Verify → Handoff이며, 특정 System-1 실패 모드(question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence)에 대한 명명된 반례에 근거한다 — 전체 운영화는 [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md)이고, 네 개의 Cognitive Blueprint(Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade)는 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)에 명세되어 있다.
+
+```mermaid
+graph TD
+    subgraph SG1["① The Agentic Mind — Intention"]
+        A["Agent\nGenerating intent for a high-impact op"]
+        B["Reasoning Surface\ncore_question · knowns · unknowns\nassumptions · disconfirmation"]
+        D["Doxa\nFluent hallucination\nnone / n/a / tbd / 해당 없음\n< 15 chars · missing fields"]
+        E["Episteme\nJustified true belief\nconcrete knowns · named unknowns\ndisconfirmation ≥ 15 chars · no placeholders"]
+    end
+
+    subgraph SG2["② The Sovereign Kernel — Interception"]
+        F["Stateful Interceptor\ncore/hooks/reasoning_surface_guard.py\nnormalises cmd · deep-scans agent-written files\ncross-call stateful memory"]
+        G["Hard Block · exit 2\nExecution denied\nAgent forced to re-author surface"]
+        H["PASS · exit 0\nPrecondition satisfied\nExecution admitted to Praxis"]
+    end
+
+    subgraph SG3["③ Praxis & Reality — Execution"]
+        I["Tool Execution\ngit push · bash script.sh · npm publish\nterraform apply · DB migrations · lockfile edits"]
+        J["Observed Outcome\ncore/hooks/calibration_telemetry.py\nexit_code 0 or non-zero · stderr captured"]
+    end
+
+    subgraph SG4["④ 결 · Gyeol — Cognitive Texture & Evolution"]
+        K["Prediction Record\ncorrelation_id stamped at PASS\n~/.episteme/telemetry/YYYY-MM-DD-audit.jsonl"]
+        L["Outcome Record\ncorrelation_id · exit_code · stderr\n~/.episteme/telemetry/YYYY-MM-DD-audit.jsonl"]
+        M["episteme evolve friction\nsrc/episteme/cli.py · _evolve_friction\npairs prediction ↔ outcome by correlation_id\nranks under-named unknowns · flags exit_code ≠ 0"]
+        N["결 · Gyeol\nRefined cognitive grain\nfriction hotspots · calibrated profile axes"]
+        O["Operator Profile\ncore/memory/global/operator_profile.md\nlast_elicited axes updated · confidence rescored"]
+        P["kernel/CONSTITUTION.md\nFour principles recalibrated\nfailure-mode counters sharpened"]
+    end
+
+    A --> B
+    B --> D
+    B --> E
+    D --> F
+    E --> F
+    F --> G
+    F --> H
+    G -.->|"cognitive retry"| A
+    H --> I
+    I --> J
+    E -.->|"correlation_id stamped at PASS"| K
+    J --> L
+    K --> M
+    L --> M
+    M --> N
+    N --> O
+    N --> P
+    O -.->|"posture loop closed"| A
+    P -.->|"posture loop closed"| A
+
+    classDef doxaStyle fill:#c0392b,stroke:#922b21,color:#fff
+    classDef episteStyle fill:#1e8449,stroke:#145a32,color:#fff
+    classDef passStyle fill:#27ae60,stroke:#1e8449,color:#fff
+    classDef praxisStyle fill:#2ecc71,stroke:#27ae60,color:#000
+    classDef gyeolStyle fill:#1a5276,stroke:#154360,color:#fff
+    classDef kernelStyle fill:#6c3483,stroke:#512e5f,color:#fff
+    classDef neutralStyle fill:#2c3e50,stroke:#1a252f,color:#fff
+
+    class D,G doxaStyle
+    class E episteStyle
+    class H,I passStyle
+    class J praxisStyle
+    class K,L,M,N,O,P gyeolStyle
+    class F kernelStyle
+    class A,B neutralStyle
+```
+
+**Doxa**(빨강) — 유창하지만 검증되지 않은 출력 — 은 커널이 막기 위해 존재하는 실패 상태다. **Episteme**(초록) — 검증된 surface — 는 실행의 전제조건이다. **Praxis** — 인가된 행동과 그 관측된 결과. **결 · Gyeol**(파랑) — 사이클을 가로질러 프레임워크를 다듬는 캘리브레이션 루프. 어떤 스택과도 작동한다: 커널은 순수 마크다운, 프로파일은 평범한 JSON, 어댑터 레이어(Claude Code, Hermes, OMO/OMX)는 플러그형이다.
+
+커널 자체는 — 순수 마크다운, 코드 없음, 벤더 종속 없음 — [`kernel/`](./kernel/)에서 시작한다:
+
+| 파일 | 무엇을 정의하는가 |
 |---|---|
-| WYSIATI (맥락에 있는 것만으로 추론) | Reasoning Surface의 Unknowns 필드 |
-| Question substitution (쉬운 질문으로 치환) | Frame 단계의 Core Question 요구 |
-| Anchoring (첫 프레이밍 고착) | Disconfirmation 필드 |
-| Chesterton's fence (제약을 이해 없이 제거) | Blueprint B Fence Reconstruction |
-| Cascade-theater (파급 동기화 연기) | Blueprint D + Layer 3 entity grounding |
+| [`SUMMARY.md`](./kernel/SUMMARY.md) | 30줄 운영 증류 |
+| [`CONSTITUTION.md`](./kernel/CONSTITUTION.md) | 뿌리 주장, 네 원칙, 추론자 실패 모드 |
+| [`FAILURE_MODES.md`](./kernel/FAILURE_MODES.md) | 전체 12-모드 분류학 ↔ 반례 아티팩트 |
+| [`REASONING_SURFACE.md`](./kernel/REASONING_SURFACE.md) | Knowns / Unknowns / Assumptions / Disconfirmation 프로토콜 |
+| [`MEMORY_ARCHITECTURE.md`](./kernel/MEMORY_ARCHITECTURE.md) | 다섯 기억 계층 (working → reflective) |
+| [`KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md) | 커널이 틀린 도구일 때 |
+| [`REFERENCES.md`](./kernel/REFERENCES.md) | 귀속 + 수렴하는 동시대 작업 |
 
-반박이 제거되거나 우회될 때는 어떤 모드가 이제 보호받지 못하는지 *명명되어야 한다*. 답이 "없음"이라면 그 반박은 자리값을 하고 있지 않았던 것이다.
+```
+episteme/
+├── kernel/          philosophy (markdown; travels across runtimes)
+├── core/hooks/      deterministic gates + session automation
+├── src/episteme/    CLI + core library (doc lifecycle, sync, telemetry)
+├── adapters/        delivery layers (Claude Code, Hermes, …)
+├── demos/           end-to-end reference deliverables
+├── skills/          reusable operator skills
+├── templates/       project scaffolds
+└── docs/            architecture, contracts, runtime docs — lifecycle-linted
+```
 
-자세히: **[`kernel/FAILURE_MODES.md`](./kernel/FAILURE_MODES.md)**.
+권한 계층: **프로젝트 문서 > 운영자 프로파일 > 커널 기본값 > 런타임 기본값.** 에이전트를 위한 저장소 운영 계약: [`AGENTS.md`](./AGENTS.md) · LLM 사이트맵: [`llms.txt`](./llms.txt).
 
----
-
-## 철학 — doxa · episteme · praxis · 결
-
-저장소 이름은 그리스어에서 왔다:
-
-- **Doxa** (δόξα) — 기본으로 산출되는 유창한 의견. 위 11가지 실패 모드는 *doxa가 자신을 episteme로 착각하는* 분류학이다.
-- **Episteme** (ἐπιστήμη) — 정당화된 지식: 구체적 Knowns, 명명된 Unknowns, 반증 가능한 Disconfirmation. 실행의 전제조건이자 이 저장소의 이름.
-- **Praxis** (πρᾶξις) — 숙지된 행동: 인가한 규율이 그대로 유지된 채 착지하는 효과.
-
-한국어 **결**(*gyeol*)은 나무나 돌의 결 — 따를 때 일관된 형태를 낳고, 거슬러 자를 때 균열하는 — 잠재적 패턴-구조다. Reasoning Surface의 필드 순서 (Knowns → Unknowns → Assumptions → Disconfirmation)가 바로 인식론적 규율의 결이다: **정착된 → 열려있는 → 잠정적 → 반증 조건**.
-
----
-
-## 더 읽기
+## 다음으로 읽을거리
 
 | 주제 | 위치 |
 |---|---|
-| 커널 30줄 증류 | [`kernel/SUMMARY.md`](./kernel/SUMMARY.md) |
-| v1.0 RC 설계 방향 | [`docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./docs/DESIGN_V1_0_SEMANTIC_GOVERNANCE.md) |
-| 커널이 산출하는 4-아티팩트 예시 | [`demos/01_attribution-audit/`](./demos/01_attribution-audit/) |
-| Thinking Framework *OFF vs. ON* 비교 | [`demos/03_differential/`](./demos/03_differential/) |
-| Hook 레퍼런스 + governance packs | [`docs/HOOKS.md`](./docs/HOOKS.md) |
-| 커널이 *틀린 도구*일 때 | [`kernel/KERNEL_LIMITS.md`](./kernel/KERNEL_LIMITS.md) |
-| 차용한 모든 개념의 1차 출처 | [`kernel/REFERENCES.md`](./kernel/REFERENCES.md) |
-| 에이전트 저장소 운영 계약 | [`AGENTS.md`](./AGENTS.md) |
+| 운영화된 실천 | [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md) |
+| 아키텍처 + 블루프린트 명세 | [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) |
+| 작동하는가? (평가 방법) | [`docs/EVALUATION_METHOD.md`](./docs/EVALUATION_METHOD.md) |
+| 설치 경로 (마켓플레이스, CLI, 개발) | [`INSTALL.md`](./INSTALL.md) |
+| 문서 생명주기 + 기억 계약 | [`docs/MEMORY_CONTRACT.md`](./docs/MEMORY_CONTRACT.md) · [`docs/SYNC_AND_MEMORY.md`](./docs/SYNC_AND_MEMORY.md) |
+| 훅 + 거버넌스 팩 | [`docs/HOOKS.md`](./docs/HOOKS.md) |
+| 보안 자세 (OWASP Agentic 2026 매핑) | [`docs/COMPLIANCE_CROSSWALK.md`](./docs/COMPLIANCE_CROSSWALK.md) |
+| 개인 맞춤 설정 | [`docs/CUSTOMIZATION.md`](./docs/CUSTOMIZATION.md) |
+| 전체 문서 색인 (생성됨) | [`docs/README.md`](./docs/README.md) |
 
----
+## 상업용 라이선스
 
-## 왜 `episteme`인가 — 한 문장으로
-
-**프롬프트가 아니라 자세(Posture over prompt).** 더 좋은 문구를 찾는 대신, AI 에이전트가 *생각하는 방식의 틀*을 파일 시스템 수준에 세운다. 컴파일러처럼 거부할 수 있는 Thinking Framework. 당신의 에이전트를 더 똑똑하게 만드는 것이 아니라, 그 똑똑함이 *당신의 맥락에* 착지하게 만든다.
-
-**Built as a Sovereign Cognitive Kernel — 생각의 틀**.
+상업용 라이선스 또는 컨설팅은 [연락 주세요](mailto:junseong.lee652@gmail.com).

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -261,6 +261,72 @@ def _reaper_line() -> str | None:
     return summary
 
 
+def _sync_selfheal_line(claude_root: Path | None = None) -> str | None:
+    """Event 150 · sync self-heal — close the forgotten-`episteme sync` gap.
+
+    Failure mode countered: hook CODE updates flow automatically (settings
+    point at repo paths; merge = deploy), but the REGISTRATION SET and the
+    CLAUDE.md emission shape only update when someone re-runs `episteme
+    sync` — a manual step operators forget, so every project on the machine
+    silently runs a stale hook registration. Mechanism bounded: the manual
+    re-sync step itself. M1-compliant: drift arrives automatically, so the
+    drain is automatic too (a banner-only advisory would just be another
+    ignorable queue). D11-compliant: wired to the live SessionStart path.
+
+    Faithfulness rule: auto-heal ONLY when the deployed governance pack is
+    known from the sync sidecar (written by every E150+ sync). Guessing a
+    pack could silently downgrade a strict deployment, so a pre-sidecar or
+    unreadable deployment gets the advisory line instead of a write.
+
+    Detection is sync's own idempotence transform (``settings_in_sync``) +
+    a managed-block compare on CLAUDE.md — no duplicated merge logic.
+    Settings written mid-session apply from the NEXT session (Claude Code
+    reads settings at start); the line says so. Never raises; any failure
+    degrades to silence — session open must not break on heal bookkeeping.
+    """
+    try:
+        from episteme.adapters import claude as _claude  # type: ignore
+        from episteme import cli as _ecli  # type: ignore
+
+        root = claude_root if claude_root is not None else (_ecli.HOME / ".claude")
+
+        # CLAUDE.md managed-block parity.
+        claude_md = root / "CLAUDE.md"
+        expected_md = _claude.render_user_claude_md().rstrip()
+        current_md = None
+        if claude_md.exists():
+            current_md = _ecli._extract_managed_block(
+                claude_md.read_text(encoding="utf-8")
+            )
+        md_in_sync = current_md is not None and current_md == expected_md
+
+        # settings.json idempotence parity.
+        meta = _claude.read_sync_meta(root)
+        pack = str(meta.get("governance_pack") or "").strip().lower()
+        settings_path = root / "settings.json"
+        try:
+            existing = json.loads(settings_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            existing = {}
+        settings_ok = bool(pack) and _claude.settings_in_sync(existing, pack)
+
+        if md_in_sync and settings_ok:
+            return None
+        if not pack:
+            # Pre-E150 deployment (no sidecar): cannot heal faithfully.
+            return (
+                "sync drift detected — run `episteme sync` once "
+                "(governance pack unknown to the self-heal; not auto-written)"
+            )
+        _claude.sync(pack)
+        return (
+            f"sync-selfheal: Claude runtime re-synced ({pack} pack) — "
+            f"settings/hook registration changes apply from the next session"
+        )
+    except Exception:
+        return None
+
+
 _DOC_STALENESS_EVENT_LAG = 15
 _DOC_STALENESS_DATE_DAYS = 45
 

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -261,7 +261,7 @@ def _reaper_line() -> str | None:
     return summary
 
 
-def _sync_selfheal_line(claude_root: Path | None = None) -> str | None:
+def _sync_selfheal_line() -> str | None:
     """Event 150 · sync self-heal — close the forgotten-`episteme sync` gap.
 
     Failure mode countered: hook CODE updates flow automatically (settings
@@ -288,7 +288,10 @@ def _sync_selfheal_line(claude_root: Path | None = None) -> str | None:
         from episteme.adapters import claude as _claude  # type: ignore
         from episteme import cli as _ecli  # type: ignore
 
-        root = claude_root if claude_root is not None else (_ecli.HOME / ".claude")
+        # Root comes from episteme.cli.HOME (no separate seam): detection and
+        # heal MUST target the same tree — a divergent test-only root would
+        # let detection pass on one tree while sync() writes another.
+        root = _ecli.HOME / ".claude"
 
         # CLAUDE.md managed-block parity.
         claude_md = root / "CLAUDE.md"
@@ -721,6 +724,14 @@ def main() -> int:
     reaper_line = _reaper_line()
     if reaper_line:
         lines.append(reaper_line)
+
+    # Event 150 · sync self-heal — if the deployed Claude runtime (settings
+    # hook registration / CLAUDE.md emission) drifted from the repo's current
+    # render, re-sync it automatically when the governance pack is known
+    # (sidecar), else advise. Silent when everything is in sync.
+    selfheal_line = _sync_selfheal_line()
+    if selfheal_line:
+        lines.append(selfheal_line)
 
     # Event 147 · doc-lifecycle staleness — count living docs whose
     # reviewed_as_of lags the corpus by >15 events (or >45 days when dated).

--- a/src/episteme/adapters/claude.py
+++ b/src/episteme/adapters/claude.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import json
 import re
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
 
 from .. import cli as _cli
 
@@ -395,6 +397,36 @@ def enforce_governance_overrides(settings: dict, governance_mode: str) -> dict:
 # Sync entry point
 # ---------------------------------------------------------------------------
 
+SYNC_META_FILENAME = ".episteme-sync-meta.json"
+
+
+def settings_in_sync(existing: dict, governance_mode: str) -> bool:
+    """True when applying sync's settings transform to ``existing`` is a
+    no-op — i.e. the deployed settings already carry the current managed
+    hook set for ``governance_mode``. This is the idempotence check the
+    SessionStart self-heal uses to detect registration drift without
+    duplicating the merge pipeline (Event 150)."""
+    managed = build_settings(governance_mode)
+    candidate = merge_settings(json.loads(json.dumps(existing)), managed)
+    candidate = prune_managed_hook_entries(candidate, governance_mode)
+    candidate = enforce_governance_overrides(candidate, governance_mode)
+    candidate["hooks"] = dedupe_hooks_map(candidate.get("hooks", {}))
+    return candidate == existing
+
+
+def read_sync_meta(claude_root: Path | None = None) -> dict:
+    """Read the sync sidecar (governance pack + timestamp). ``{}`` when
+    absent/unreadable — pre-E150 deployments have no sidecar, and the
+    self-heal treats that as mode-unknown (advise, never guess a pack:
+    healing with the wrong pack could silently downgrade strict)."""
+    root = claude_root if claude_root is not None else (_cli.HOME / ".claude")
+    try:
+        data = json.loads((root / SYNC_META_FILENAME).read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
 def sync(governance_mode: str = "balanced") -> None:
     claude_root = _cli.HOME / ".claude"
 
@@ -425,9 +457,28 @@ def sync(governance_mode: str = "balanced") -> None:
     for skill_dir in _cli._managed_skills():
         _cli._copy_tree(skill_dir, claude_root / "skills" / skill_dir.name)
 
+    # Event 150 — record which governance pack this deployment carries so
+    # the SessionStart self-heal can re-sync faithfully on registration
+    # drift. Without the sidecar the pack is unrecoverable from
+    # settings.json alone, and guessing could silently downgrade strict.
+    _cli._write_text(
+        claude_root / SYNC_META_FILENAME,
+        json.dumps(
+            {
+                "governance_pack": (governance_mode or "balanced").strip().lower(),
+                "synced_at": datetime.now(timezone.utc).isoformat(),
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+
 
 __all__ = [
     "sync",
+    "settings_in_sync",
+    "read_sync_meta",
+    "SYNC_META_FILENAME",
     "build_settings",
     "render_user_claude_md",
     "merge_settings",

--- a/tests/test_sync_selfheal.py
+++ b/tests/test_sync_selfheal.py
@@ -1,0 +1,132 @@
+"""Event 150 · sync self-heal — the forgotten-`episteme sync` gap.
+
+Covers `_sync_selfheal_line()` (SessionStart) + the adapter substrate
+(`settings_in_sync`, `read_sync_meta`, the sync sidecar): a synced runtime
+stays silent; registration drift with a KNOWN governance pack (sidecar)
+auto-heals and says so; drift with an UNKNOWN pack advises without writing
+(healing with a guessed pack could silently downgrade strict); any failure
+degrades to silence. Detection and heal target the same tree
+(episteme.cli.HOME) by construction.
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from core.hooks import session_context as sc  # pyright: ignore[reportAttributeAccessIssue]
+
+import episteme.cli as ecli  # pyright: ignore[reportMissingImports]
+from episteme.adapters import claude as cadapter  # pyright: ignore[reportMissingImports]
+
+
+class _TmpHome:
+    """Context manager: point episteme.cli.HOME at a tmp dir and run a real
+    `sync('balanced')` there so tests start from a genuinely-synced state."""
+
+    def __enter__(self):
+        self._td = tempfile.TemporaryDirectory()
+        self._orig = ecli.HOME
+        ecli.HOME = Path(self._td.name)
+        cadapter.sync("balanced")
+        self.claude_root = ecli.HOME / ".claude"
+        return self
+
+    def __exit__(self, *exc):
+        ecli.HOME = self._orig
+        self._td.cleanup()
+        return False
+
+
+class SyncMetaTests(unittest.TestCase):
+    def test_sidecar_written_by_sync_and_readable(self):
+        with _TmpHome() as th:
+            meta = cadapter.read_sync_meta(th.claude_root)
+            self.assertEqual(meta.get("governance_pack"), "balanced")
+            self.assertIn("synced_at", meta)
+
+    def test_read_sync_meta_absent_returns_empty(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertEqual(cadapter.read_sync_meta(Path(td)), {})
+
+    def test_read_sync_meta_malformed_returns_empty(self):
+        with tempfile.TemporaryDirectory() as td:
+            (Path(td) / cadapter.SYNC_META_FILENAME).write_text("not json{", encoding="utf-8")
+            self.assertEqual(cadapter.read_sync_meta(Path(td)), {})
+
+
+class SettingsInSyncTests(unittest.TestCase):
+    def test_freshly_synced_settings_are_in_sync(self):
+        with _TmpHome() as th:
+            existing = json.loads((th.claude_root / "settings.json").read_text(encoding="utf-8"))
+            self.assertTrue(cadapter.settings_in_sync(existing, "balanced"))
+
+    def test_removed_hook_entry_is_drift(self):
+        with _TmpHome() as th:
+            existing = json.loads((th.claude_root / "settings.json").read_text(encoding="utf-8"))
+            hooks = existing.get("hooks", {})
+            first_event = next(iter(hooks))
+            hooks[first_event] = hooks[first_event][1:]  # drop one registration
+            self.assertFalse(cadapter.settings_in_sync(existing, "balanced"))
+
+
+class SelfHealLineTests(unittest.TestCase):
+    def test_synced_state_is_silent(self):
+        with _TmpHome():
+            self.assertIsNone(sc._sync_selfheal_line())
+
+    def test_settings_drift_with_sidecar_heals_and_reports(self):
+        with _TmpHome() as th:
+            settings_path = th.claude_root / "settings.json"
+            existing = json.loads(settings_path.read_text(encoding="utf-8"))
+            first_event = next(iter(existing["hooks"]))
+            existing["hooks"][first_event] = existing["hooks"][first_event][1:]
+            settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+
+            line = sc._sync_selfheal_line()
+            assert line is not None
+            self.assertIn("sync-selfheal", line)
+            self.assertIn("balanced", line)
+            self.assertIn("next session", line)
+            healed = json.loads(settings_path.read_text(encoding="utf-8"))
+            self.assertTrue(cadapter.settings_in_sync(healed, "balanced"))
+
+    def test_claude_md_drift_with_sidecar_heals(self):
+        with _TmpHome() as th:
+            claude_md = th.claude_root / "CLAUDE.md"
+            claude_md.write_text("# something the operator pasted over it\n", encoding="utf-8")
+            line = sc._sync_selfheal_line()
+            assert line is not None
+            self.assertIn("sync-selfheal", line)
+            body = claude_md.read_text(encoding="utf-8")
+            self.assertIn("episteme Global Memory", body)
+
+    def test_drift_without_sidecar_advises_without_writing(self):
+        with _TmpHome() as th:
+            (th.claude_root / cadapter.SYNC_META_FILENAME).unlink()
+            settings_path = th.claude_root / "settings.json"
+            existing = json.loads(settings_path.read_text(encoding="utf-8"))
+            first_event = next(iter(existing["hooks"]))
+            existing["hooks"][first_event] = existing["hooks"][first_event][1:]
+            drifted = json.dumps(existing, indent=2) + "\n"
+            settings_path.write_text(drifted, encoding="utf-8")
+
+            line = sc._sync_selfheal_line()
+            assert line is not None
+            self.assertIn("run `episteme sync`", line)
+            self.assertIn("not auto-written", line)
+            # Fail-safe: nothing was rewritten.
+            self.assertEqual(settings_path.read_text(encoding="utf-8"), drifted)
+
+    def test_any_exception_degrades_to_silence(self):
+        with _TmpHome():
+            with mock.patch.object(
+                cadapter, "render_user_claude_md", side_effect=RuntimeError("boom")
+            ):
+                self.assertIsNone(sc._sync_selfheal_line())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Answers the operator's question directly: hook CODE updates already flow to every project automatically (settings point at repo paths — merge = deploy) and the CLI is editable-installed, but the hook REGISTRATION SET and the CLAUDE.md emission shape only refreshed when someone remembered `episteme sync`. That manual step is now closed:

- Every SessionStart (any project) checks parity using sync's own idempotence transform (`settings_in_sync`: apply the merge/prune/dedupe pipeline to current settings — no-op ⇒ in sync) plus a managed-block compare on `~/.claude/CLAUDE.md`.
- On drift with a KNOWN governance pack — recorded by the new sync sidecar `~/.claude/.episteme-sync-meta.json` — it re-runs the Claude-adapter sync automatically and says so in one banner line (registration changes apply from the next session). **Unknown pack (pre-sidecar deployment) gets the advisory line instead of a write** — guessing could silently downgrade a strict deployment (fail-safe direction chosen deliberately).
- Silent-on-parity, never-raises. M1-compliant: automatically-arriving drift gets an automatic drain, not another ignorable advisory. D11-compliant: wired to the live SessionStart path, not a CLI nobody runs.

Verification: 10 new tests (real `sync()` into a tmp HOME; parity→silent · settings drift→healed+reported+parity-restored · CLAUDE.md clobber→healed · sidecar-absent drift→advises and provably writes nothing · exception→silence) · full suite 1663 passed + 88 subtests, 0 failed.