### PR TITLE
fix(framework): Event 158 — deferred-discovery queue gets the Event 157 drain (open-cap, expiry relief, truthful counter)

### DIFF
--- a/core/hooks/_blueprint_d.py
+++ b/core/hooks/_blueprint_d.py
@@ -467,8 +467,11 @@ def write_cascade_deferred_discoveries(
                 },
                 "status": "pending",
             }
-            write_deferred_discovery(payload)
-            count += 1
+            res = write_deferred_discovery(payload)
+            # A cap-declined write is not a written record (Event 158);
+            # suppressed duplicates keep counting per prior behavior.
+            if not (isinstance(res, dict) and res.get("declined_at_cap")):
+                count += 1
         except Exception as exc:
             sys.stderr.write(
                 f"[episteme] Blueprint D deferred-discovery write "

--- a/core/hooks/_blueprint_d.py
+++ b/core/hooks/_blueprint_d.py
@@ -467,7 +467,7 @@ def write_cascade_deferred_discoveries(
                 },
                 "status": "pending",
             }
-            res = write_deferred_discovery(payload)
+            res = write_deferred_discovery(payload, now=now_dt)
             # A cap-declined write is not a written record (Event 158);
             # suppressed duplicates keep counting per prior behavior.
             if not (isinstance(res, dict) and res.get("declined_at_cap")):

--- a/core/hooks/_framework.py
+++ b/core/hooks/_framework.py
@@ -54,7 +54,9 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -110,6 +112,29 @@ DISCOVERY_VERDICT_TYPE = "deferred_discovery_verdict"
 RESOLUTION_VERDICTS = frozenset({"resolved", "noise", "duplicate", "accepted"})
 _VERDICT_RATIONALE_FLOOR = 15  # same lazy-value bar as surface fields
 _REF_PREFIX_FLOOR = 8
+
+# Terminal, machine-written aging-out of an OPEN discovery by the
+# at-cap relief valve (Event 158 — sibling of Event 157's
+# ``spot_check_expiry``). Deliberately NOT a RESOLUTION_VERDICTS value:
+# that enum records operator judgment; an expiry records the absence of
+# it, honestly. An expiry closes the entry (open_deferred_discoveries
+# treats its ref like a verdict ref) and is not re-openable.
+DISCOVERY_EXPIRY_TYPE = "deferred_discovery_expiry"
+
+# Open-set backpressure (Event 158, M1 follow-through). Blueprint D
+# auto-enqueues discoveries on the live write path; the only drain is
+# the operator verdict CLI. Without a bound the open set grows without
+# limit (178 open at audit time; 1,208 records historically). The cap
+# mirrors the spot-check queue's DEFAULT_PENDING_CAP — one mental
+# model for operator review load — with its own env knob. At cap,
+# open entries older than the age floor expire as chained records so
+# writes resume; the floor is 30 days (vs the spot-check queue's 7)
+# because architectural-debt entries deserve a longer review window
+# than op samples. Budgets are code — changing either constant IS the
+# decision.
+DEFAULT_DEFERRED_OPEN_CAP = 100
+DEFERRED_EXPIRY_AGE_SECONDS = 30 * 24 * 60 * 60
+_DEFERRED_SKIP_COUNTER_FILENAME = "deferred_skipped.json"
 CP5_FORMAT_VERSION = "cp5-pre-chain"
 UPGRADED_FORMAT_MARKER = "cp7-chained-v1"
 
@@ -172,6 +197,173 @@ def _protocols_path() -> Path:
 
 def _deferred_discoveries_path() -> Path:
     return _episteme_home() / "framework" / "deferred_discoveries.jsonl"
