### PR TITLE
chore(docs): stamp 1.10.0-rc into volatile-fact version spans

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -123,7 +123,7 @@ Regraba tú mismo la demo estrella: `scripts/demo_posture.sh` (la receta está e
 
 ## Bajo el capó
 
-Estado: **<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->** · La práctica es Frame → Decompose → Execute → Verify → Handoff, anclada en contadores nombrados a failure modes específicos del System-1 (question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence) — la operacionalización completa está en [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md), y los cuatro Cognitive Blueprints (Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade) están especificados en [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
+Estado: **<!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version -->** · La práctica es Frame → Decompose → Execute → Verify → Handoff, anclada en contadores nombrados a failure modes específicos del System-1 (question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence) — la operacionalización completa está en [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md), y los cuatro Cognitive Blueprints (Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade) están especificados en [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 
 ```mermaid
 graph TD

--- a/README.ko.md
+++ b/README.ko.md
@@ -123,7 +123,7 @@ episteme doctor    # verify wiring
 
 ## 내부 구조
 
-상태: **<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->** · 실천은 Frame → Decompose → Execute → Verify → Handoff이며, 특정 System-1 실패 모드(question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence)에 대한 명명된 반례에 근거한다 — 전체 운영화는 [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md)이고, 네 개의 Cognitive Blueprint(Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade)는 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)에 명세되어 있다.
+상태: **<!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version -->** · 실천은 Frame → Decompose → Execute → Verify → Handoff이며, 특정 System-1 실패 모드(question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence)에 대한 명명된 반례에 근거한다 — 전체 운영화는 [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md)이고, 네 개의 Cognitive Blueprint(Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade)는 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)에 명세되어 있다.
 
 ```mermaid
 graph TD

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Re-record the hero demo yourself: `scripts/demo_posture.sh` (recipe in the scrip
 
 ## Under the hood
 
-Status: **<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->** · The practice is Frame → Decompose → Execute → Verify → Handoff, grounded in named counters to specific System-1 failure modes (question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence) — the full operationalization is [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md), and the four Cognitive Blueprints (Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade) are specified in [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
+Status: **<!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version -->** · The practice is Frame → Decompose → Execute → Verify → Handoff, grounded in named counters to specific System-1 failure modes (question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence) — the full operationalization is [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md), and the four Cognitive Blueprints (Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade) are specified in [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 
 ```mermaid
 graph TD

--- a/README.zh.md
+++ b/README.zh.md
@@ -123,7 +123,7 @@ episteme doctor    # verify wiring
 
 ## 底层原理
 
-状态：**<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->** · 这套实践是 Frame → Decompose → Execute → Verify → Handoff，锚定于针对特定 System-1 failure modes（question substitution、WYSIATI、anchoring、narrative fallacy、planning fallacy、overconfidence）的具名反制 —— 完整的操作化在 [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md)，四个 Cognitive Blueprints（Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade）在 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) 中给出规格。
+状态：**<!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version -->** · 这套实践是 Frame → Decompose → Execute → Verify → Handoff，锚定于针对特定 System-1 failure modes（question substitution、WYSIATI、anchoring、narrative fallacy、planning fallacy、overconfidence）的具名反制 —— 完整的操作化在 [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md)，四个 Cognitive Blueprints（Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade）在 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) 中给出规格。
 
 ```mermaid
 graph TD

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 <!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
-# Architecture — The Sovereign Kernel (<!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version -->)
+# Architecture — The Sovereign Kernel (<!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version -->)
 
 > Mermaid flowchart. Renders natively on GitHub, Obsidian, and any CommonMark viewer with Mermaid support. **Five** subgraphs trace the full lifecycle from agent intention through the three-pillar kernel — Cognitive Blueprints, Append-Only Hash Chain, Framework Synthesis & Active Guidance — into praxis, the learning loop, and the post-v1.0-RC behavior-conformance extensions (Event 130 — Contract Gate; Event 131 — FAILURE_MODES mode 12 + CALIBRATION_TELEMETRY).
 >
-> **State.** This diagram depicts the **v1.0 RC shipped state** (spec: [`./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md), status *approved (reframed, third pass)* 2026-04-21) plus the v1.2-RC behavior-conformance extensions in Subgraph ⑤. All ten RC checkpoints shipped with paused-review-before-commit discipline. Current head: <!-- episteme-fact:version -->1.9.0<!-- /episteme-fact:version --> (via release-please; test counts are owned by CI, not this prose). v1.3.0-rc2 stages from this Event's `feat:` commits; release-please regenerates the staging PR automatically — no manual version edit.
+> **State.** This diagram depicts the **v1.0 RC shipped state** (spec: [`./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md), status *approved (reframed, third pass)* 2026-04-21) plus the v1.2-RC behavior-conformance extensions in Subgraph ⑤. All ten RC checkpoints shipped with paused-review-before-commit discipline. Current head: <!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version --> (via release-please; test counts are owned by CI, not this prose). v1.3.0-rc2 stages from this Event's `feat:` commits; release-please regenerates the staging PR automatically — no manual version edit.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ hand-edit between the markers; run the command and commit the result.
 <!-- episteme-docs-index:start -->
 - [`ADAPTER_PORTABILITY.md`](./ADAPTER_PORTABILITY.md) · report · Adapter Portability Audit
 - [`ANTHROPIC_MANAGED_AGENTS_BRIDGE.md`](./ANTHROPIC_MANAGED_AGENTS_BRIDGE.md) · living · Anthropic Managed Agents Bridge
-- [`ARCHITECTURE.md`](./ARCHITECTURE.md) · living · Architecture — The Sovereign Kernel (1.9.0)
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) · living · Architecture — The Sovereign Kernel (1.10.0-rc)
 - [`COMMANDS.md`](./COMMANDS.md) · living · episteme — command reference
 - [`COMPLIANCE_CROSSWALK.md`](./COMPLIANCE_CROSSWALK.md) · living · Compliance Crosswalk — `signed-surface@1.0` → Regulatory Clauses
 - [`CONTRACT_GATE.md`](./CONTRACT_GATE.md) · living · Contract Gate — deterministic contract-test complement to the Reasoning Surface


### PR DESCRIPTION
The E147 volatile-fact stamper (run by `episteme sync` after the 1.10.0-rc release) updated the version spans in the 4 READMEs + ARCHITECTURE.md + the generated docs index. It had landed via a local chkpt auto-commit on master (chkpt-to-master pathology — a keep-live ledger item); re-routed as a clean PR. Mechanical, idempotent, no prose changes.