### PR TITLE
feat(sync): Event 159 — deploy layer cleans up after itself (manifest-based orphan prune)

### DIFF
--- a/src/episteme/adapters/claude.py
+++ b/src/episteme/adapters/claude.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -427,6 +428,55 @@ def read_sync_meta(claude_root: Path | None = None) -> dict:
         return {}
 
 
+def prune_orphaned_deploy_copies(
+    claude_root: Path,
+    prior_meta: dict,
+    *,
+    current_skills: set[str],
+    current_agents: set[str],
+) -> list[str]:
+    """Event 159 — prune deployed skill/agent copies whose repo source
+    was removed. Positive-system ownership: ONLY names the PRIOR sync
+    manifest recorded as deployed are candidates; operator-authored
+    entries under ``~/.claude/{skills,agents}`` were never manifested
+    and are structurally untouchable. A candidate absent from the
+    CURRENT managed set lost its repo source — the deployed copy goes
+    (sources are git-history-recoverable, so this is reversible by
+    construction). A pre-E159 sidecar without the manifest fields
+    prunes nothing: the first sync after upgrade only RECORDS the
+    manifest. Returns pruned paths; never raises."""
+
+    def _safe_name(name: str) -> bool:
+        return bool(name) and "/" not in name and "\\" not in name and name not in {".", ".."}
+
+    pruned: list[str] = []
+    try:
+        prior_skills = prior_meta.get("deployed_skills")
+        if isinstance(prior_skills, list):
+            for name in sorted({str(n) for n in prior_skills} - current_skills):
+                if not _safe_name(name):
+                    continue
+                target = claude_root / "skills" / name
+                if target.is_dir():
+                    shutil.rmtree(target, ignore_errors=True)
+                    pruned.append(str(target))
+        prior_agents = prior_meta.get("deployed_agents")
+        if isinstance(prior_agents, list):
+            for name in sorted({str(n) for n in prior_agents} - current_agents):
+                if not _safe_name(name):
+                    continue
+                target = claude_root / "agents" / name
+                if target.is_file():
+                    try:
+                        target.unlink()
+                    except OSError:
+                        continue
+                    pruned.append(str(target))
+    except Exception:
+        pass
+    return pruned
+
+
 def sync(governance_mode: str = "balanced") -> None:
     claude_root = _cli.HOME / ".claude"
 
@@ -451,22 +501,43 @@ def sync(governance_mode: str = "balanced") -> None:
     merged["hooks"] = dedupe_hooks_map(merged.get("hooks", {}))
     _cli._write_text(settings_path, json.dumps(merged, indent=2) + "\n")
 
-    for agent_file in (_cli.REPO_ROOT / "core" / "agents").glob("*.md"):
+    agent_files = sorted((_cli.REPO_ROOT / "core" / "agents").glob("*.md"))
+    for agent_file in agent_files:
         _cli._copy_file(agent_file, claude_root / "agents" / agent_file.name)
 
-    for skill_dir in _cli._managed_skills():
+    managed_skill_dirs = _cli._managed_skills()
+    for skill_dir in managed_skill_dirs:
         _cli._copy_tree(skill_dir, claude_root / "skills" / skill_dir.name)
+
+    # Event 159 — the deploy layer cleans up after itself: prune deployed
+    # copies whose repo source is gone, using the PRIOR sync's manifest
+    # as the ownership record. Read the prior sidecar BEFORE rewriting it.
+    deployed_skills = sorted(d.name for d in managed_skill_dirs)
+    deployed_agents = sorted(f.name for f in agent_files)
+    prior_meta = read_sync_meta(claude_root)
+    pruned = prune_orphaned_deploy_copies(
+        claude_root,
+        prior_meta,
+        current_skills=set(deployed_skills),
+        current_agents=set(deployed_agents),
+    )
+    for pruned_path in pruned:
+        print(f"  - pruned orphaned deploy copy: {pruned_path}")
 
     # Event 150 — record which governance pack this deployment carries so
     # the SessionStart self-heal can re-sync faithfully on registration
     # drift. Without the sidecar the pack is unrecoverable from
     # settings.json alone, and guessing could silently downgrade strict.
