### PR TITLE
feat(deferred-ledger): add `accepted` verdict for conscious wontfix (Event 152)

### DIFF
--- a/core/hooks/_framework.py
+++ b/core/hooks/_framework.py
@@ -87,8 +87,27 @@ DEFERRED_DISCOVERY_TYPE = "deferred_discovery"
 # the pending->verdict pair IS the audit trail). Readers derive
 # openness: open = status in OPEN_STATUSES AND no verdict references
 # the entry_hash.
+#
+# Four first-class verdicts, each closing an entry identically (openness
+# keys on has-any-verdict, not on which verdict):
+#   - resolved  : the finding was addressed; the rationale names what was
+#                 done (commit/test).
+#   - noise     : NOT a real finding — false positive or non-issue; the
+#                 rationale names why the pattern cannot occur.
+#   - duplicate : a real finding already covered by another entry; the
+#                 rationale points at the covering entry.
+#   - accepted  : a REAL finding the operator/agent consciously decides
+#                 NOT to act on, closed with the COST OF IGNORANCE named
+#                 (Event 152). Distinct from `noise` — the finding is
+#                 genuine; the ledger records a deliberate wontfix rather
+#                 than falsifying it into noise. Required because the
+#                 anti-treadmill rule (workflow_policy.md) makes
+#                 "accept-and-close with the cost of ignorance named" a
+#                 first-class disposition; without it, real-but-wontfix
+#                 findings either rot the open-count signal forever or get
+#                 mislabeled `noise`, corrupting the record.
 DISCOVERY_VERDICT_TYPE = "deferred_discovery_verdict"
-RESOLUTION_VERDICTS = frozenset({"resolved", "noise", "duplicate"})
+RESOLUTION_VERDICTS = frozenset({"resolved", "noise", "duplicate", "accepted"})
 _VERDICT_RATIONALE_FLOOR = 15  # same lazy-value bar as surface fields
 _REF_PREFIX_FLOOR = 8
 CP5_FORMAT_VERSION = "cp5-pre-chain"
@@ -528,7 +547,8 @@ def append_discovery_verdict(
     if len(rationale) < _VERDICT_RATIONALE_FLOOR:
         raise ChainError(
             f"rationale must be >= {_VERDICT_RATIONALE_FLOOR} chars — "
-            "name what was done or why the finding is noise"
+            "name what was done, why the finding is noise/duplicate, or "
+            "(accepted) the cost of ignorance"
         )
     ref = (ref or "").strip()
     if len(ref) < _REF_PREFIX_FLOOR:

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -5186,7 +5186,7 @@ def _deferred_print_list(args, envelopes: list) -> int:
     noun = "discovery" if len(envelopes) == 1 else "discoveries"
     print(f"\n{len(envelopes)} open deferred {noun}. Resolve with: "
           f"episteme deferred resolve <ref> --verdict "
-          f"resolved OR noise OR duplicate --why '...'")
+          f"resolved OR noise OR duplicate OR accepted --why '...'")
     return 0
 
 
@@ -6267,12 +6267,13 @@ def build_parser() -> argparse.ArgumentParser:
         "ref", help="entry_hash of the discovery, or a unique >= 8-char prefix",
     )
     deferred_resolve.add_argument(
-        "--verdict", required=True, choices=["resolved", "noise", "duplicate"],
-        help="resolved: addressed · noise: not a real finding · duplicate: covered by another entry",
+        "--verdict", required=True,
+        choices=["resolved", "noise", "duplicate", "accepted"],
+        help="resolved: addressed · noise: not a real finding · duplicate: covered by another entry · accepted: real finding, consciously not acting — name the cost of ignorance",
     )
     deferred_resolve.add_argument(
         "--why", required=True,
-        help="What was done, or why it is noise/duplicate (>= 15 chars)",
+        help="What was done, why it is noise/duplicate, or (accepted) the cost of ignorance (>= 15 chars)",
     )
 
     # CP9 — Pillar 3 active guidance query.

--- a/tests/test_deferred_resolution.py
+++ b/tests/test_deferred_resolution.py
@@ -84,6 +84,53 @@ class ResolutionSemantics(unittest.TestCase):
         )
         self.assertEqual(verdict.total_entries, 2)
 