+
+
+def _deferred_skip_counter_path() -> Path:
+    return _episteme_home() / "state" / _DEFERRED_SKIP_COUNTER_FILENAME
+
+
+# ---------------------------------------------------------------------------
+# Open-set backpressure (Event 158 — mirrors _spot_check's Event 148/157
+# machinery; small helpers duplicated per the hooks-stay-self-contained
+# convention)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_deferred_open_cap(explicit: int | None = None) -> int:
+    """Resolve the open-set cap. Precedence: explicit arg (test seam) >
+    ``EPISTEME_DEFERRED_OPEN_CAP`` env var > ``DEFAULT_DEFERRED_OPEN_CAP``.
+    Non-parseable / negative values fall back to the default — a bad
+    knob must never break the write path. Never raises."""
+    if explicit is not None:
+        try:
+            return max(0, int(explicit))
+        except (TypeError, ValueError):
+            return DEFAULT_DEFERRED_OPEN_CAP
+    raw = os.environ.get("EPISTEME_DEFERRED_OPEN_CAP", "").strip()
+    if raw:
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            pass
+    return DEFAULT_DEFERRED_OPEN_CAP
+
+
+def read_deferred_skip_counter(path: Path | None = None) -> dict:
+    """Read the backpressure skip sidecar — ``{"skipped_count": 0}``
+    when absent or unreadable. Never raises."""
+    target = path if path is not None else _deferred_skip_counter_path()
+    try:
+        if target.is_file():
+            data = json.loads(target.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and isinstance(
+                data.get("skipped_count"), int
+            ):
+                return data
+    except (OSError, json.JSONDecodeError, ValueError):
+        pass
+    return {"skipped_count": 0}
+
+
+def _write_deferred_skip_counter(payload: dict, target: Path) -> bool:
+    """Atomic temp+rename sidecar write. Returns False when degraded —
+    callers must not block the write path on it."""
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(
+            prefix=target.name + ".tmp-", dir=str(target.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f, ensure_ascii=False)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, target)
+        except OSError:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            return False
+    except OSError:
+        return False
+    return True
+
+
+def _bump_deferred_skip_counter(
+    reason: str, now: datetime, *, path: Path | None = None
+) -> int | None:
+    target = path if path is not None else _deferred_skip_counter_path()
+    current = read_deferred_skip_counter(target).get("skipped_count", 0)
+    if not isinstance(current, int) or current < 0:
+        current = 0
+    payload = {
+        "skipped_count": current + 1,
+        "last_skipped_at": now.isoformat(),
+        "last_reason": reason,
+    }
+    if not _write_deferred_skip_counter(payload, target):
+        return None
+    return current + 1
+
+
+def _reset_deferred_skip_counter(
+    now: datetime, *, path: Path | None = None
+) -> None:
+    """Zero the counter — an operator verdict is drain activity and
+    starts a new 'since last drain' window. Best-effort: never raises."""
+    target = path if path is not None else _deferred_skip_counter_path()
+    _write_deferred_skip_counter(
+        {"skipped_count": 0, "last_reset_at": now.isoformat()}, target
+    )
+
+
+def _parse_iso_ts(value: str) -> datetime | None:
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _expire_stale_open(
+    target: Path,
+    now_dt: datetime,
+    *,
+    age_seconds: int = DEFERRED_EXPIRY_AGE_SECONDS,
+) -> int:
+    """At-cap relief valve (Event 158): append a terminal
+    ``deferred_discovery_expiry`` record for every OPEN discovery older
+    than the age floor. Age comes from payload ``logged_at``, falling
+    back to the envelope's append ``ts`` (machine-written, always
+    present); an entry with neither parseable is expiry-eligible — an
+    unstampable entry must not jam a cap slot forever (Event 157
+    immortal-entry lesson, baked in from the start here). Drains ALL
+    stale entries in one pass — the cohort is bounded by the cap and a
+    full drain lets the SessionStart banner clear honestly. Returns the
+    count expired; errors propagate to the caller's guard."""
+    cutoff = now_dt - timedelta(seconds=age_seconds)
+    expired = 0
+    for env in open_deferred_discoveries(path=target):
+        payload = env.get("payload") if isinstance(env, dict) else None
+        payload = payload if isinstance(payload, dict) else {}
+        stamp = _parse_iso_ts(str(payload.get("logged_at") or ""))
+        if stamp is None:
+            stamp = _parse_iso_ts(str(env.get("ts") or ""))
+        if stamp is not None and stamp > cutoff:
+            continue
+        _chain_append(target, {
+            "type": DISCOVERY_EXPIRY_TYPE,
+            "ref": str(env.get("entry_hash") or ""),
+            "expired_at": now_dt.isoformat(),
+            "logged_at": payload.get("logged_at"),
+            "reason": "cap_relief",
+        })
+        expired += 1
+    return expired
+
+
+def _deferred_cap_admit(
+    target: Path, cap_value: int, now_dt: datetime
+) -> bool:
+    """Cap consult for the discovery write path. At cap, run the relief
+    valve then recount; True when there is room. A count error fails
+    toward admit — backpressure must never break Blueprint D's
+    bookkeeping (its writer already degrades gracefully)."""
+    try:
+        open_n = len(open_deferred_discoveries(path=target))
+    except Exception:
+        return True
+    if open_n < cap_value:
+        return True
+    try:
+        if _expire_stale_open(target, now_dt):
+            open_n = len(open_deferred_discoveries(path=target))
+    except Exception:
+        pass
+    return open_n < cap_value
 
 
 # ---------------------------------------------------------------------------
@@ -357,6 +549,9 @@ def write_deferred_discovery(
     dedup: bool = True,
     dedup_tail_n: int = DEFAULT_DEDUP_TAIL_N,
     dedup_desc_prefix: int = DEFAULT_DEDUP_DESC_PREFIX,
+    cap: int | None = None,
+    now: datetime | None = None,
+    skip_counter_path: Path | None = None,
 ) -> dict:
     """Append a deferred_discovery record. Type-tagged like
     ``write_protocol``; independent chain stream.
@@ -404,6 +599,22 @@ def write_deferred_discovery(
                     "matched_ts": existing.get("ts"),
                     "reason": "cp-dedup-01 suppression",
                 }
+    # Open-set backpressure + relief (Event 158). Consulted AFTER dedup
+    # so a suppressed duplicate never bumps the decline counter. At cap
+    # the relief valve first ages out open entries past the floor; if
+    # the set stays saturated the write declines with a marker dict
+    # (same tolerate-discarding contract as suppressed_duplicate).
+    now_dt = now or datetime.now(timezone.utc)
+    cap_value = _resolve_deferred_open_cap(cap)
+    if not _deferred_cap_admit(target, cap_value, now_dt):
+        _bump_deferred_skip_counter(
+            "cap_exceeded", now_dt, path=skip_counter_path
+        )
+        return {
+            "declined_at_cap": True,
+            "open_cap": cap_value,
+            "reason": "cap_exceeded",
+        }
     return _chain_append(target, payload)
 
 
@@ -493,10 +704,12 @@ def open_deferred_discoveries(*, path: Path | None = None) -> list[dict]:
 
     OPEN iff payload status is in ``OPEN_STATUSES`` (legacy records
     without a status count as open — the historical Blueprint-D writer
-    emitted none) AND no ``deferred_discovery_verdict`` record
-    references the discovery's ``entry_hash``. Single chain pass; the
-    SessionStart banner and ``episteme guide --deferred`` read this so
-    a verdicted finding stops re-firing every session.
+    emitted none) AND no ``deferred_discovery_verdict`` OR
+    ``deferred_discovery_expiry`` record references the discovery's
+    ``entry_hash`` (Event 158: an expiry closes like a verdict does).
+    Single chain pass; the SessionStart banner and ``episteme guide
+    --deferred`` read this so a verdicted finding stops re-firing every
+    session.
     """
     target = path if path is not None else _deferred_discoveries_path()
     discoveries: list[dict] = []
@@ -506,7 +719,7 @@ def open_deferred_discoveries(*, path: Path | None = None) -> list[dict]:
         if not isinstance(payload, dict):
             continue
         ptype = payload.get("type")
-        if ptype == DISCOVERY_VERDICT_TYPE:
+        if ptype in (DISCOVERY_VERDICT_TYPE, DISCOVERY_EXPIRY_TYPE):
             ref = payload.get("ref")
             if isinstance(ref, str) and ref:
                 verdicted.add(ref)
@@ -574,8 +787,8 @@ def append_discovery_verdict(
     if not matches:
         raise ChainError(
             f"no OPEN deferred discovery matches {ref!r} — it may "
-            "already be verdicted, or the ref is wrong "
-            "(see `episteme guide --deferred` for open entries)"
+            "already be verdicted or expired (cap relief), or the ref "
+            "is wrong (see `episteme guide --deferred` for open entries)"
         )
     if len(matches) > 1:
         raise ChainError(
@@ -583,12 +796,16 @@ def append_discovery_verdict(
             "use a longer prefix"
         )
     full_hash = str(matches[0]["entry_hash"])
-    return _chain_append(target, {
+    envelope = _chain_append(target, {
         "type": DISCOVERY_VERDICT_TYPE,
         "ref": full_hash,
         "verdict": verdict,
         "rationale": rationale,
     })
+    # Drain activity — reset the backpressure window (Event 158) so the
+    # banner's 'skipped since last drain' stays truthful.
+    _reset_deferred_skip_counter(datetime.now(timezone.utc))
+    return envelope
 
 
 # ---------------------------------------------------------------------------

--- a/core/hooks/_framework.py
+++ b/core/hooks/_framework.py
@@ -213,17 +213,23 @@ def _deferred_skip_counter_path() -> Path:
 def _resolve_deferred_open_cap(explicit: int | None = None) -> int:
     """Resolve the open-set cap. Precedence: explicit arg (test seam) >
     ``EPISTEME_DEFERRED_OPEN_CAP`` env var > ``DEFAULT_DEFERRED_OPEN_CAP``.
-    Non-parseable / negative values fall back to the default — a bad
-    knob must never break the write path. Never raises."""
+    Non-parseable / NON-POSITIVE values fall back to the default — a
+    bad knob must never break the write path, and unlike the spot-check
+    sampler (where cap=0 merely quiets sampling) a zero cap here would
+    silently drop architectural-debt records with the banner notice
+    suppressed (Event 158 review finding). Never raises."""
     if explicit is not None:
         try:
-            return max(0, int(explicit))
+            val = int(explicit)
         except (TypeError, ValueError):
             return DEFAULT_DEFERRED_OPEN_CAP
+        return val if val > 0 else DEFAULT_DEFERRED_OPEN_CAP
     raw = os.environ.get("EPISTEME_DEFERRED_OPEN_CAP", "").strip()
     if raw:
         try:
-            return max(0, int(raw))
+            val = int(raw)
+            if val > 0:
+                return val
         except ValueError:
             pass
     return DEFAULT_DEFERRED_OPEN_CAP
@@ -733,6 +739,75 @@ def open_deferred_discoveries(*, path: Path | None = None) -> list[dict]:
     ]
 
 
+def _discovery_ref_sets(target: Path) -> tuple[list[dict], set[str], set[str]]:
+    """Single chain pass → (open-shaped discovery envelopes,
+    verdict refs, expiry refs). Open-shaped = status pending/None;
+    callers apply the closing semantics they need."""
+    discoveries: list[dict] = []
+    verdict_refs: set[str] = set()
+    expiry_refs: set[str] = set()
+    for rec in _chain_iter(target, verify=True):
+        payload = rec.get("payload") if isinstance(rec, dict) else None
+        if not isinstance(payload, dict):
+            continue
+        ptype = payload.get("type")
+        if ptype == DISCOVERY_VERDICT_TYPE:
+            ref = payload.get("ref")
+            if isinstance(ref, str) and ref:
+                verdict_refs.add(ref)
+        elif ptype == DISCOVERY_EXPIRY_TYPE:
+            ref = payload.get("ref")
+            if isinstance(ref, str) and ref:
+                expiry_refs.add(ref)
+        elif ptype == DEFERRED_DISCOVERY_TYPE:
+            status = payload.get("status")
+            if status is None or status in OPEN_STATUSES:
+                discoveries.append(rec)
+    return discoveries, verdict_refs, expiry_refs
+
+
+def _verdictable_discoveries(*, path: Path | None = None) -> list[dict]:
+    """Discoveries an operator verdict may target: OPEN ones plus
+    expiry-closed ones with no verdict yet. An operator verdict
+    SUPERSEDES a machine expiry (Event 158 review — mirrors the Event
+    157 spot-check semantics): cap relief must not permanently block a
+    real disposition, especially the Event 152 ``accepted`` verdict
+    whose whole point is naming the cost of ignorance."""
+    target = path if path is not None else _deferred_discoveries_path()
+    discoveries, verdict_refs, _ = _discovery_ref_sets(target)
+    return [
+        d for d in discoveries
+        if str(d.get("entry_hash") or "") not in verdict_refs
+    ]
+
+
+def expired_unverdicted_count(*, path: Path | None = None) -> int:
+    """Count of discoveries machine-expired by cap relief with no
+    operator verdict recorded. Surfaced by the SessionStart banner and
+    ``episteme deferred list`` so mass expiry is never invisible
+    (Event 158 review)."""
+    target = path if path is not None else _deferred_discoveries_path()
+    discoveries, verdict_refs, expiry_refs = _discovery_ref_sets(target)
+    return sum(
+        1 for d in discoveries
+        if str(d.get("entry_hash") or "") in expiry_refs
+        and str(d.get("entry_hash") or "") not in verdict_refs
+    )
+
+
+def expired_unverdicted_discoveries(*, path: Path | None = None) -> list[dict]:
+    """The machine-expired, still-unverdicted discovery envelopes —
+    ``episteme deferred list --expired`` renders these with full refs so
+    the supersede path is actually reachable."""
+    target = path if path is not None else _deferred_discoveries_path()
+    discoveries, verdict_refs, expiry_refs = _discovery_ref_sets(target)
+    return [
+        d for d in discoveries
+        if str(d.get("entry_hash") or "") in expiry_refs
+        and str(d.get("entry_hash") or "") not in verdict_refs
+    ]
+
+
 def append_discovery_verdict(
     ref: str,
     verdict: str,
@@ -780,15 +855,19 @@ def append_discovery_verdict(
         _, _, bare = entry_hash.partition(":")
         return bool(bare) and bare.startswith(ref)
 
+    # Event 158 review: match against verdictable (open OR expiry-closed
+    # -but-unverdicted) discoveries — an operator verdict supersedes a
+    # machine expiry; only a prior operator verdict blocks.
     matches = [
-        d for d in open_deferred_discoveries(path=target)
+        d for d in _verdictable_discoveries(path=target)
         if _ref_matches(str(d.get("entry_hash") or ""))
     ]
     if not matches:
         raise ChainError(
-            f"no OPEN deferred discovery matches {ref!r} — it may "
-            "already be verdicted or expired (cap relief), or the ref "
-            "is wrong (see `episteme guide --deferred` for open entries)"
+            f"no verdictable deferred discovery matches {ref!r} — it "
+            "may already carry an operator verdict, or the ref is wrong "
+            "(open: `episteme deferred list` · machine-expired: "
+            "`episteme deferred list --expired`)"
         )
     if len(matches) > 1:
         raise ChainError(
@@ -1145,16 +1224,20 @@ def compact_deferred_discoveries(
                 f"before compaction."
             )
 
-        # Verdicts couple to discoveries by entry_hash (see § Resolution
-        # layer). A GENESIS rebuild recomputes every entry_hash, so any
-        # verdict ref would dangle and a resolved discovery would re-open —
-        # unless we (1) never drop a verdicted discovery as a duplicate, and
-        # (2) remap verdict refs old->new during the rebuild. Collect the
-        # referenced hashes first.
+        # Verdicts AND cap-relief expiries couple to discoveries by
+        # entry_hash (see § Resolution layer; Event 158 review finding —
+        # an unremapped expiry ref would dangle after the rebuild and a
+        # machine-expired discovery would silently RE-OPEN). A GENESIS
+        # rebuild recomputes every entry_hash, so any closing ref would
+        # dangle — unless we (1) never drop a closed discovery as a
+        # duplicate, and (2) remap closing refs old->new during the
+        # rebuild. Collect the referenced hashes first.
         verdict_refs: set[str] = set()
         for rec in parsed:
             payload = rec.get("payload")
-            if isinstance(payload, dict) and payload.get("type") == DISCOVERY_VERDICT_TYPE:
+            if isinstance(payload, dict) and payload.get("type") in (
+                DISCOVERY_VERDICT_TYPE, DISCOVERY_EXPIRY_TYPE
+            ):
                 ref = payload.get("ref")
                 if isinstance(ref, str) and ref:
                     verdict_refs.add(ref)
@@ -1219,7 +1302,9 @@ def compact_deferred_discoveries(
                     f"{target}: kept record missing payload / ts during rebuild "
                     f"(payload={type(payload).__name__}, ts={type(ts).__name__})"
                 )
-            if payload.get("type") == DISCOVERY_VERDICT_TYPE:
+            if payload.get("type") in (
+                DISCOVERY_VERDICT_TYPE, DISCOVERY_EXPIRY_TYPE
+            ):
                 old_ref = payload.get("ref")
                 if isinstance(old_ref, str) and old_ref in hash_remap:
                     payload = {**payload, "ref": hash_remap[old_ref]}

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -157,11 +157,29 @@ def _framework_digest_line() -> str | None:
         return None
     protocol_noun = "protocol" if since_last == 1 else "protocols"
     deferred_noun = "discovery" if pending_deferred == 1 else "discoveries"
-    return (
+    line = (
         f"framework: {since_last} {protocol_noun} synthesized since "
         f"last session ({total} total), {pending_deferred} deferred "
         f"{deferred_noun} pending"
     )
+    # Event 158 — at/over the open cap the discovery writer declines
+    # (relief valve permitting); surface the degradation instead of
+    # letting the ledger go silently lossy. Below cap the line is
+    # byte-identical to before. Any cap-read failure degrades to the
+    # plain line.
+    try:
+        cap = _framework._resolve_deferred_open_cap()
+        if cap and pending_deferred >= cap:
+            skipped = _framework.read_deferred_skip_counter().get(
+                "skipped_count", 0
+            )
+            line += (
+                f" — queue AT CAP ({cap}): writes paused, "
+                f"{skipped} record(s) skipped since last drain"
+            )
+    except Exception:
+        pass
+    return line
 
 
 _E1_PROTOCOL_FLOOR = 3

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -164,9 +164,21 @@ def _framework_digest_line() -> str | None:
     )
     # Event 158 — at/over the open cap the discovery writer declines
     # (relief valve permitting); surface the degradation instead of
-    # letting the ledger go silently lossy. Below cap the line is
-    # byte-identical to before. Any cap-read failure degrades to the
-    # plain line.
+    # letting the ledger go silently lossy. Machine-expired findings are
+    # ALSO surfaced so a mass expiry is never invisible (review
+    # finding): they left the open count without any operator judgment.
+    # Below cap with zero expiries the line is byte-identical to
+    # before. Any read failure degrades to the plain line.
+    try:
+        expired_n = _framework.expired_unverdicted_count()
+        if expired_n:
+            noun = "y" if expired_n == 1 else "ies"
+            line += (
+                f", {expired_n} expired-unreviewed discover{noun} "
+                f"(`episteme deferred list --expired`)"
+            )
+    except Exception:
+        pass
     try:
         cap = _framework._resolve_deferred_open_cap()
         if cap and pending_deferred >= cap:

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -5139,7 +5139,12 @@ def _deferred_dispatch(args) -> int:
     from _chain import ChainError  # type: ignore  # noqa: E402  # pyright: ignore[reportMissingImports]
 
     if args.deferred_action == "list":
-        envelopes = _framework.open_deferred_discoveries()
+        if getattr(args, "deferred_expired", False):
+            # Event 158 — machine-expired (cap relief), still
+            # verdictable: an operator verdict supersedes the expiry.
+            envelopes = _framework.expired_unverdicted_discoveries()
+        else:
+            envelopes = _framework.open_deferred_discoveries()
         # Piping into head is the expected drain workflow; a closed
         # stdout must not stack-trace (observed via a commit-hook
         # pipeline on 2026-07-03).
@@ -5183,10 +5188,23 @@ def _deferred_print_list(args, envelopes: list) -> int:
         desc = str(payload.get("description") or "")[:100]
         print(f"{str(env.get('entry_hash') or '')[:12]}  "
               f"{str(env.get('ts') or '')[:10]}  {desc}")
+    expired_view = getattr(args, "deferred_expired", False)
+    state = "expired-unreviewed" if expired_view else "open"
     noun = "discovery" if len(envelopes) == 1 else "discoveries"
-    print(f"\n{len(envelopes)} open deferred {noun}. Resolve with: "
+    print(f"\n{len(envelopes)} {state} deferred {noun}. Resolve with: "
           f"episteme deferred resolve <ref> --verdict "
           f"resolved OR noise OR duplicate OR accepted --why '...'")
+    if not expired_view:
+        # Surface machine-expired findings so cap relief is never an
+        # invisible loss (Event 158 review finding).
+        try:
+            import _framework  # type: ignore  # pyright: ignore[reportMissingImports]
+            expired_n = _framework.expired_unverdicted_count()
+            if expired_n:
+                print(f"{expired_n} machine-expired (cap relief), still "
+                      f"verdictable: episteme deferred list --expired")
+        except Exception:
+            pass
     return 0
 
 
@@ -6284,6 +6302,10 @@ def build_parser() -> argparse.ArgumentParser:
     deferred_list.add_argument(
         "--json", dest="deferred_json", action="store_true",
         help="Machine-readable output",
+    )
+    deferred_list.add_argument(
+        "--expired", dest="deferred_expired", action="store_true",
+        help="Show machine-expired (cap relief) discoveries instead of open ones — still verdictable; an operator verdict supersedes the expiry",
     )
     deferred_resolve = deferred_sub.add_parser(
         "resolve", help="Record a verdict for an open discovery (append-only)"

--- a/tests/test_chain_and_framework.py
+++ b/tests/test_chain_and_framework.py
@@ -804,6 +804,148 @@ def _write_cp5_prechain_fixture(path: Path, count: int = 3) -> None:
     path.write_text("\n".join(json.dumps(r) for r in recs) + "\n")
 
 
+class DeferredCapRelief(unittest.TestCase):
+    """Event 158 — the deferred-discovery queue gets the Event 157
+    drain: open-cap with at-cap expiry relief (terminal chained
+    ``deferred_discovery_expiry`` records), a decline counter, and a
+    truthful reset on operator verdict."""
+
+    def test_at_cap_declines_and_bumps_counter(self):
+        with EphemeralHome():
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "fresh finding one",
+                 "logged_at": datetime.now(timezone.utc).isoformat()}
+            )
+            res = _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "distinct second finding",
+                 "logged_at": datetime.now(timezone.utc).isoformat()},
+                cap=1,
+            )
+            self.assertTrue(res.get("declined_at_cap"))
+            self.assertEqual(len(_framework.open_deferred_discoveries()), 1)
+            self.assertEqual(
+                _framework.read_deferred_skip_counter()["skipped_count"], 1
+            )
+
+    def test_at_cap_stale_relief_then_appends(self):
+        with EphemeralHome():
+            old = (
+                datetime.now(timezone.utc) - timedelta(days=31)
+            ).isoformat()
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "ancient finding", "logged_at": old}
+            )
+            res = _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "distinct new finding",
+                 "logged_at": datetime.now(timezone.utc).isoformat()},
+                cap=1,
+            )
+            self.assertIn("entry_hash", res)
+            open_now = _framework.open_deferred_discoveries()
+            self.assertEqual(len(open_now), 1)
+            self.assertEqual(
+                open_now[0]["payload"]["description"], "distinct new finding"
+            )
+            chains = _framework.verify_chains()
+            self.assertTrue(chains["deferred_discoveries"].intact)
+
+    def test_expiry_uses_envelope_ts_when_logged_at_missing(self):
+        # Entries without a payload stamp age by the envelope's append
+        # ts (machine-written, always present) — a young entry without
+        # logged_at must NOT be expired.
+        with EphemeralHome():
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "young unstamped finding"}
+            )
+            res = _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "distinct newer finding",
+                 "logged_at": datetime.now(timezone.utc).isoformat()},
+                cap=1,
+            )
+            self.assertTrue(res.get("declined_at_cap"))
+            self.assertEqual(len(_framework.open_deferred_discoveries()), 1)
+
+    def test_expired_discovery_not_verdictable(self):
+        with EphemeralHome():
+            old = (
+                datetime.now(timezone.utc) - timedelta(days=31)
+            ).isoformat()
+            env = _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "ancient finding", "logged_at": old}
+            )
+            expired_hash = env["entry_hash"]
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "distinct new finding",
+                 "logged_at": datetime.now(timezone.utc).isoformat()},
+                cap=1,
+            )
+            with self.assertRaises(_framework.ChainError):
+                _framework.append_discovery_verdict(
+                    expired_hash, "resolved",
+                    "attempting to verdict an expiry-closed entry",
+                )
+
+    def test_blueprint_d_writer_does_not_count_declined_entries(self):
+        from core.hooks import _blueprint_d  # pyright: ignore[reportAttributeAccessIssue]
+        with EphemeralHome():
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "fresh occupant of the only cap slot",
+                 "logged_at": datetime.now(timezone.utc).isoformat()}
+            )
+            surface = {
+                "flaw_classification": "doc-code-drift",
+                "deferred_discoveries": [
+                    {"description": "a genuinely distinct adjacent gap",
+                     "observable": "obs", "log_only_rationale": "why"},
+                ],
+            }
+            with patch.dict(
+                os.environ, {"EPISTEME_DEFERRED_OPEN_CAP": "1"}
+            ):
+                count = _blueprint_d.write_cascade_deferred_discoveries(
+                    surface, correlation_id="cid-bd", op_label="git push",
+                    cwd=Path("."),
+                )
+            self.assertEqual(count, 0)
+            self.assertEqual(len(_framework.open_deferred_discoveries()), 1)
+            self.assertEqual(
+                _framework.read_deferred_skip_counter()["skipped_count"], 1
+            )
+
+    def test_verdict_resets_deferred_skip_counter(self):
+        with EphemeralHome():
+            env = _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "fresh finding one",
+                 "logged_at": datetime.now(timezone.utc).isoformat()}
+            )
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "distinct second finding",
+                 "logged_at": datetime.now(timezone.utc).isoformat()},
+                cap=1,
+            )
+            self.assertEqual(
+                _framework.read_deferred_skip_counter()["skipped_count"], 1
+            )
+            _framework.append_discovery_verdict(
+                env["entry_hash"], "resolved",
+                "drained by operator in test — resets the window",
+            )
+            self.assertEqual(
+                _framework.read_deferred_skip_counter()["skipped_count"], 0
+            )
+
+
 class Cp5RetroactiveUpgrade(unittest.TestCase):
     def test_upgrade_wraps_prechain_records_in_cp7_envelope(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_chain_and_framework.py
+++ b/tests/test_chain_and_framework.py
@@ -871,7 +871,11 @@ class DeferredCapRelief(unittest.TestCase):
             self.assertTrue(res.get("declined_at_cap"))
             self.assertEqual(len(_framework.open_deferred_discoveries()), 1)
 
-    def test_expired_discovery_not_verdictable(self):
+    def test_operator_verdict_supersedes_expiry(self):
+        # Event 158 review — cap relief must not permanently block a
+        # real disposition (the Event 152 `accepted` verdict names the
+        # cost of ignorance; a machine expiry cannot). Mirrors the
+        # Event 157 spot-check semantics.
         with EphemeralHome():
             old = (
                 datetime.now(timezone.utc) - timedelta(days=31)
@@ -887,11 +891,127 @@ class DeferredCapRelief(unittest.TestCase):
                  "logged_at": datetime.now(timezone.utc).isoformat()},
                 cap=1,
             )
+            self.assertEqual(
+                _framework.expired_unverdicted_count(), 1
+            )
+            verdict_env = _framework.append_discovery_verdict(
+                expired_hash, "accepted",
+                "real finding, consciously deferred — cost of ignorance named",
+            )
+            self.assertEqual(
+                verdict_env["payload"]["verdict"], "accepted"
+            )
+            # Verdicted now — no longer open, no longer expired-pending.
+            self.assertEqual(len(_framework.open_deferred_discoveries()), 1)
+            self.assertEqual(_framework.expired_unverdicted_count(), 0)
+            # A second verdict on the same entry is still rejected.
             with self.assertRaises(_framework.ChainError):
                 _framework.append_discovery_verdict(
-                    expired_hash, "resolved",
-                    "attempting to verdict an expiry-closed entry",
+                    expired_hash, "resolved", "double verdict must reject"
                 )
+
+    def test_compaction_preserves_expiry_closure(self):
+        # Event 158 review BLOCKING finding: compaction rebuilds the
+        # chain from GENESIS; an unremapped expiry ref would dangle and
+        # silently RE-OPEN a machine-expired discovery. The dropped
+        # duplicate sits BEFORE the expired entry so its hash shifts.
+        with EphemeralHome():
+            now = datetime.now(timezone.utc).isoformat()
+            old = (
+                datetime.now(timezone.utc) - timedelta(days=31)
+            ).isoformat()
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "config-gap",
+                 "description": "dup family finding", "logged_at": now}
+            )
+            # Duplicate of the first — dedup only scans a tail window,
+            # so force-append it to guarantee an open duplicate exists.
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "config-gap",
+                 "description": "dup family finding", "logged_at": now},
+                dedup=False,
+            )
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "doc-code-drift",
+                 "description": "ancient distinct finding",
+                 "logged_at": old}
+            )
+            # Trigger relief: the ancient entry expires.
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "other",
+                 "description": "distinct trigger finding",
+                 "logged_at": now},
+                cap=2,
+            )
+            open_before = {
+                e["payload"]["description"]
+                for e in _framework.open_deferred_discoveries()
+            }
+            self.assertNotIn("ancient distinct finding", open_before)
+            result = _framework.compact_deferred_discoveries()
+            self.assertEqual(result.status, "compacted")
+            open_after = {
+                e["payload"]["description"]
+                for e in _framework.open_deferred_discoveries()
+            }
+            self.assertEqual(open_before, open_after)
+            self.assertNotIn("ancient distinct finding", open_after)
+            chains = _framework.verify_chains()
+            self.assertTrue(chains["deferred_discoveries"].intact)
+
+    def test_expiry_via_old_envelope_ts_fallback(self):
+        # The live-ledger legacy path: no payload logged_at at all, but
+        # an old envelope append ts — MUST be expiry-eligible (this is
+        # the shape of the real 178-entry backlog).
+        with EphemeralHome():
+            old_ts = (
+                datetime.now(timezone.utc) - timedelta(days=31)
+            ).isoformat()
+            _framework._chain_append(
+                _framework._deferred_discoveries_path(),
+                {"type": "deferred_discovery",
+                 "flaw_classification": "other",
+                 "description": "legacy unstamped finding",
+                 "status": "pending"},
+                ts=old_ts,
+            )
+            res = _framework.write_deferred_discovery(
+                {"flaw_classification": "config-gap",
+                 "description": "distinct fresh finding",
+                 "logged_at": datetime.now(timezone.utc).isoformat()},
+                cap=1,
+            )
+            self.assertIn("entry_hash", res)
+            open_now = _framework.open_deferred_discoveries()
+            self.assertEqual(len(open_now), 1)
+            self.assertEqual(
+                open_now[0]["payload"]["description"],
+                "distinct fresh finding",
+            )
+
+    def test_non_positive_cap_falls_back_to_default(self):
+        # Event 158 review: a fat-fingered 0/-1 knob must not silently
+        # freeze the write path with the banner suppressed.
+        self.assertEqual(
+            _framework._resolve_deferred_open_cap(0),
+            _framework.DEFAULT_DEFERRED_OPEN_CAP,
+        )
+        self.assertEqual(
+            _framework._resolve_deferred_open_cap(-5),
+            _framework.DEFAULT_DEFERRED_OPEN_CAP,
+        )
+        with patch.dict(os.environ, {"EPISTEME_DEFERRED_OPEN_CAP": "0"}):
+            self.assertEqual(
+                _framework._resolve_deferred_open_cap(),
+                _framework.DEFAULT_DEFERRED_OPEN_CAP,
+            )
+        with patch.dict(os.environ, {"EPISTEME_DEFERRED_OPEN_CAP": "-1"}):
+            self.assertEqual(
+                _framework._resolve_deferred_open_cap(),
+                _framework.DEFAULT_DEFERRED_OPEN_CAP,
+            )
+        with patch.dict(os.environ, {"EPISTEME_DEFERRED_OPEN_CAP": "7"}):
+            self.assertEqual(_framework._resolve_deferred_open_cap(), 7)
 
     def test_blueprint_d_writer_does_not_count_declined_entries(self):
         from core.hooks import _blueprint_d  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/test_deferred_resolution.py
+++ b/tests/test_deferred_resolution.py
@@ -391,7 +391,7 @@ class CliDrain(unittest.TestCase):
             "--verdict", "noise", "--why", "no such reference exists",
         ])
         self.assertEqual(rc, 1)
-        self.assertIn("no OPEN deferred discovery matches", err)
+        self.assertIn("no verdictable deferred discovery matches", err)
 
 
 if __name__ == "__main__":

--- a/tests/test_session_context_deferred_cap.py
+++ b/tests/test_session_context_deferred_cap.py
@@ -1,9 +1,11 @@
 """Event 158 — deferred-discovery cap surfacing in the SessionStart banner.
 
 Covers the extension of ``_framework_digest_line()``: below the open cap
-the line is byte-identical to before; at/over cap it appends the
-degradation notice (writes paused + skipped count); a cap-read failure
-degrades to the plain line rather than killing the digest.
+with zero machine-expiries the line is byte-identical to before; at/over
+cap it appends the degradation notice (writes paused + skipped count);
+machine-expired findings surface their own count so cap relief is never
+an invisible loss; a cap-read failure degrades to the plain line rather
+than killing the digest.
 """
 from __future__ import annotations
 
@@ -29,17 +31,37 @@ def _open_stub(n: int) -> list[dict]:
 
 
 class DeferredCapLineTests(unittest.TestCase):
-    def test_below_cap_line_unchanged(self):
+    def _line(self, *, open_n, cap=100, skipped=0, expired=0,
+              cap_error=False):
+        cap_mock = (
+            mock.patch.object(
+                _framework, "_resolve_deferred_open_cap",
+                side_effect=RuntimeError("boom"),
+            )
+            if cap_error
+            else mock.patch.object(
+                _framework, "_resolve_deferred_open_cap", return_value=cap
+            )
+        )
         with mock.patch.object(_framework, "list_protocols", return_value=[]), \
              mock.patch.object(
                  _framework, "open_deferred_discoveries",
-                 return_value=_open_stub(28),
+                 return_value=_open_stub(open_n),
              ), \
              mock.patch.object(
-                 _framework, "_resolve_deferred_open_cap", return_value=100
+                 _framework, "expired_unverdicted_count",
+                 return_value=expired,
+             ), \
+             cap_mock, \
+             mock.patch.object(
+                 _framework, "read_deferred_skip_counter",
+                 return_value={"skipped_count": skipped},
              ), \
              mock.patch.object(sc, "_read_last_session_ts", return_value=None):
-            line = sc._framework_digest_line()
+            return sc._framework_digest_line()
+
+    def test_below_cap_line_unchanged(self):
+        line = self._line(open_n=28)
         self.assertEqual(
             line,
             "framework: 0 protocols synthesized since last session "
@@ -47,38 +69,31 @@ class DeferredCapLineTests(unittest.TestCase):
         )
 
     def test_at_cap_appends_degradation_notice(self):
-        with mock.patch.object(_framework, "list_protocols", return_value=[]), \
-             mock.patch.object(
-                 _framework, "open_deferred_discoveries",
-                 return_value=_open_stub(100),
-             ), \
-             mock.patch.object(
-                 _framework, "_resolve_deferred_open_cap", return_value=100
-             ), \
-             mock.patch.object(
-                 _framework, "read_deferred_skip_counter",
-                 return_value={"skipped_count": 7},
-             ), \
-             mock.patch.object(sc, "_read_last_session_ts", return_value=None):
-            line = sc._framework_digest_line()
+        line = self._line(open_n=100, cap=100, skipped=7)
         assert line is not None
         self.assertIn("100 deferred discoveries pending", line)
         self.assertIn("queue AT CAP (100)", line)
         self.assertIn("writes paused", line)
         self.assertIn("7 record(s) skipped", line)
 
+    def test_over_cap_also_notices(self):
+        line = self._line(open_n=178, cap=100, skipped=42)
+        assert line is not None
+        self.assertIn("178 deferred discoveries pending", line)
+        self.assertIn("AT CAP (100)", line)
+        self.assertIn("42 record(s) skipped", line)
+
+    def test_expired_count_surfaces(self):
+        # Machine expiry must never be invisible (Event 158 review).
+        line = self._line(open_n=5, expired=173)
+        assert line is not None
+        self.assertIn("5 deferred discoveries pending", line)
+        self.assertIn("173 expired-unreviewed discoveries", line)
+        self.assertIn("--expired", line)
+        self.assertNotIn("AT CAP", line)
+
     def test_cap_read_failure_degrades_to_plain_line(self):
-        with mock.patch.object(_framework, "list_protocols", return_value=[]), \
-             mock.patch.object(
-                 _framework, "open_deferred_discoveries",
-                 return_value=_open_stub(150),
-             ), \
-             mock.patch.object(
-                 _framework, "_resolve_deferred_open_cap",
-                 side_effect=RuntimeError("boom"),
-             ), \
-             mock.patch.object(sc, "_read_last_session_ts", return_value=None):
-            line = sc._framework_digest_line()
+        line = self._line(open_n=150, cap_error=True)
         assert line is not None
         self.assertIn("150 deferred discoveries pending", line)
         self.assertNotIn("AT CAP", line)

--- a/tests/test_session_context_deferred_cap.py
+++ b/tests/test_session_context_deferred_cap.py
@@ -1,0 +1,88 @@
+"""Event 158 — deferred-discovery cap surfacing in the SessionStart banner.
+
+Covers the extension of ``_framework_digest_line()``: below the open cap
+the line is byte-identical to before; at/over cap it appends the
+degradation notice (writes paused + skipped count); a cap-read failure
+degrades to the plain line rather than killing the digest.
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from core.hooks import session_context as sc  # pyright: ignore[reportAttributeAccessIssue]
+
+# The hook resolves `import _framework` as a TOP-LEVEL module via the
+# hooks dir on sys.path — mirror that so mock.patch.object targets the
+# same cached module object the hook uses.
+_HOOKS_DIR = Path(__file__).resolve().parents[1] / "core" / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+import _framework  # noqa: E402  # pyright: ignore[reportMissingImports]
+
+
+def _open_stub(n: int) -> list[dict]:
+    return [{"payload": {"type": "deferred_discovery"}} for _ in range(n)]
+
+
+class DeferredCapLineTests(unittest.TestCase):
+    def test_below_cap_line_unchanged(self):
+        with mock.patch.object(_framework, "list_protocols", return_value=[]), \
+             mock.patch.object(
+                 _framework, "open_deferred_discoveries",
+                 return_value=_open_stub(28),
+             ), \
+             mock.patch.object(
+                 _framework, "_resolve_deferred_open_cap", return_value=100
+             ), \
+             mock.patch.object(sc, "_read_last_session_ts", return_value=None):
+            line = sc._framework_digest_line()
+        self.assertEqual(
+            line,
+            "framework: 0 protocols synthesized since last session "
+            "(0 total), 28 deferred discoveries pending",
+        )
+
+    def test_at_cap_appends_degradation_notice(self):
+        with mock.patch.object(_framework, "list_protocols", return_value=[]), \
+             mock.patch.object(
+                 _framework, "open_deferred_discoveries",
+                 return_value=_open_stub(100),
+             ), \
+             mock.patch.object(
+                 _framework, "_resolve_deferred_open_cap", return_value=100
+             ), \
+             mock.patch.object(
+                 _framework, "read_deferred_skip_counter",
+                 return_value={"skipped_count": 7},
+             ), \
+             mock.patch.object(sc, "_read_last_session_ts", return_value=None):
+            line = sc._framework_digest_line()
+        assert line is not None
+        self.assertIn("100 deferred discoveries pending", line)
+        self.assertIn("queue AT CAP (100)", line)
+        self.assertIn("writes paused", line)
+        self.assertIn("7 record(s) skipped", line)
+
+    def test_cap_read_failure_degrades_to_plain_line(self):
+        with mock.patch.object(_framework, "list_protocols", return_value=[]), \
+             mock.patch.object(
+                 _framework, "open_deferred_discoveries",
+                 return_value=_open_stub(150),
+             ), \
+             mock.patch.object(
+                 _framework, "_resolve_deferred_open_cap",
+                 side_effect=RuntimeError("boom"),
+             ), \
+             mock.patch.object(sc, "_read_last_session_ts", return_value=None):
+            line = sc._framework_digest_line()
+        assert line is not None
+        self.assertIn("150 deferred discoveries pending", line)
+        self.assertNotIn("AT CAP", line)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Closes audit Finding 3 (2026-07-20 governance-closure audit): the deferred-discovery ledger repeated the pre-E148 spot-check shape — Blueprint D auto-enqueues on the live write path, the only drain is the manual verdict CLI, no cap — 178 open at audit time, 1,208 records historically. This generalizes the E148/E157 lesson to the queue *class*, not just the one instance.

## Changes

- **Open-set cap** — `DEFAULT_DEFERRED_OPEN_CAP` (100, env `EPISTEME_DEFERRED_OPEN_CAP`, non-positive values fall back per docstring) consulted in `write_deferred_discovery` after dedup; declines return a `declined_at_cap` marker and bump `deferred_skipped.json`; Blueprint D stops counting declined writes.
- **At-cap relief** — open entries older than `DEFERRED_EXPIRY_AGE_SECONDS` (30d; architectural debt gets a longer window than the spot-check queue's 7d) age out as terminal chained `deferred_discovery_expiry` records. Age = payload `logged_at` → envelope `ts` fallback → neither-parseable is eligible (E157 immortal-entry lesson baked in; the envelope-ts path is the real 178-entry backlog's shape, pinned by test).
- **Verdict supersedes expiry** (review round) — cap relief never blocks a real disposition; the E152 `accepted` verdict remains recordable on an aged-out finding. Only a prior operator verdict blocks.
- **Expiry is never invisible** (review round) — SessionStart banner surfaces an expired-unreviewed count + recovery command; `episteme deferred list` gains a footer pointer and `--expired` view with full refs.
- **Compaction integrity** (review round, BLOCKING fix) — `compact_deferred_discoveries` now protects and remaps expiry refs exactly like verdict refs; previously a rebuild dangled them and silently re-opened machine-expired findings (reproduced by the independent reviewer).
- **Banner** — framework digest line gains the AT CAP suffix mirroring the E148 spot-check notice; byte-identical below cap with zero expiries.

## Verification

- Suite: **1702 passed + 93 subtests, 0 failed** (+13 new tests over Event 157's baseline).
- End-to-end (sandboxed `EPISTEME_HOME`, real hooks + CLI): SessionStart hook renders AT CAP and expired-count lines and clears them after drain; a real at-cap write expired a 31-day entry and still declined at the strict bound; `deferred resolve` reset the counter to 0; `--expired` → `resolve --verdict accepted` superseded a machine expiry live; double verdict rejected.
- Independent adversarial review (separate context): 1 blocking + 2 should-fix findings — all fixed and re-verified; reviewer's perf disconfirmation run measured first-firing mass-expiry at ~69ms on a 586-line/178-open replica (accepted one-time cost).

## Notes

- First live at-cap firing will mass-expire the aged cohort of the real 178-open ledger — chained, surfaced in the banner and `deferred list --expired`, and each entry remains operator-verdictable (supersede).