+    # Event 159 extends it with the deployed manifest the next sync's
+    # prune consults (the E150 reader ignores unknown fields).
     _cli._write_text(
         claude_root / SYNC_META_FILENAME,
         json.dumps(
             {
                 "governance_pack": (governance_mode or "balanced").strip().lower(),
                 "synced_at": datetime.now(timezone.utc).isoformat(),
+                "deployed_skills": deployed_skills,
+                "deployed_agents": deployed_agents,
             },
             indent=2,
         )
@@ -478,6 +549,7 @@ __all__ = [
     "sync",
     "settings_in_sync",
     "read_sync_meta",
+    "prune_orphaned_deploy_copies",
     "SYNC_META_FILENAME",
     "build_settings",
     "render_user_claude_md",

--- a/src/episteme/adapters/claude.py
+++ b/src/episteme/adapters/claude.py
@@ -428,6 +428,80 @@ def read_sync_meta(claude_root: Path | None = None) -> dict:
         return {}
 
 
+def _safe_name(name: str) -> bool:
+    return bool(name) and "/" not in name and "\\" not in name and name not in {".", ".."}
+
+
+def prune_candidates(
+    claude_root: Path,
+    prior_meta: dict,
+    *,
+    current_skills: set[str],
+    current_agents: set[str],
+) -> list[Path]:
+    """Shared candidate computation for ``sync()`` and ``sync --check``
+    (Event 159 review: the dry-run must surface deletions too).
+
+    Positive-system ownership: ONLY names the PRIOR sync manifest
+    recorded as deployed are candidates; operator-authored entries were
+    never manifested and are structurally untouchable. Guards, each a
+    named review finding: traversal-shaped names skipped; a candidate
+    whose name casefolds onto a CURRENTLY-wanted name is skipped (on a
+    case-insensitive filesystem the case-variant aliases the wanted
+    copy — deleting it would delete the wanted skill); symlinks are
+    skipped (sync never deploys symlinks, so a symlink under a
+    manifested name is operator-authored)."""
+    out: list[Path] = []
+    skills_cf = {c.casefold() for c in current_skills}
+    agents_cf = {c.casefold() for c in current_agents}
+    prior_skills = prior_meta.get("deployed_skills")
+    if isinstance(prior_skills, list):
+        for name in sorted({str(n) for n in prior_skills} - current_skills):
+            if not _safe_name(name) or name.casefold() in skills_cf:
+                continue
+            target = claude_root / "skills" / name
+            if target.is_symlink():
+                continue
+            if target.is_dir():
+                out.append(target)
+    prior_agents = prior_meta.get("deployed_agents")
+    if isinstance(prior_agents, list):
+        for name in sorted({str(n) for n in prior_agents} - current_agents):
+            if not _safe_name(name) or name.casefold() in agents_cf:
+                continue
+            target = claude_root / "agents" / name
+            if target.is_symlink():
+                continue
+            if target.is_file():
+                out.append(target)
+    return out
+
+
+def _archive_verbatim(target: Path, claude_root: Path) -> bool:
+    """[K] archive-verbatim before deleting a file without version
+    history: a formerly-managed deployed copy may carry operator
+    hand-edits that exist nowhere else (Event 159 review — git history
+    only recovers the pristine source). Copies into
+    ``~/.claude/_archive/<date>/pruned-deploy-copies/``. Returns False
+    on any failure — the caller must then SKIP the deletion."""
+    try:
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        base = claude_root / "_archive" / stamp / "pruned-deploy-copies"
+        base.mkdir(parents=True, exist_ok=True)
+        dest = base / target.name
+        n = 1
+        while dest.exists():
+            dest = base / f"{target.name}.{n}"
+            n += 1
+        if target.is_dir():
+            shutil.copytree(target, dest)
+        else:
+            shutil.copy2(target, dest)
+        return True
+    except Exception:
+        return False
+
+
 def prune_orphaned_deploy_copies(
     claude_root: Path,
     prior_meta: dict,
@@ -436,42 +510,29 @@ def prune_orphaned_deploy_copies(
     current_agents: set[str],
 ) -> list[str]:
     """Event 159 — prune deployed skill/agent copies whose repo source
-    was removed. Positive-system ownership: ONLY names the PRIOR sync
-    manifest recorded as deployed are candidates; operator-authored
-    entries under ``~/.claude/{skills,agents}`` were never manifested
-    and are structurally untouchable. A candidate absent from the
-    CURRENT managed set lost its repo source — the deployed copy goes
-    (sources are git-history-recoverable, so this is reversible by
-    construction). A pre-E159 sidecar without the manifest fields
-    prunes nothing: the first sync after upgrade only RECORDS the
-    manifest. Returns pruned paths; never raises."""
-
-    def _safe_name(name: str) -> bool:
-        return bool(name) and "/" not in name and "\\" not in name and name not in {".", ".."}
-
+    was removed. Candidates come from ``prune_candidates`` (positive-
+    system ownership + traversal / case-alias / symlink guards); each
+    is archived verbatim before deletion, and a failed archive skips
+    the deletion — never delete what could not be archived. A pre-E159
+    sidecar without the manifest fields prunes nothing: the first sync
+    after upgrade only RECORDS the manifest. Returns pruned paths;
+    never raises."""
     pruned: list[str] = []
     try:
-        prior_skills = prior_meta.get("deployed_skills")
-        if isinstance(prior_skills, list):
-            for name in sorted({str(n) for n in prior_skills} - current_skills):
-                if not _safe_name(name):
+        for target in prune_candidates(
+            claude_root, prior_meta,
+            current_skills=current_skills, current_agents=current_agents,
+        ):
+            if not _archive_verbatim(target, claude_root):
+                continue
+            if target.is_dir():
+                shutil.rmtree(target, ignore_errors=True)
+            else:
+                try:
+                    target.unlink()
+                except OSError:
                     continue
-                target = claude_root / "skills" / name
-                if target.is_dir():
-                    shutil.rmtree(target, ignore_errors=True)
-                    pruned.append(str(target))
-        prior_agents = prior_meta.get("deployed_agents")
-        if isinstance(prior_agents, list):
-            for name in sorted({str(n) for n in prior_agents} - current_agents):
-                if not _safe_name(name):
-                    continue
-                target = claude_root / "agents" / name
-                if target.is_file():
-                    try:
-                        target.unlink()
-                    except OSError:
-                        continue
-                    pruned.append(str(target))
+            pruned.append(str(target))
     except Exception:
         pass
     return pruned
@@ -550,6 +611,7 @@ __all__ = [
     "settings_in_sync",
     "read_sync_meta",
     "prune_orphaned_deploy_copies",
+    "prune_candidates",
     "SYNC_META_FILENAME",
     "build_settings",
     "render_user_claude_md",

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -1481,6 +1481,26 @@ def _sync_check(governance_mode: str = "balanced") -> int:
         else:
             changes_needed.append(f"would create: {label}")
 
+    # Deploy-copy prune preview (Event 159 review: the dry-run must
+    # surface deletions — they are the single most dangerous action a
+    # sync performs, and reporting them only after the fact defeats the
+    # point of --check).
+    try:
+        prior_meta = _claude.read_sync_meta(claude_root)
+        current_skills = {d.name for d in _managed_skills()}
+        current_agents = {
+            f.name for f in (REPO_ROOT / "core" / "agents").glob("*.md")
+        }
+        for target in _claude.prune_candidates(
+            claude_root, prior_meta,
+            current_skills=current_skills, current_agents=current_agents,
+        ):
+            changes_needed.append(
+                f"would prune (DELETE, archived first): {target}"
+            )
+    except Exception:
+        pass
+
     # Hermes OPERATOR.md — managed region check (composed by the hermes adapter)
     if hermes_root.exists():
         _check_managed_target(

--- a/tests/test_sync_selfheal.py
+++ b/tests/test_sync_selfheal.py
@@ -208,6 +208,56 @@ class DeployPruneTests(unittest.TestCase):
             self.assertEqual(meta.get("deployed_skills"), expected_skills)
             self.assertEqual(meta.get("deployed_agents"), expected_agents)
 
+    def test_prune_archives_verbatim_before_delete(self):
+        # [K] archive-verbatim: a formerly-managed copy may carry
+        # operator hand-edits that exist nowhere else.
+        with _TmpHome() as th:
+            self._seed_ghosts(th, manifest=True)
+            cadapter.sync("balanced")
+            archive_root = th.claude_root / "_archive"
+            hits = list(archive_root.rglob("ghost-skill/SKILL.md"))
+            self.assertEqual(len(hits), 1)
+            self.assertEqual(hits[0].read_text(encoding="utf-8"), "orphan")
+            self.assertTrue(list(archive_root.rglob("ghost-agent.md")))
+
+    def test_case_alias_of_wanted_name_never_pruned(self):
+        # Event 159 review finding: on a case-insensitive filesystem a
+        # case-variant candidate aliases the currently-wanted copy —
+        # deleting it would delete the wanted skill. The guard is set
+        # logic, so this test holds on case-sensitive CI too.
+        with _TmpHome() as th:
+            wanted = th.claude_root / "skills" / "kept-skill"
+            wanted.mkdir(parents=True, exist_ok=True)
+            (wanted / "SKILL.md").write_text("wanted", encoding="utf-8")
+            pruned = cadapter.prune_orphaned_deploy_copies(
+                th.claude_root,
+                {"deployed_skills": ["Kept-Skill"], "deployed_agents": []},
+                current_skills={"kept-skill"},
+                current_agents=set(),
+            )
+            self.assertEqual(pruned, [])
+            self.assertTrue((wanted / "SKILL.md").exists())
+
+    def test_symlinked_entry_under_manifested_name_skipped(self):
+        # sync never deploys symlinks; a symlink under a manifested name
+        # is operator-authored — neither the link nor its target may be
+        # touched.
+        with _TmpHome() as th:
+            real = Path(self_dir := tempfile.mkdtemp()) / "real-content"
+            real.mkdir()
+            (real / "SKILL.md").write_text("precious", encoding="utf-8")
+            link = th.claude_root / "skills" / "linked-skill"
+            link.symlink_to(real)
+            pruned = cadapter.prune_orphaned_deploy_copies(
+                th.claude_root,
+                {"deployed_skills": ["linked-skill"], "deployed_agents": []},
+                current_skills=set(),
+                current_agents=set(),
+            )
+            self.assertEqual(pruned, [])
+            self.assertTrue(link.is_symlink())
+            self.assertTrue((real / "SKILL.md").exists())
+
     def test_traversal_shaped_manifest_names_skipped(self):
         with _TmpHome() as th:
             meta = cadapter.read_sync_meta(th.claude_root)

--- a/tests/test_sync_selfheal.py
+++ b/tests/test_sync_selfheal.py
@@ -128,5 +128,100 @@ class SelfHealLineTests(unittest.TestCase):
                 self.assertIsNone(sc._sync_selfheal_line())
 
 
+class DeployPruneTests(unittest.TestCase):
+    """Event 159 — sync cleans up after itself. Positive-system
+    ownership: only names the PRIOR sync manifest recorded as deployed
+    are prune candidates; operator-authored entries under
+    ~/.claude/{skills,agents} were never manifested and are
+    structurally untouchable."""
+
+    def _seed_ghosts(self, th, *, manifest: bool) -> None:
+        """Plant a deployed skill dir + agent file whose repo source is
+        gone; optionally record them in the sync sidecar manifest."""
+        ghost_skill = th.claude_root / "skills" / "ghost-skill"
+        ghost_skill.mkdir(parents=True, exist_ok=True)
+        (ghost_skill / "SKILL.md").write_text("orphan", encoding="utf-8")
+        (th.claude_root / "agents" / "ghost-agent.md").write_text(
+            "orphan", encoding="utf-8"
+        )
+        if manifest:
+            meta = cadapter.read_sync_meta(th.claude_root)
+            meta["deployed_skills"] = list(
+                meta.get("deployed_skills") or []
+            ) + ["ghost-skill"]
+            meta["deployed_agents"] = list(
+                meta.get("deployed_agents") or []
+            ) + ["ghost-agent.md"]
+            (th.claude_root / cadapter.SYNC_META_FILENAME).write_text(
+                __import__("json").dumps(meta), encoding="utf-8"
+            )
+
+    def test_prior_manifest_orphans_pruned_on_next_sync(self):
+        with _TmpHome() as th:
+            self._seed_ghosts(th, manifest=True)
+            cadapter.sync("balanced")
+            self.assertFalse(
+                (th.claude_root / "skills" / "ghost-skill").exists()
+            )
+            self.assertFalse(
+                (th.claude_root / "agents" / "ghost-agent.md").exists()
+            )
+
+    def test_unmanifested_entries_never_touched(self):
+        with _TmpHome() as th:
+            self._seed_ghosts(th, manifest=False)
+            cadapter.sync("balanced")
+            self.assertTrue(
+                (th.claude_root / "skills" / "ghost-skill" / "SKILL.md").exists()
+            )
+            self.assertTrue(
+                (th.claude_root / "agents" / "ghost-agent.md").exists()
+            )
+
+    def test_pre_e159_sidecar_without_fields_prunes_nothing(self):
+        with _TmpHome() as th:
+            self._seed_ghosts(th, manifest=False)
+            # Rewrite the sidecar WITHOUT the deployed_* fields — the
+            # pre-E159 shape.
+            (th.claude_root / cadapter.SYNC_META_FILENAME).write_text(
+                '{"governance_pack": "balanced", "synced_at": "2026-01-01T00:00:00+00:00"}',
+                encoding="utf-8",
+            )
+            cadapter.sync("balanced")
+            self.assertTrue(
+                (th.claude_root / "skills" / "ghost-skill").exists()
+            )
+            meta = cadapter.read_sync_meta(th.claude_root)
+            self.assertIsInstance(meta.get("deployed_skills"), list)
+            self.assertIsInstance(meta.get("deployed_agents"), list)
+
+    def test_meta_records_current_deployed_sets(self):
+        with _TmpHome() as th:
+            meta = cadapter.read_sync_meta(th.claude_root)
+            expected_skills = sorted(
+                d.name for d in ecli._managed_skills()
+            )
+            expected_agents = sorted(
+                f.name
+                for f in (ecli.REPO_ROOT / "core" / "agents").glob("*.md")
+            )
+            self.assertEqual(meta.get("deployed_skills"), expected_skills)
+            self.assertEqual(meta.get("deployed_agents"), expected_agents)
+
+    def test_traversal_shaped_manifest_names_skipped(self):
+        with _TmpHome() as th:
+            meta = cadapter.read_sync_meta(th.claude_root)
+            meta["deployed_skills"] = ["../outside-skill"]
+            meta["deployed_agents"] = ["../../outside.md"]
+            (th.claude_root / cadapter.SYNC_META_FILENAME).write_text(
+                __import__("json").dumps(meta), encoding="utf-8"
+            )
+            outside = th.claude_root / "outside-skill"
+            outside.mkdir(parents=True, exist_ok=True)
+            (outside / "SKILL.md").write_text("x", encoding="utf-8")
+            cadapter.sync("balanced")
+            self.assertTrue((outside / "SKILL.md").exists())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Closes the twice-recorded ledger gap from the self-maintenance follow-up: `episteme sync` was additive-only — deployed copies of removed skills/agents accumulated in `~/.claude` forever.

## Mechanism

- Each sync records `deployed_skills` / `deployed_agents` in the E150 sidecar (`.episteme-sync-meta.json`); the E150 self-heal reader ignores the new fields.
- The NEXT sync prunes deployed entries present in the PRIOR manifest but absent from the current managed set. **Positive-system ownership:** names never manifested (operator-authored skills/agents) are structurally untouchable. Pre-E159 sidecars prune nothing (safe rollout — the upgrade sync only records).
- Guards, each from the independent review: case-alias guard (a case-variant candidate must not delete the wanted copy through APFS aliasing — reviewer-reproduced), traversal-shaped names skipped, symlinks skipped, **archive-verbatim before every deletion** ([K] rule — hand-edits on formerly-managed copies exist nowhere else) with failed-archive → skip-delete.
- `sync --check` now previews deletions ("would prune (DELETE, archived first)").

## Verification

- Suite: **1710 + 93 subtests, 0 failed** (+8 new tests: orphan prune, unmanifested untouchable, pre-E159 no-op, manifest recording, traversal, case-alias, symlink, archive-verbatim).
- Live via the real CLI with redirected HOME: first sync recorded an 11-skill manifest and pruned nothing; manifested ghosts pruned with printed notice; unmanifested ghosts survived; `--check` previewed a deletion; a hand-edited orphan's content survived verbatim in `_archive/`.
- Independent adversarial review (separate context): 1 borderline-blocking + 3 should-fix findings — all fixed and re-verified above.