+    def test_accepted_verdict_closes_a_discovery(self):
+        # Event 152: `accepted` is a fourth first-class verdict — a REAL
+        # finding the operator consciously decides NOT to act on, closed
+        # with the cost of ignorance named. It must close an open
+        # discovery exactly like resolved/noise/duplicate (openness =
+        # has-any-verdict), and still enforce the rationale floor so the
+        # cost of ignorance cannot be an empty gesture.
+        a = _write_discovery(self.path, "alpha finding")
+        _write_discovery(self.path, "beta finding")
+        self.assertEqual(
+            len(_framework.open_deferred_discoveries(path=self.path)), 2
+        )
+        _framework.append_discovery_verdict(
+            a["entry_hash"], "accepted",
+            "real gap; not acting this cycle — cost: stale doc ref lingers",
+            path=self.path,
+        )
+        open_now = _framework.open_deferred_discoveries(path=self.path)
+        self.assertEqual(len(open_now), 1)
+        self.assertEqual(
+            open_now[0]["payload"]["description"], "beta finding"
+        )
+        # Too-short rationale is rejected for `accepted` just like the
+        # other verdicts (the cost of ignorance must actually be named).
+        b = _write_discovery(self.path, "gamma finding")
+        with self.assertRaises(ChainError):
+            _framework.append_discovery_verdict(
+                b["entry_hash"], "accepted", "meh", path=self.path,
+            )
+
+    def test_chain_remains_verifiable_after_accepted_verdict(self):
+        a = _write_discovery(self.path, "alpha finding")
+        _framework.append_discovery_verdict(
+            a["entry_hash"], "accepted",
+            "real finding; deferred by decision — cost of ignorance named",
+            path=self.path,
+        )
+        verdict = _framework.verify_chains(
+            deferred_discoveries_path=self.path,
+            protocols_path=self.path.with_name("protocols.jsonl"),
+        )["deferred_discoveries"]
+        self.assertTrue(
+            verdict.intact,
+            f"chain broken after accepted verdict: {verdict}",
+        )
+        self.assertEqual(verdict.total_entries, 2)
+
     def test_double_verdict_rejected(self):
         a = _write_discovery(self.path, "alpha finding")
         _framework.append_discovery_verdict(
@@ -288,6 +335,21 @@ class CliDrain(unittest.TestCase):
         ])
         self.assertEqual(rc, 0, err)
         self.assertIn("[ok] verdict 'resolved' chained", out)
+        self.assertIn("0 open deferred discoveries remain", out)
+        rc2, out2, _ = self._main(["deferred", "list", "--json"])
+        self.assertEqual(rc2, 0)
+        self.assertEqual(json.loads(out2), [])
+
+    def test_resolve_accepted_verdict(self):
+        # Event 152: the CLI must admit `--verdict accepted` and chain it
+        # like any other verdict, dropping the entry from the open count.
+        rc, out, err = self._main([
+            "deferred", "resolve", self.entry["entry_hash"][:12],
+            "--verdict", "accepted",
+            "--why", "real gap; consciously not acting — cost of ignorance named",
+        ])
+        self.assertEqual(rc, 0, err)
+        self.assertIn("[ok] verdict 'accepted' chained", out)
         self.assertIn("0 open deferred discoveries remain", out)
         rc2, out2, _ = self._main(["deferred", "list", "--json"])
         self.assertEqual(rc2, 0)


### PR DESCRIPTION
The ledger could record resolved / noise / duplicate but not the disposition our own workflow_policy.md anti-treadmill rule names — **accept-and-close with the cost of ignorance named**. Forcing a real-but-wontfix finding into `noise` corrupts the record (noise means "not a real finding"), which is the exact confident-wrongness the kernel blocks. `accepted` = a genuine finding consciously not acted on, closed with rationale.

- `_framework.py`: `RESOLUTION_VERDICTS` gains `accepted` (closes an entry like the others — `open_deferred_discoveries` keys on presence of any verdict, verified no per-value branching); Resolution-layer comment documents all four; rationale-floor message extended.
- `cli.py`: `deferred resolve --verdict` choices + help + the stale usage string.
- Exhaustive enumeration-site grep: no docs/tests assert the set is exactly three; nothing else needed alignment.

Red→green (3 tests: accepted closes an open discovery, rejects short rationale, CLI accepts the choice; chain stays intact). Suite 1655 passed + 93 subtests, 0 failures · docs lint clean · zero new dangling refs.

Enables the E152 accept-and-close sweep of the stale deferred backlog (evidence-backed, per-cluster cost-of-ignorance rationale).