### PR TITLE
fix(deferred-ledger): resolve a bare-hex ref (Event 152)

### DIFF
--- a/core/hooks/_framework.py
+++ b/core/hooks/_framework.py
@@ -556,9 +556,20 @@ def append_discovery_verdict(
             f"ref must be an entry_hash or a >= {_REF_PREFIX_FLOOR}-char "
             f"prefix (got {ref!r})"
         )
+    # Match the full `sha256:<hex>` entry_hash OR a bare hex prefix: entries
+    # are stored scheme-prefixed but `episteme deferred list` also shows the
+    # bare hex, so a copy-paste of either must resolve (Event 152 — the
+    # scheme-only startswith rejected bare hex, forcing operators to prepend
+    # `sha256:` by hand).
+    def _ref_matches(entry_hash: str) -> bool:
+        if entry_hash.startswith(ref):
+            return True
+        _, _, bare = entry_hash.partition(":")
+        return bool(bare) and bare.startswith(ref)
+
     matches = [
         d for d in open_deferred_discoveries(path=target)
-        if str(d.get("entry_hash") or "").startswith(ref)
+        if _ref_matches(str(d.get("entry_hash") or ""))
     ]
     if not matches:
         raise ChainError(

--- a/tests/test_deferred_resolution.py
+++ b/tests/test_deferred_resolution.py
@@ -67,6 +67,36 @@ class ResolutionSemantics(unittest.TestCase):
             open_now[0]["payload"]["description"], "beta finding"
         )
 
+    def test_bare_hex_prefix_matches_scheme_prefixed_hash(self):
+        # Event 152: entries are stored as `sha256:<hex>` but `episteme
+        # deferred list` also shows the bare hex; a copy-paste of EITHER
+        # must resolve. Pre-fix the scheme-only startswith rejected bare
+        # hex, forcing operators to hand-prepend `sha256:`.
+        a = _write_discovery(self.path, "alpha finding")
+        full = a["entry_hash"]
+        self.assertTrue(full.startswith("sha256:"))
+        bare = full.split(":", 1)[1]
+        _framework.append_discovery_verdict(
+            bare[:12], "resolved",
+            "resolved via a bare-hex prefix ref (no sha256: scheme)",
+            path=self.path,
+        )
+        self.assertEqual(
+            len(_framework.open_deferred_discoveries(path=self.path)), 0
+        )
+
+    def test_scheme_prefixed_ref_still_matches(self):
+        # The fix must not regress the scheme-prefixed path.
+        a = _write_discovery(self.path, "alpha finding")
+        _framework.append_discovery_verdict(
+            a["entry_hash"][:19], "noise",
+            "still resolves with the full sha256: scheme prefix",
+            path=self.path,
+        )
+        self.assertEqual(
+            len(_framework.open_deferred_discoveries(path=self.path)), 0
+        )
+
     def test_chain_remains_verifiable_after_verdicts(self):
         a = _write_discovery(self.path, "alpha finding")
         _framework.append_discovery_verdict(


### PR DESCRIPTION
`episteme deferred resolve` matched only the full `sha256:<hex>` via startswith, but the list shows the bare hex too — a copy-pasted bare prefix failed. The matcher now resolves either form (+2 red-green tests). Improves the exact drain tool the E151/E152 ledger work depends on. Suite 1669 + 93 subtests.