### PR TITLE
fix(spot-check): Event 157 — turn the E148 cap into a drain (at-cap expiry relief, cap-aware interrogation enqueue, truthful skip counter)

### DIFF
--- a/core/hooks/_interrogation.py
+++ b/core/hooks/_interrogation.py
@@ -316,8 +316,10 @@ def enqueue_verdict_spot_check(cwd: Path, *, op_label: str) -> bool:
             "multipliers_applied": ["interrogation_verdict"],
             "effective_rate_at_sample": 1.0,
         }
-        _spot_check._chain_append(_spot_check._queue_path(), payload)
-        return True
+        # Event 157: sample-all stays the design, but through the cap-
+        # aware path — the raw _chain_append here was the one enqueue
+        # route that could push pending past the E148 cap (and did).
+        return bool(_spot_check.enqueue_direct(payload).queued)
     except Exception:
         return False
 

--- a/core/hooks/_spot_check.py
+++ b/core/hooks/_spot_check.py
@@ -434,14 +434,22 @@ def _expire_stale_pending(
     ``spot_check_expiry`` record for every pending entry older than
     the age floor, so sampling resumes instead of silently stopping.
     Terminal is deliberate — ``SKIP_TYPE`` is a snooze that re-presents
-    after its TTL and would re-saturate the cap on schedule. Returns
-    the count expired; ``ChainError``/``OSError`` propagate to the
+    after its TTL and would re-saturate the cap on schedule. Drains ALL
+    stale entries in one pass (not just enough to duck under cap): the
+    cohort is bounded by the cap itself, the measured cost is ~57ms at
+    200 records (accepted one-time spike per cohort), and a full drain
+    lets the SessionStart banner clear honestly instead of riding at
+    cap forever. Returns the count expired; errors propagate to the
     caller's guard."""
     cutoff = now_dt - timedelta(seconds=age_seconds)
     expired = 0
     for e in list_pending(path=target, now=now_dt):
         queued = _parse_iso(str(e.payload.get("queued_at", "")))
-        if queued is None or queued > cutoff:
+        # queued is None → the review-window start is unknowable
+        # (legacy writer / corruption); an unstampable entry must not
+        # jam a cap slot forever, so it is expiry-eligible (immortal-
+        # entry review finding, Event 157).
+        if queued is not None and queued > cutoff:
             continue
         _chain_append(target, {
             "type": EXPIRY_TYPE,
@@ -469,7 +477,10 @@ def _cap_admit(target: Path, cap_value: int, now_dt: datetime) -> bool:
     try:
         if _expire_stale_pending(target, now_dt):
             pending = count_pending(path=target, now=now_dt)
-    except (ChainError, OSError):
+    except Exception:
+        # The relief pass must never break either enqueue path — the
+        # same never-raise contract maybe_sample documents (review
+        # finding, Event 157: (ChainError, OSError) alone narrowed it).
         pass
     return pending < cap_value
 
@@ -748,6 +759,14 @@ def enqueue_direct(
     cid = str(payload.get("correlation_id") or "").strip()
     try:
         if payload.get("type") != ENTRY_TYPE or not cid:
+            return SampleResult(
+                queued=False, correlation_id=cid, effective_rate=0.0,
+                multipliers=(), entry_hash=None, reason="error",
+            )
+        # The relief valve ages entries by ``queued_at``; an entry
+        # without a parseable stamp would jam a cap slot forever
+        # (immortal-entry review finding, Event 157) — reject it here.
+        if _parse_iso(str(payload.get("queued_at") or "")) is None:
             return SampleResult(
                 queued=False, correlation_id=cid, effective_rate=0.0,
                 multipliers=(), entry_hash=None, reason="error",

--- a/core/hooks/_spot_check.py
+++ b/core/hooks/_spot_check.py
@@ -43,6 +43,22 @@ CP7's ``_chain.append``. Three payload types:
 - ``spot_check_skip`` — operator deferred the entry; skip records
   carry a 7-day TTL (CP8 plan Q4). The reader treats an entry with
   a non-expired skip as "hidden"; after TTL the entry re-presents.
+  Wired to ``episteme review --skip`` (Event 157).
+- ``spot_check_expiry`` — terminal, machine-written aging-out of a
+  pending entry by the at-cap relief valve (Event 157). Unlike a
+  skip, an expiry never re-presents; an operator verdict written
+  afterwards supersedes it in ``stats``.
+
+## Enqueue paths + backpressure
+
+Two enqueue paths, one cap contract (Event 157): ``maybe_sample``
+(dice-rolled, PostToolUse) and ``enqueue_direct`` (always-sample
+producers — interrogation verdicts at rate 1.0, kernel E5). Both
+consult the pending cap; at cap, ``_cap_admit`` first ages out
+pending entries older than ``CAP_EXPIRY_AGE_SECONDS`` as chained
+expiry records so sampling resumes instead of silently stopping.
+Declines bump the skip sidecar; a verdict write resets it (the
+banner's 'since last drain' window).
 
 ## Verdict dimensions (locked per CP8 plan Q5)
 
@@ -108,6 +124,7 @@ from _chain import (  # noqa: E402  # pyright: ignore[reportMissingImports]
 ENTRY_TYPE = "spot_check_entry"
 VERDICT_TYPE = "spot_check_verdict"
 SKIP_TYPE = "spot_check_skip"
+EXPIRY_TYPE = "spot_check_expiry"
 
 BASE_RATE_COLD = 0.10
 BASE_RATE_WARM = 0.05
@@ -118,6 +135,17 @@ MULTIPLIER_SYNTHESIS_PRODUCED = 2.0
 MULTIPLIER_BLUEPRINT_D_RESOLUTION = 2.0
 
 SKIP_TTL_SECONDS = 7 * 24 * 60 * 60
+
+# Cap-relief expiry age (Event 157, M1 follow-through). The E148 cap
+# was a brake, not a drain: at saturation ``maybe_sample`` declined
+# silently, and once enqueue-rate outran the manual drain the sampler
+# stayed off (live queue re-reached cap within days of the E148
+# archive, 199 ops skipped). At cap, pending entries older than this
+# age floor are aged out as terminal, chained ``spot_check_expiry``
+# records — visible, auditable loss instead of a silent sampler outage
+# — and sampling resumes. Every entry is guaranteed at least this
+# window of operator reviewability before it can expire.
+CAP_EXPIRY_AGE_SECONDS = 7 * 24 * 60 * 60
 
 # Enqueue backpressure (Event 148, M1). The spot-check queue is
 # operator-facing and drained manually; automatic enqueue paired with a
@@ -396,6 +424,56 @@ def _resolve_pending_cap(explicit: int | None = None) -> int:
     return DEFAULT_PENDING_CAP
 
 
+def _expire_stale_pending(
+    target: Path,
+    now_dt: datetime,
+    *,
+    age_seconds: int = CAP_EXPIRY_AGE_SECONDS,
+) -> int:
+    """At-cap relief valve (Event 157): append a terminal
+    ``spot_check_expiry`` record for every pending entry older than
+    the age floor, so sampling resumes instead of silently stopping.
+    Terminal is deliberate — ``SKIP_TYPE`` is a snooze that re-presents
+    after its TTL and would re-saturate the cap on schedule. Returns
+    the count expired; ``ChainError``/``OSError`` propagate to the
+    caller's guard."""
+    cutoff = now_dt - timedelta(seconds=age_seconds)
+    expired = 0
+    for e in list_pending(path=target, now=now_dt):
+        queued = _parse_iso(str(e.payload.get("queued_at", "")))
+        if queued is None or queued > cutoff:
+            continue
+        _chain_append(target, {
+            "type": EXPIRY_TYPE,
+            "correlation_id": e.payload.get("correlation_id"),
+            "entry_hash": e.entry_hash,
+            "expired_at": _iso(now_dt),
+            "queued_at": e.payload.get("queued_at"),
+            "reason": "cap_relief",
+        })
+        expired += 1
+    return expired
+
+
+def _cap_admit(target: Path, cap_value: int, now_dt: datetime) -> bool:
+    """Shared cap consult for both enqueue paths (``maybe_sample`` and
+    ``enqueue_direct``). At cap, run the relief valve then recount.
+    A count error fails toward admit — the cap must NEVER block the
+    hook path or lose an existing entry (E148 contract, preserved)."""
+    try:
+        pending = count_pending(path=target, now=now_dt)
+    except Exception:
+        return True
+    if pending < cap_value:
+        return True
+    try:
+        if _expire_stale_pending(target, now_dt):
+            pending = count_pending(path=target, now=now_dt)
+    except (ChainError, OSError):
+        pass
+    return pending < cap_value
+
+
 def read_skip_counter(path: Path | None = None) -> dict:
     """Read the backpressure skip sidecar. Returns
     ``{"skipped_count": int, ...}`` — ``{"skipped_count": 0}`` when the
@@ -434,6 +512,29 @@ def _bump_skip_counter(
         "last_skipped_at": _iso(now),
         "last_reason": reason,
     }
+    if not _write_skip_counter(payload, target):
+        return None
+    return current + 1
+
+
+def _reset_skip_counter(
+    now: datetime, *, path: Path | None = None
+) -> None:
+    """Zero the backpressure counter. Drain activity (a verdict write)
+    starts a new window, so the SessionStart banner's 'skipped since
+    last drain' label stays truthful (Event 157 — previously nothing
+    ever reset this sidecar and the label was cumulative-forever).
+    Best-effort: never raises."""
+    target = path if path is not None else _skip_counter_path()
+    _write_skip_counter(
+        {"skipped_count": 0, "last_reset_at": _iso(now)}, target
+    )
+
+
+def _write_skip_counter(payload: dict, target: Path) -> bool:
+    """Atomic temp+rename write of the skip sidecar (same discipline as
+    the fence/cascade markers). Returns False when the write degraded —
+    callers must not block the admit path on it."""
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp = tempfile.mkstemp(
@@ -450,10 +551,10 @@ def _bump_skip_counter(
                 os.unlink(tmp)
             except OSError:
                 pass
-            return None
+            return False
     except OSError:
-        return None
-    return current + 1
+        return False
+    return True
 
 
 def _fatigue_active(
@@ -573,18 +674,17 @@ def maybe_sample(
 
         target = path if path is not None else _queue_path()
 
-        # Backpressure (Event 148, M1). Consult the pending set BEFORE
-        # appending. count_pending only runs on the sampled path (post
-        # dice-roll, ~base-rate of ops), and the cap keeps the pending
-        # set bounded going forward so this read stays cheap. A count
-        # error fails toward enqueue — the cap must NEVER block the hook
-        # or lose an existing entry.
+        # Backpressure (Event 148, M1) + relief valve (Event 157).
+        # Consult the pending set BEFORE appending. count_pending only
+        # runs on the sampled path (post dice-roll, ~base-rate of ops),
+        # and the cap keeps the pending set bounded going forward so
+        # this read stays cheap. At cap, _cap_admit first ages out
+        # pending entries past CAP_EXPIRY_AGE_SECONDS as chained expiry
+        # records — the sampler resumes instead of silently staying
+        # off. A count error fails toward enqueue — the cap must NEVER
+        # block the hook or lose an existing entry.
         cap_value = _resolve_pending_cap(cap)
-        try:
-            pending = count_pending(path=target, now=now_dt)
-        except Exception:
-            pending = None
-        if pending is not None and pending >= cap_value:
+        if not _cap_admit(target, cap_value, now_dt):
             _bump_skip_counter("cap_exceeded", now_dt, path=skip_counter_path)
             return SampleResult(
                 queued=False, correlation_id=correlation_id,
@@ -628,6 +728,65 @@ def maybe_sample(
         )
 
 
+def enqueue_direct(
+    payload: dict,
+    *,
+    path: Path | None = None,
+    now: datetime | None = None,
+    cap: int | None = None,
+    skip_counter_path: Path | None = None,
+) -> SampleResult:
+    """Cap-aware direct enqueue for always-sample producers — entries
+    whose effective rate is 1.0 by design (interrogation verdicts;
+    kernel falsifiability condition E5 needs them measurable) rather
+    than dice-rolled. Honors the same backpressure contract as
+    ``maybe_sample``: idempotent by correlation_id, at-cap relief via
+    the expiry valve, decline + skip-counter bump while saturated.
+    Event 157 — closes the E148 cap bypass (raw ``_chain_append`` from
+    the interrogation arm pushed pending past the cap). The caller owns
+    the payload, including ``queued_at``. Never raises."""
+    cid = str(payload.get("correlation_id") or "").strip()
+    try:
+        if payload.get("type") != ENTRY_TYPE or not cid:
+            return SampleResult(
+                queued=False, correlation_id=cid, effective_rate=0.0,
+                multipliers=(), entry_hash=None, reason="error",
+            )
+        rate = float(payload.get("effective_rate_at_sample") or 1.0)
+        multipliers = tuple(payload.get("multipliers_applied") or ())
+        target = path if path is not None else _queue_path()
+        if _correlation_already_queued(cid, path=target):
+            return SampleResult(
+                queued=False, correlation_id=cid, effective_rate=rate,
+                multipliers=multipliers, entry_hash=None,
+                reason="already_queued",
+            )
+        now_dt = now or datetime.now(timezone.utc)
+        cap_value = _resolve_pending_cap(cap)
+        if not _cap_admit(target, cap_value, now_dt):
+            _bump_skip_counter("cap_exceeded", now_dt, path=skip_counter_path)
+            return SampleResult(
+                queued=False, correlation_id=cid, effective_rate=rate,
+                multipliers=multipliers, entry_hash=None,
+                reason="cap_exceeded",
+            )
+        envelope = _chain_append(target, payload)
+        return SampleResult(
+            queued=True, correlation_id=cid, effective_rate=rate,
+            multipliers=multipliers, entry_hash=envelope["entry_hash"],
+            reason="queued",
+        )
+    except (ChainError, OSError, TypeError, ValueError) as exc:
+        sys.stderr.write(
+            f"[episteme spot_check] direct enqueue error: "
+            f"{exc.__class__.__name__}; admit path untouched\n"
+        )
+        return SampleResult(
+            queued=False, correlation_id=cid, effective_rate=0.0,
+            multipliers=(), entry_hash=None, reason="error",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Read-side helpers
 # ---------------------------------------------------------------------------
@@ -640,6 +799,7 @@ class QueuedEntry:
     verdict: dict | None           # latest verdict record (payload dict) or None
     skip_until: datetime | None    # non-None when a non-expired skip was recorded
     entry_hash: str
+    expiry: dict | None = None     # terminal cap-relief record (Event 157) or None
 
 
 def _parse_iso(value: str) -> datetime | None:
@@ -673,6 +833,7 @@ def list_entries(
     entries: list[tuple[dict, dict]] = []      # (envelope, payload)
     verdicts_by_cid: dict[str, tuple[str, dict]] = {}   # cid -> (verdicted_at, payload)
     skips_by_cid: dict[str, datetime] = {}  # cid -> skip expires_at
+    expiries_by_cid: dict[str, dict] = {}   # cid -> expiry payload (terminal; first wins)
 
     for rec in records:
         payload = rec.get("payload") if isinstance(rec, dict) else None
@@ -696,18 +857,24 @@ def list_entries(
                 prior = skips_by_cid.get(cid)
                 if prior is None or expires > prior:
                     skips_by_cid[cid] = expires
+        elif ptype == EXPIRY_TYPE:
+            cid = payload.get("correlation_id")
+            if isinstance(cid, str):
+                expiries_by_cid.setdefault(cid, payload)
 
     out: list[QueuedEntry] = []
     for envelope, payload in entries:
         cid = payload.get("correlation_id")
         verdict_pair = verdicts_by_cid.get(cid) if isinstance(cid, str) else None
         skip_until = skips_by_cid.get(cid) if isinstance(cid, str) else None
+        expiry = expiries_by_cid.get(cid) if isinstance(cid, str) else None
         out.append(QueuedEntry(
             envelope=envelope,
             payload=payload,
             verdict=verdict_pair[1] if verdict_pair else None,
             skip_until=skip_until,
             entry_hash=envelope.get("entry_hash", ""),
+            expiry=expiry,
         ))
     return out
 
@@ -717,12 +884,12 @@ def list_pending(
     path: Path | None = None,
     now: datetime | None = None,
 ) -> list[QueuedEntry]:
-    """Entries with no verdict AND no active skip. Ordered by
-    ``queued_at`` ascending — oldest-first."""
+    """Entries with no verdict, no active skip, and no terminal expiry.
+    Ordered by ``queued_at`` ascending — oldest-first."""
     entries = list_entries(path=path, now=now)
     pending = [
         e for e in entries
-        if e.verdict is None and e.skip_until is None
+        if e.verdict is None and e.skip_until is None and e.expiry is None
     ]
     pending.sort(key=lambda e: str(e.payload.get("queued_at", "")))
     return pending
@@ -757,8 +924,13 @@ def stats(
     entries = list_entries(path=path, now=now)
     total = len(entries)
     verdicted = [e for e in entries if e.verdict is not None]
-    pending = [e for e in entries if e.verdict is None and e.skip_until is None]
+    pending = [
+        e for e in entries
+        if e.verdict is None and e.skip_until is None and e.expiry is None
+    ]
     skipped = [e for e in entries if e.skip_until is not None]
+    # An operator verdict on an aged-out entry supersedes its expiry.
+    expired = [e for e in entries if e.verdict is None and e.expiry is not None]
     distribution: dict[str, int] = {}
     for e in verdicted:
         verdicts = e.verdict.get("verdicts") if e.verdict else None
@@ -771,6 +943,7 @@ def stats(
         "verdicted": len(verdicted),
         "pending": len(pending),
         "skipped": len(skipped),
+        "expired": len(expired),
         "surface_validity_distribution": distribution,
     }
 
@@ -830,12 +1003,15 @@ def write_verdict(
     is_revision: bool = False,
     path: Path | None = None,
     now: datetime | None = None,
+    skip_counter_path: Path | None = None,
 ) -> dict:
     """Append a ``spot_check_verdict`` record. Never mutates the
     original entry. Raises ``ChainError`` when the entry does not
     exist or the verdict shape violates the required dimensions.
 
-    Returns the full envelope.
+    A successful verdict is drain activity: it resets the backpressure
+    skip counter so the banner's 'since last drain' window is truthful
+    (Event 157). Returns the full envelope.
     """
     entry = get_entry(correlation_id, path=path, now=now)
     if entry is None:
@@ -863,7 +1039,9 @@ def write_verdict(
         "is_revision": bool(is_revision),
     }
     target = path if path is not None else _queue_path()
-    return _chain_append(target, payload)
+    envelope = _chain_append(target, payload)
+    _reset_skip_counter(now_dt, path=skip_counter_path)
+    return envelope
 
 
 def write_skip(

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -5386,7 +5386,19 @@ def _review_dispatch(args) -> int:
     if getattr(args, "review_skip", False):
         # Operator snooze (Event 157 — wires the previously-unwired
         # write_skip): defer the entry 7 days; it re-presents after.
+        # Only a genuinely-pending entry can be snoozed — a skip on a
+        # verdicted/expired entry would never re-present (the terminal
+        # record wins), so the deferral message would lie and stats
+        # would double-count the entry.
         cid = entry.payload.get("correlation_id", "")
+        if entry.verdict is not None or getattr(entry, "expiry", None) is not None:
+            state = "verdicted" if entry.verdict is not None else "expired"
+            print(
+                f"[episteme review] {cid} is {state} — --skip only defers "
+                f"a pending entry (a terminal entry never re-presents)",
+                file=sys.stderr,
+            )
+            return 2
         try:
             _spot_check.write_skip(cid)
         except Exception as exc:

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -5361,6 +5361,7 @@ def _review_dispatch(args) -> int:
             mults = ",".join(e.payload.get("multipliers_applied") or []) or "(none)"
             state = (
                 "verdicted" if e.verdict is not None
+                else "expired" if getattr(e, "expiry", None) is not None
                 else "skipped" if e.skip_until is not None
                 else "pending"
             )
@@ -5381,6 +5382,18 @@ def _review_dispatch(args) -> int:
             print("(no pending entries — queue empty)")
             return 0
         entry = pending[0]
+
+    if getattr(args, "review_skip", False):
+        # Operator snooze (Event 157 — wires the previously-unwired
+        # write_skip): defer the entry 7 days; it re-presents after.
+        cid = entry.payload.get("correlation_id", "")
+        try:
+            _spot_check.write_skip(cid)
+        except Exception as exc:
+            print(f"[episteme review] skip error: {exc}", file=sys.stderr)
+            return 2
+        print(f"Deferred {cid} for 7 days (re-presents after TTL).")
+        return 0
 
     return _run_interactive_review(_spot_check, entry, revise=revise)
 
@@ -6314,6 +6327,10 @@ def build_parser() -> argparse.ArgumentParser:
     review_cmd.add_argument(
         "--correlation-id", dest="review_correlation_id", default=None,
         help="Review the entry matching this correlation id (instead of the oldest pending)",
+    )
+    review_cmd.add_argument(
+        "--skip", dest="review_skip", action="store_true",
+        help="Defer the selected entry for 7 days instead of verdicting it",
     )
     review_cmd.add_argument(
         "--revise", action="store_true",

--- a/tests/test_interrogation.py
+++ b/tests/test_interrogation.py
@@ -444,5 +444,93 @@ class RootBoundary(unittest.TestCase):
             self.assertEqual(_interrogation.artifact_status(sub)[0], "missing")
 
 
+# ---------- Verdict spot-check enqueue (E5 · Event 157 cap contract) -----
+
+
+class VerdictSpotCheckEnqueue(unittest.TestCase):
+    """enqueue_verdict_spot_check must honor the Layer 8 pending cap
+    (Event 157): sample-all by design, but never past the backpressure
+    bound the E148 closure rests on."""
+
+    def _spot(self):
+        from core.hooks import _spot_check  # pyright: ignore[reportAttributeAccessIssue]
+        return _spot_check
+
+    def test_enqueues_below_cap(self):
+        with EphemeralHome(), _TmpProject() as proj:
+            _write_artifact(proj, _valid_artifact())
+            ok = _interrogation.enqueue_verdict_spot_check(
+                proj, op_label="cascade:architectural"
+            )
+            self.assertTrue(ok)
+            self.assertEqual(self._spot().count_pending(), 1)
+
+    def test_idempotent_per_artifact_content(self):
+        with EphemeralHome(), _TmpProject() as proj:
+            _write_artifact(proj, _valid_artifact())
+            self.assertTrue(
+                _interrogation.enqueue_verdict_spot_check(
+                    proj, op_label="cascade:architectural"
+                )
+            )
+            self.assertFalse(
+                _interrogation.enqueue_verdict_spot_check(
+                    proj, op_label="cascade:architectural"
+                )
+            )
+            self.assertEqual(self._spot().count_pending(), 1)
+
+    def test_declines_at_cap_and_bumps_skip_counter(self):
+        with EphemeralHome(), _TmpProject() as proj:
+            _spot = self._spot()
+            seed = {
+                "type": _spot.ENTRY_TYPE,
+                "correlation_id": "seed-fresh",
+                "queued_at": _spot._iso(datetime.now(timezone.utc)),
+                "op_label": "git push",
+                "blueprint": "generic",
+                "context_signature": {},
+                "surface_snapshot": {},
+                "multipliers_applied": [],
+                "effective_rate_at_sample": 1.0,
+            }
+            self.assertTrue(_spot.enqueue_direct(seed).queued)
+            _write_artifact(proj, _valid_artifact())
+            with patch.dict(os.environ, {"EPISTEME_SPOT_CHECK_CAP": "1"}):
+                ok = _interrogation.enqueue_verdict_spot_check(
+                    proj, op_label="cascade:architectural"
+                )
+            self.assertFalse(ok)
+            self.assertEqual(_spot.count_pending(), 1)
+            self.assertEqual(
+                _spot.read_skip_counter()["skipped_count"], 1
+            )
+
+    def test_at_cap_stale_relief_restores_interrogation_sampling(self):
+        with EphemeralHome(), _TmpProject() as proj:
+            _spot = self._spot()
+            stale = {
+                "type": _spot.ENTRY_TYPE,
+                "correlation_id": "seed-stale",
+                "queued_at": _spot._iso(
+                    datetime.now(timezone.utc) - timedelta(days=8)
+                ),
+                "op_label": "git push",
+                "blueprint": "generic",
+                "context_signature": {},
+                "surface_snapshot": {},
+                "multipliers_applied": [],
+                "effective_rate_at_sample": 1.0,
+            }
+            self.assertTrue(_spot.enqueue_direct(stale).queued)
+            _write_artifact(proj, _valid_artifact())
+            with patch.dict(os.environ, {"EPISTEME_SPOT_CHECK_CAP": "1"}):
+                ok = _interrogation.enqueue_verdict_spot_check(
+                    proj, op_label="cascade:architectural"
+                )
+            self.assertTrue(ok)
+            self.assertEqual(_spot.stats()["expired"], 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spot_check.py
+++ b/tests/test_spot_check.py
@@ -828,5 +828,193 @@ class ProjectOverrideRootResolution(unittest.TestCase):
             )
 
 
+# ---------- Cap relief + drain truthfulness (Event 157) -----------------
+
+
+def _stale_payload(cid: str, *, age_days: int = 8) -> dict:
+    """Entry payload with a queued_at older than the cap-expiry age
+    floor, in the direct-enqueue (interrogation-shaped) form."""
+    queued = datetime.now(timezone.utc) - timedelta(days=age_days)
+    return {
+        "type": _spot_check.ENTRY_TYPE,
+        "correlation_id": cid,
+        "queued_at": _spot_check._iso(queued),
+        "op_label": "cascade:architectural",
+        "blueprint": "interrogation",
+        "context_signature": {},
+        "surface_snapshot": {"interrogation": {"verdict": "proceed"}},
+        "multipliers_applied": ["interrogation_verdict"],
+        "effective_rate_at_sample": 1.0,
+    }
+
+
+def _fresh_payload(cid: str) -> dict:
+    return _stale_payload(cid, age_days=0)
+
+
+class CapExpiryRelief(unittest.TestCase):
+    """At cap, pending entries older than CAP_EXPIRY_AGE_SECONDS age out
+    as chained ``spot_check_expiry`` records so sampling resumes instead
+    of silently stopping (Event 157 — the E148 cap was a brake, not a
+    drain)."""
+
+    def _cwd_rate_one(self, stack):
+        import contextlib  # noqa: F401 — parity with EnqueueBackpressure
+        cwd = stack.enter_context(tempfile.TemporaryDirectory())
+        (Path(cwd) / ".episteme").mkdir()
+        (Path(cwd) / ".episteme" / "spot_check_rate").write_text("1.0\n")
+        return Path(cwd)
+
+    def test_at_cap_expires_stale_and_enqueues(self):
+        import contextlib
+        with EphemeralHome(), contextlib.ExitStack() as stack:
+            cwd = self._cwd_rate_one(stack)
+            old_now = datetime.now(timezone.utc) - timedelta(days=8)
+            r_old = _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-stale"),
+                cwd=cwd, now=old_now,
+            )
+            self.assertTrue(r_old.queued)
+            r_new = _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-new"), cwd=cwd, cap=1
+            )
+            self.assertTrue(r_new.queued)
+            self.assertEqual(r_new.reason, "queued")
+            pending = _spot_check.list_pending()
+            self.assertEqual(
+                [e.payload["correlation_id"] for e in pending], ["cid-new"]
+            )
+            st = _spot_check.stats()
+            self.assertEqual(st["expired"], 1)
+            self.assertEqual(st["pending"], 1)
+
+    def test_at_cap_young_queue_still_declines(self):
+        import contextlib
+        with EphemeralHome(), contextlib.ExitStack() as stack:
+            cwd = self._cwd_rate_one(stack)
+            r0 = _force_queue("cid-young", cwd)
+            self.assertTrue(r0.queued)
+            r1 = _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-next"), cwd=cwd, cap=1
+            )
+            self.assertFalse(r1.queued)
+            self.assertEqual(r1.reason, "cap_exceeded")
+            self.assertEqual(
+                _spot_check.read_skip_counter()["skipped_count"], 1
+            )
+            self.assertEqual(_spot_check.stats()["expired"], 0)
+
+    def test_expiry_records_survive_chain_verification(self):
+        import contextlib
+        with EphemeralHome(), contextlib.ExitStack() as stack:
+            cwd = self._cwd_rate_one(stack)
+            old_now = datetime.now(timezone.utc) - timedelta(days=8)
+            _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-stale"),
+                cwd=cwd, now=old_now,
+            )
+            _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-new"), cwd=cwd, cap=1
+            )
+            verdict = _spot_check.verify_chain()
+            self.assertTrue(verdict.intact)
+
+    def test_expired_entry_can_still_be_verdicted(self):
+        import contextlib
+        with EphemeralHome(), contextlib.ExitStack() as stack:
+            cwd = self._cwd_rate_one(stack)
+            old_now = datetime.now(timezone.utc) - timedelta(days=8)
+            _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-stale"),
+                cwd=cwd, now=old_now,
+            )
+            _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-new"), cwd=cwd, cap=1
+            )
+            # Operator judgment on an aged-out entry still lands; the
+            # verdict supersedes the expiry in stats.
+            _spot_check.write_verdict(
+                "cid-stale", {"surface_validity": "real"}
+            )
+            st = _spot_check.stats()
+            self.assertEqual(st["verdicted"], 1)
+            self.assertEqual(st["expired"], 0)
+
+
+class DirectEnqueue(unittest.TestCase):
+    """enqueue_direct — the cap-aware path for always-sample producers
+    (interrogation verdicts). Same backpressure contract as
+    maybe_sample (Event 157: closes the E148 cap bypass)."""
+
+    def test_below_cap_appends(self):
+        with EphemeralHome():
+            r = _spot_check.enqueue_direct(_fresh_payload("iv-1"))
+            self.assertTrue(r.queued)
+            self.assertEqual(_spot_check.count_pending(), 1)
+
+    def test_dedupe_by_correlation_id(self):
+        with EphemeralHome():
+            self.assertTrue(
+                _spot_check.enqueue_direct(_fresh_payload("iv-1")).queued
+            )
+            r2 = _spot_check.enqueue_direct(_fresh_payload("iv-1"))
+            self.assertFalse(r2.queued)
+            self.assertEqual(r2.reason, "already_queued")
+            self.assertEqual(_spot_check.count_pending(), 1)
+
+    def test_at_cap_declines_and_bumps_skip_counter(self):
+        with EphemeralHome():
+            self.assertTrue(
+                _spot_check.enqueue_direct(_fresh_payload("iv-1")).queued
+            )
+            r2 = _spot_check.enqueue_direct(_fresh_payload("iv-2"), cap=1)
+            self.assertFalse(r2.queued)
+            self.assertEqual(r2.reason, "cap_exceeded")
+            self.assertEqual(_spot_check.count_pending(), 1)
+            self.assertEqual(
+                _spot_check.read_skip_counter()["skipped_count"], 1
+            )
+
+    def test_at_cap_stale_relief_then_appends(self):
+        with EphemeralHome():
+            self.assertTrue(
+                _spot_check.enqueue_direct(_stale_payload("iv-old")).queued
+            )
+            r2 = _spot_check.enqueue_direct(_fresh_payload("iv-new"), cap=1)
+            self.assertTrue(r2.queued)
+            pending = _spot_check.list_pending()
+            self.assertEqual(
+                [e.payload["correlation_id"] for e in pending], ["iv-new"]
+            )
+            self.assertEqual(_spot_check.stats()["expired"], 1)
+
+
+class SkipCounterReset(unittest.TestCase):
+    """The banner reads 'skipped since last drain' — so drain activity
+    (a verdict write) must reset the counter, or the label lies
+    (Event 157 truthfulness fix)."""
+
+    def test_write_verdict_resets_skip_counter(self):
+        import contextlib
+        with EphemeralHome(), contextlib.ExitStack() as stack:
+            cwd = stack.enter_context(tempfile.TemporaryDirectory())
+            (Path(cwd) / ".episteme").mkdir()
+            (Path(cwd) / ".episteme" / "spot_check_rate").write_text("1.0\n")
+            cwd = Path(cwd)
+            r0 = _force_queue("cid-0", cwd)
+            self.assertTrue(r0.queued)
+            # Bump the counter via an at-cap decline on a young queue.
+            _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-1"), cwd=cwd, cap=1
+            )
+            self.assertEqual(
+                _spot_check.read_skip_counter()["skipped_count"], 1
+            )
+            _spot_check.write_verdict("cid-0", {"surface_validity": "real"})
+            self.assertEqual(
+                _spot_check.read_skip_counter()["skipped_count"], 0
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spot_check.py
+++ b/tests/test_spot_check.py
@@ -989,6 +989,94 @@ class DirectEnqueue(unittest.TestCase):
             self.assertEqual(_spot_check.stats()["expired"], 1)
 
 
+class DirectEnqueueValidation(unittest.TestCase):
+    """Review findings (Event 157): a payload without a parseable
+    ``queued_at`` must not enter the queue — the relief valve ages
+    entries by that stamp, so an unstampable entry would jam a cap
+    slot forever (immortal-entry defect)."""
+
+    def test_missing_queued_at_rejected(self):
+        with EphemeralHome():
+            p = _fresh_payload("iv-nostamp")
+            del p["queued_at"]
+            r = _spot_check.enqueue_direct(p)
+            self.assertFalse(r.queued)
+            self.assertEqual(r.reason, "error")
+            self.assertEqual(_spot_check.count_pending(), 0)
+
+    def test_malformed_queued_at_rejected(self):
+        with EphemeralHome():
+            p = _fresh_payload("iv-badstamp")
+            p["queued_at"] = "not-a-date"
+            r = _spot_check.enqueue_direct(p)
+            self.assertFalse(r.queued)
+            self.assertEqual(r.reason, "error")
+            self.assertEqual(_spot_check.count_pending(), 0)
+
+    def test_legacy_unparseable_queued_at_is_expiry_eligible(self):
+        # Defense in depth: an unstampable entry that reached the
+        # queue anyway (legacy writer, corruption) must not be
+        # immortal — its review-window start is unknowable, so the
+        # valve treats it as expiry-eligible rather than letting it
+        # jam the cap.
+        with EphemeralHome():
+            bad = _fresh_payload("iv-legacy-bad")
+            bad["queued_at"] = "garbage"
+            _spot_check._chain_append(_spot_check._queue_path(), bad)
+            self.assertEqual(_spot_check.count_pending(), 1)
+            r = _spot_check.enqueue_direct(_fresh_payload("iv-new"), cap=1)
+            self.assertTrue(r.queued)
+            self.assertEqual(_spot_check.stats()["expired"], 1)
+            pending = _spot_check.list_pending()
+            self.assertEqual(
+                [e.payload["correlation_id"] for e in pending], ["iv-new"]
+            )
+
+
+class CapZeroSemantics(unittest.TestCase):
+    """Pin the ``cap=0`` knob: it disables sampling entirely (every
+    attempt declines; the empty queue offers nothing to relieve) and
+    must never raise — an operator footgun worth a contract test."""
+
+    def test_maybe_sample_cap_zero_declines(self):
+        import contextlib
+        with EphemeralHome(), contextlib.ExitStack() as stack:
+            cwd = stack.enter_context(tempfile.TemporaryDirectory())
+            (Path(cwd) / ".episteme").mkdir()
+            (Path(cwd) / ".episteme" / "spot_check_rate").write_text("1.0\n")
+            r = _spot_check.maybe_sample(
+                **_sample_inputs(correlation_id="cid-z"),
+                cwd=Path(cwd), cap=0,
+            )
+            self.assertFalse(r.queued)
+            self.assertEqual(r.reason, "cap_exceeded")
+
+    def test_enqueue_direct_cap_zero_declines(self):
+        with EphemeralHome():
+            r = _spot_check.enqueue_direct(_fresh_payload("iv-z"), cap=0)
+            self.assertFalse(r.queued)
+            self.assertEqual(r.reason, "cap_exceeded")
+
+
+class ResetFailureTolerance(unittest.TestCase):
+    """A degraded skip-counter write must never break the verdict
+    write (same never-block discipline as _bump_skip_counter)."""
+
+    def test_write_verdict_survives_unwritable_counter_path(self):
+        with EphemeralHome() as home:
+            r = _seed_entry("cid-rf")
+            self.assertTrue(r.queued)
+            blocker = home / "not-a-dir"
+            blocker.write_text("file, not a directory")
+            env = _spot_check.write_verdict(
+                "cid-rf",
+                {"surface_validity": "real"},
+                skip_counter_path=blocker / "counter.json",
+            )
+            self.assertIn("entry_hash", env)
+            self.assertEqual(_spot_check.stats()["verdicted"], 1)
+
+
 class SkipCounterReset(unittest.TestCase):
     """The banner reads 'skipped since last drain' — so drain activity
     (a verdict write) must reset the counter, or the label lies


### PR DESCRIPTION
## What

Closes the three spot-check-queue findings from the 2026-07-20 governance-closure audit (Findings 1, 2, 4 + the write_skip D11 wire-or-delete), plus a hardening round from independent review.

**The defect class:** the E148 backpressure cap was a brake, not a drain. At saturation the Layer 8 sampler paused silently and stayed off once enqueue-rate outran the manual drain — live queue re-reached cap within days of the E148 archive (117 pending > cap 100, 199 ops skipped, sampler off since ~Jul 11). The M1 closure criterion (pending = 0 that day) never tested drain-rate ≥ enqueue-rate.

## Changes

- **At-cap relief valve** — pending entries older than `CAP_EXPIRY_AGE_SECONDS` (7d) age out as terminal, chained `spot_check_expiry` records; sampling resumes instead of silently stopping. Every entry keeps a 7-day operator-review window; a later operator verdict supersedes the expiry in `stats()`.
- **`enqueue_direct`** — cap-aware path for always-sample producers. `_interrogation.enqueue_verdict_spot_check` previously appended via raw `_chain_append` with no cap consult (the one route that could push pending past the cap, and did). Sample-all stays the E5 design; a saturated decline retries on the next firing once the queue drains.
- **Truthful "since last drain"** — `write_verdict` resets the skip sidecar; previously nothing ever reset it, so the SessionStart banner asserted windowed semantics over a cumulative-forever counter.
- **`episteme review --skip`** — wires the previously-unwired `write_skip` (D11: wire-or-delete); `--list` gains the `expired` state; `stats()` gains an `expired` bucket.
- **Review hardening (879b943)** — unstampable payloads rejected at `enqueue_direct` AND expiry-eligible in the valve (immortal-entry defect); `--skip` rejects verdicted/expired entries; `_cap_admit` relief pass matches the never-raise contract; cap=0 and reset-failure semantics pinned by contract tests.

## Verification

- Suite: **1688 passed + 93 subtests, 0 failed** (+19 new tests over the E156 baseline).
- End-to-end beyond the suite (sandboxed `EPISTEME_HOME`, real `reasoning_surface_guard.py` PreToolUse drive at cap=1): stale entry expired + interrogation entry admitted in one firing; second artifact declined with counter bump and gate exit 0 (admit path never blocked); verdict reset the counter to 0; `--skip` deferred a pending entry and rejected expired/verdicted ones.
- Independent adversarial review (separate context): 3 should-fix findings, all fixed and re-verified; 2 accepted-design notes documented in-code.

## Notes

- First live at-cap firing after deploy will expire the aged cohort of the real 117-pending queue in one pass (~57ms measured at 200 records) — expected, chained, visible in `episteme review --stats`.
- Same pathology in the deferred-discovery queue (audit Finding 3) is deliberately NOT in this diff — separate bounded event next.