### PR TITLE
feat(practice): Event 161 — THE_WAY_TO_THINK enforcement parity (gate teaches the move, mirror reads the doc, overclaims corrected)

### DIFF
--- a/core/hooks/reasoning_surface_guard.py
+++ b/core/hooks/reasoning_surface_guard.py
@@ -963,6 +963,20 @@ def _is_lazy(text: str) -> bool:
     return stripped in LAZY_TOKENS
 
 
+# THE_WAY_TO_THINK gate labels (Event 161). The block message names the
+# skipped COGNITIVE MOVE, not just the schema field — the gate is where
+# the practice reaches the agent, so the message teaches the move at the
+# moment of failure. Literal duplicates of
+# core/practice/cognitive_moves.gate_move_labels() per the hooks-stay-
+# self-contained convention; parity is CI-enforced by
+# tests/test_practice_cognitive_moves.py::test_gate_labels_match_guard_duplicates.
+_MOVE_BY_FIELD = {
+    "core_question": "Frame · Core Question discipline — counters question substitution (Kahneman)",
+    "unknowns": "Frame · Unknowns ledger with cost_of_ignorance — counters WYSIATI (Kahneman)",
+    "disconfirmation": "Verify · Disconfirmation conditions (pre-committed) — counters motivated reasoning + post-hoc rationalization (cognitive_profile.md § Decision Engine)",
+}
+
+
 def _surface_missing_fields(surface: dict) -> list[str]:
     """Return the list of fields that fail the kernel's validation contract.
 
@@ -1370,8 +1384,10 @@ def _surface_status(cwd: Path) -> tuple[str, str]:
         return "stale", f"surface is {mins} minute(s) old (TTL {SURFACE_TTL_SECONDS // 60} min)"
     missing = _surface_missing_fields(surface)
     if missing:
+        moves = "; ".join(_MOVE_BY_FIELD.get(f, f) for f in missing)
         detail = (
-            f"surface fails validation on: {', '.join(missing)}. "
+            f"cognitive move(s) skipped — {moves}. "
+            f"Surface fails validation on: {', '.join(missing)}. "
             f"Disconfirmation must be a concrete observable condition "
             f"(>= {_min_disconfirmation_len()} chars, not 'none'/'n/a'/'tbd'/'해당 없음'). "
             f"At least one unknown must be sharp and specific (>= {_min_unknown_len()} chars)."

--- a/core/practice/cognitive_moves.py
+++ b/core/practice/cognitive_moves.py
@@ -342,3 +342,42 @@ def ordered_stages() -> List[Stage]:
 def all_move_ids() -> List[str]:
     """All cognitive-move ids in registration order."""
     return list(COGNITIVE_MOVES.keys())
+
+
+# ---------------------------------------------------------------------------
+# Gate labels (Event 161)
+# ---------------------------------------------------------------------------
+
+# Hook-artifact field (the flat .episteme/reasoning-surface.json shape the
+# default PreToolUse gate validates) -> registry move id. The gate's block
+# message names the skipped COGNITIVE MOVE, so the practice reaches the
+# agent at the exact moment of failure instead of a bare schema-field name.
+GATE_FIELD_TO_MOVE: Dict[str, str] = {
+    "core_question": "frame.core_question",
+    "unknowns": "frame.unknowns",
+    "disconfirmation": "verify.disconfirmation_conditions",
+}
+
+
+def gate_move_label(field: str) -> Optional[str]:
+    """Render the gate-facing label for a hook-artifact field:
+    ``<Stage> · <Move name> — counters <short counter>``. The guard
+    duplicates these strings literally (hooks-stay-self-contained
+    convention); parity is CI-enforced by
+    ``tests/test_practice_cognitive_moves.py``."""
+    move_id = GATE_FIELD_TO_MOVE.get(field)
+    if move_id is None:
+        return None
+    move = COGNITIVE_MOVES[move_id]
+    stage = STAGES[move.stage]
+    counter = move.system_1_failure_counter.split(" — ")[0].strip()
+    return f"{stage.name} · {move.name} — counters {counter}"
+
+
+def gate_move_labels() -> Dict[str, str]:
+    """All gate labels keyed by hook-artifact field."""
+    return {
+        field: label
+        for field in GATE_FIELD_TO_MOVE
+        if (label := gate_move_label(field)) is not None
+    }

--- a/docs/THE_WAY_TO_THINK.md
+++ b/docs/THE_WAY_TO_THINK.md
@@ -1,4 +1,4 @@
-<!-- episteme-lifecycle: status=living; reviewed_as_of=E148 -->
+<!-- episteme-lifecycle: status=living; reviewed_as_of=E161 -->
 # The Way to Think — 생각의 틀
 
 > *"The product is a way to think when the model can finish your sentences."*
@@ -86,7 +86,7 @@ Authored in [`core/memory/global/cognitive_profile.md`](/Users/junlee/episteme/c
 | Start from uncomfortable friction | Curiosity-driven exploration that never lands | Surface must declare the *uncomfortable friction* in the operator's own words |
 | Form explicit hypothesis early (*A likely works because B*) | Floating reasoning that never commits | `decision.choice` + `decision.confidence` with elicitation method |
 | Strict utility filter: *so what is the cost of staying ignorant?* | Information collection without operational utility | `unknowns[].cost_of_ignorance` (min 30 chars; operator-authored) |
-| Rebuild ideas in your own language | Quoting authority without understanding | Surface text must pass LLM-paraphrase classifier check (the model couldn't have authored it) |
+| Rebuild ideas in your own language | Quoting authority without understanding | Today: operator signing key + factored interrogation (a fresh context verifies substance it never drafted). Deferred design, not yet wired: LLM-paraphrase classifier over surface text — tracked as a deferred discovery, not claimed as deployed |
 | Invite audit of reasoning paths, not just conclusions | Conclusion-only handoffs lose the chain | The signed surface IS the reasoning path; reasoning is the persisted artifact |
 
 ---
@@ -170,7 +170,7 @@ The practice maps to artifacts that fall into three lanes:
 | Artifact | What it does | Source |
 |---|---|---|
 | Pre-tool-use validator hook | Blocks irreversible-class action until a valid signed surface exists | `core/hooks/reasoning_surface_guard.py` (default) + `src/episteme/hooks/signed_surface_validator.py` (opt-in signed-surface variant) |
-| PTSP typed ledgers | Forces context injection to distinguish `<fact>` from `<inference>` in next-step prompts | `core/ptsp/` |
+| PTSP typed ledgers | Typed `Fact`/`Inference` ledgers with the promotion gate, live in the practice CLI + signing path. Next-step prompt context injection (`core/ptsp/context_injection.py`) is designed and not yet wired into the agent hook loop — tracked as a deferred discovery | `core/ptsp/` |
 | Promotion Gate (Invariants I1–I5) | An `Inference` cannot become a `Fact` without explicit external evidence | `core/ptsp/promotion.py` |
 | Substrate adapters (Claude Code, Hermes) | Practice follows the operator across substrates; same gate exists wherever the operator works | `core/hooks/`, `src/episteme/adapters/hermes.py`, `adapters/claude/` |
 

--- a/tests/test_practice_cognitive_moves.py
+++ b/tests/test_practice_cognitive_moves.py
@@ -114,3 +114,64 @@ def test_verify_stage_includes_disconfirmation_move():
     verify = moves_by_stage("verify")
     discon_moves = [m for m in verify if "disconfirmation" in m.id]
     assert len(discon_moves) >= 1
+
+
+# ---- Event 161 · doc-code parity: the mirror reads the actual doc ----
+
+
+def _doc_text() -> str:
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[1]
+    return (root / "docs" / "THE_WAY_TO_THINK.md").read_text(encoding="utf-8")
+
+
+def test_doc_anchor_sections_exist_in_the_doc():
+    # E148's mirror checked anchor SHAPE only; a renamed/removed doc
+    # section drifted silently. Every move's § N(.N) must exist as a
+    # real heading in THE_WAY_TO_THINK.md.
+    import re
+    doc = _doc_text()
+    for move in COGNITIVE_MOVES.values():
+        m = re.search(r"§ (\d+(?:\.\d+)?)", move.doc_anchor)
+        assert m, f"{move.id}: doc_anchor carries no § number: {move.doc_anchor}"
+        num = m.group(1)
+        assert re.search(rf"^#+ {re.escape(num)}[. ]", doc, re.MULTILINE), (
+            f"{move.id}: doc_anchor § {num} has no matching heading in "
+            f"THE_WAY_TO_THINK.md — doc and registry have drifted"
+        )
+
+
+def test_gate_labels_match_guard_duplicates():
+    # The PreToolUse gate names the skipped cognitive move in its block
+    # message (Event 161). The guard duplicates the labels per the
+    # hooks-stay-self-contained convention; this is the parity lock.
+    from core.practice.cognitive_moves import gate_move_labels
+    from core.hooks import reasoning_surface_guard as guard  # pyright: ignore[reportAttributeAccessIssue]
+    assert guard._MOVE_BY_FIELD == gate_move_labels()
+
+
+def test_doc_numeric_claims_match_signed_schema():
+    # THE_WAY_TO_THINK claims 'min 20 chars' (core_question) and
+    # 'min 30 chars' (cost_of_ignorance); the schema constants are the
+    # truth those claims must track.
+    from episteme.surface._builder import MIN_LENGTH_FIELDS  # pyright: ignore[reportMissingImports]
+    doc = _doc_text()
+    assert MIN_LENGTH_FIELDS["core_question"] == 20
+    assert "min 20 chars" in doc
+    assert MIN_LENGTH_FIELDS["unknowns[].cost_of_ignorance"] == 30
+    assert "min 30 chars" in doc
+
+
+def test_doc_does_not_overclaim_unwired_enforcement():
+    # Event 161 audit: the doc claimed an LLM-paraphrase classifier
+    # 'must pass' when no classifier exists in the codebase, and that
+    # PTSP 'forces context injection' when core/ptsp/context_injection
+    # has no consumers. The identity doc must not overclaim — deferred
+    # designs are named as deferred.
+    doc = _doc_text()
+    assert "must pass LLM-paraphrase classifier" not in doc, (
+        "THE_WAY_TO_THINK claims a deployed paraphrase classifier; none exists"
+    )
+    assert "Forces context injection" not in doc, (
+        "THE_WAY_TO_THINK claims PTSP context injection is forced; it is unwired"
+    )


### PR DESCRIPTION
## What

Operator ask: "are we actually enforcing THE_WAY_TO_THINK on the agent?" Audited every mechanical claim in the identity doc against the code; closed the three gaps found.

## Enforcement map (audit result)

- **Wired and verified:** core_question/lazy-token validation, strict-mode exit-2 gate, hash chain, Ed25519 signing + verify CLI + evidence packet, promotion gate (operator-side), min-20/min-30 schema constants.
- **Partial → fixed:** cognitive-move-named block messages existed only in the opt-in signed validator — the DEFAULT gate now names the skipped move + its System-1 counter (parity with the registry is CI-locked).
- **Overclaims → corrected + pinned:** "must pass LLM-paraphrase classifier" (no classifier exists anywhere in the codebase) and PTSP "forces context injection" (`context_injection.py` has zero consumers). Both reworded to name reality + deferred design, both pinned by a regression test so the doc cannot re-overclaim, both filed as deferred discoveries in the (freshly drained) ledger.
- **Mirror strengthened:** the E148 policy mirror never read the doc; it now asserts every registry anchor exists as a real heading and the numeric claims match `MIN_LENGTH_FIELDS`.

## Verification

Suite **1714 + 93 subtests, 0 failed**. Live fire: a lazy surface (`core_question: "tbd"`, `disconfirmation: "none"`) blocked in strict mode with the message naming all three skipped moves. No control-flow change — block/admit decisions byte-identical; independent subagent review deliberately skipped for that reason (message/doc/test diff; parity tests are the lock).