### PR TITLE
fix(framework): Event 163 — drain the deferred ledger; it was global across every repo all along

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@
 
 <p align="center"><a href="https://epistemekernel.com"><b>epistemekernel.com</b></a></p>
 
-> **episteme makes an AI agent show its work before it acts — and makes your repo's docs stop lying about your code.**
+> **episteme makes an AI agent show its work before it acts.**
 >
-> It installs into the coding tools you already use (Claude Code today; a vendor-neutral adapter layer for others). Before any high-impact action — `git push`, a deploy, a migration, deleting a constraint — the agent must write down, on disk, what it knows, what it doesn't, and what observable event would prove it wrong. A deterministic hook checks the artifact and refuses to proceed until it's real (`exit 2`). Lessons from verified decisions become tamper-evident, context-scoped protocols that resurface at the next matching decision — so the agent gets sharper on *your* codebase over time, and your documentation is linted against your code the same way your code is linted against your tests.
+> You know the feeling: the diff looks fine, the analysis sounds right, and a small voice says *I should probably read this more carefully.* episteme is that voice, given teeth. Before anything irreversible — a push, a deploy, a migration — your agent has to write down what it knows, what it doesn't, and what would prove it wrong. On disk, where you can read it. A quiet, deterministic gate holds the door until the thinking is real.
+>
+> It plugs into the tools you already use (Claude Code today; a vendor-neutral adapter layer for others). Lessons from verified decisions stick around as tamper-evident protocols that resurface exactly when they matter again — so the agent gets sharper on *your* codebase over time, and your docs are held to the same standard as your code.
 
 **[What it looks like ↓](#what-it-looks-like)** · **[Install ↓](#install)** · **[The demos ↓](#the-demos)** · **[How it compares ↓](#how-it-compares)** · **[Under the hood ↓](#under-the-hood)** · **[Does it work? ↗](docs/EVALUATION_METHOD.md)**
 
@@ -30,15 +32,15 @@
 
 ## What it looks like
 
-You ask your agent: *"Evaluate whether our retrieval-augmented memory system is actually improving response quality."*
+Say you ask your agent: *"Evaluate whether our retrieval-augmented memory system is actually improving response quality."*
 
-**Without episteme** — the agent treats this as a measurement chore. It pulls 30 days of metrics, finds a 7% lift in thumbs-up rate, and writes a confident memo: *"memory helps; keep shipping."* You read it. It's wrong three ways, fluently:
+**Without episteme**, the agent treats this as a measurement chore. It pulls 30 days of metrics, finds a 7% lift in thumbs-up rate, and writes you a confident memo: *"memory helps; keep shipping."* It reads beautifully. It's also wrong three ways at once:
 
 - Thumbs-up tracks response *confidence*, not *correctness* — it measured a proxy for your question, not the question.
 - Memory responses run 30% longer, and length independently drives thumbs-up — the "lift" might be the length effect.
 - No condition was ever named under which the conclusion would be judged wrong — so it can't be.
 
-**With episteme** — before the memo can land, the agent has to commit this to disk:
+**With episteme**, the memo can't land yet. First, the agent has to put this on disk:
 
 | Field | What the agent must write |
 |---|---|
@@ -48,7 +50,7 @@ You ask your agent: *"Evaluate whether our retrieval-augmented memory system is 
 | **Assumptions** | Load-bearing beliefs, flagged so they can be falsified |
 | **Disconfirmation** | A pre-committed observable — *"if the lift disappears under length-controlled re-run, memory is adding tokens, not signal"* |
 
-Lazy tokens (`none`, `n/a`, `tbd`, `해당 없음`) are rejected. Vague hedges (*"if issues arise"*) are rejected — only concrete falsification conditions pass. The act of writing the surface is what exposes that the proxy wasn't the question. That's the product: **the agent is forced to think in a way you can audit, before the consequences exist.**
+Lazy answers (`none`, `n/a`, `tbd`, `해당 없음`) don't pass. Vague hedges (*"if issues arise"*) don't pass either — only a concrete, observable way to be proven wrong does. And here's the quiet magic: the act of writing that surface is exactly what exposes that thumbs-up was never the question. That's the product. **The agent has to think in a way you can audit, before the consequences exist.**
 
 ![episteme — the thinking framework in motion](docs/assets/demo_posture.gif)
 
@@ -56,12 +58,12 @@ Lazy tokens (`none`, `n/a`, `tbd`, `해당 없음`) are rejected. Vague hedges (
 
 ## What you get
 
-- **A reasoning gate at the point of no return.** Hooks intercept high-impact operations and validate the Reasoning Surface structurally — normalized command scanning catches bypass shapes (`subprocess.run(['git','push'])`, agent-written shell scripts, wrapped executors). Absent or hollow surface → the op is refused. Strict by default; advisory mode is opt-in per project.
-- **Interrogation for load-bearing decisions.** Structure alone can't tell thinking from theater, so the gate also accepts a stronger artifact: the decision decomposed into claims, each load-bearing claim verified by a **fresh context that never saw the draft reasoning**, the strongest opposition argued, the weakest link named. A `stop` verdict fails closed.
-- **Memory that compounds instead of decaying.** Every verified lesson becomes a hash-chained, context-scoped protocol — append-only and tamper-evident, so the agent can't silently rewrite what it learned. At the next matching decision the kernel surfaces the protocol proactively: `[episteme guide] … · overlap 5/6 · Protocol: In context X, do Y`. You don't have to remember to ask.
-- **Docs that are linted against reality.** Every tracked doc carries a machine-readable lifecycle marker (`living / spec-implemented / design-history / report / tombstone`). CI fails when a new doc lands unclassified, when a living doc cites a retired one as if current, or when a point-in-time report tries to squat in `docs/`. Version strings are stamped from the release manifest, never hand-copied. Stale docs surface at session start — silently, only when something is actually stale. **Single source of truth, enforced — not aspired to.**
-- **A system that cleans up after itself.** Review queues are capped with visible backpressure, logs rotate at size caps, expired markers and old telemetry are reaped at session start. Artifacts don't stack; deletion is a designed operation, not an accident of neglect.
-- **One identity across tools.** Your working style, risk posture, and reasoning preferences live in governed, versioned markdown — synced to every adapter with one command. The kernel outlives the tool.
+- **A gate at the point of no return.** High-impact operations get intercepted before they run, and the agent's reasoning is checked for substance — including the sneaky shapes (`subprocess.run(['git','push'])`, agent-written shell scripts, wrapped commands). No real surface, no execution. Strict by default; you can soften it per project if you want.
+- **A second opinion the draft never touched.** Structure alone can't tell thinking from theater. So for load-bearing decisions, the gate accepts a stronger artifact: the decision broken into claims, each one verified by a fresh context that never saw the original reasoning, with the strongest opposition actually argued. If the verdict says stop, it stops.
+- **Memory that compounds instead of decaying.** Every verified lesson becomes a tamper-evident protocol scoped to its context. The next time a matching decision comes up, the kernel brings the lesson to you — `Protocol: In context X, do Y` — without you having to remember it exists. The agent gets sharper on your codebase specifically.
+- **Docs that stay honest.** Every tracked doc carries a lifecycle marker, and CI fails when reality drifts — an unclassified doc, a living doc citing a retired one, a version string someone hand-copied. Stale docs greet you at session start, and only when something is genuinely stale. One source of truth, enforced rather than aspired to.
+- **A system that cleans up after itself.** Queues have caps with visible backpressure, logs rotate, expired markers get swept at session start. Nothing stacks up in a corner; deletion is a designed operation, not an accident of neglect.
+- **One identity across tools.** Your working style, risk posture, and reasoning preferences live in versioned markdown — synced to every adapter with one command. The kernel outlives whichever tool you're using this year.
 
 ## Install
 
@@ -86,7 +88,7 @@ episteme sync      # push identity to every adapter
 episteme doctor    # verify wiring
 ```
 
-Adopting in an existing repo: `episteme docs lint` forces a lifecycle classification of every tracked doc — that first lint run is the honest inventory most repos have never had. Details, project harnesses, and the full command reference: [`INSTALL.md`](./INSTALL.md) · [`docs/SETUP.md`](./docs/SETUP.md) · [`docs/COMMANDS.md`](./docs/COMMANDS.md).
+Adopting in an existing repo? Run `episteme docs lint` first — it asks every tracked doc to declare what it is, and that first run is usually the most honest inventory the repo has ever had. Details, project harnesses, and the full command reference live in [`INSTALL.md`](./INSTALL.md) · [`docs/SETUP.md`](./docs/SETUP.md) · [`docs/COMMANDS.md`](./docs/COMMANDS.md).
 
 ## The demos
 

--- a/core/hooks/_framework.py
+++ b/core/hooks/_framework.py
@@ -134,7 +134,21 @@ DISCOVERY_EXPIRY_TYPE = "deferred_discovery_expiry"
 # decision.
 UNATTRIBUTED_KEY = "<unattributed>"
 
+# Mirror of the other hooks' root-walk bound (hooks-stay-self-contained).
+_ROOT_WALK_MAX_DEPTH = 64
+
 DEFAULT_DEFERRED_OPEN_CAP = 100
+
+# Global ceiling across ALL projects (Event 163 review, hard rule 5 —
+# "budgets are code; raising a budget constant IS the decision, made in
+# the diff"). Making the cap per-project silently changed the effective
+# ceiling from 100 total to 100 x (however many projects exist), which
+# is a budget raise nobody wrote down. The per-project cap prevents
+# cross-project starvation; this ceiling keeps total operator review
+# load bounded. 3x the per-project cap: enough headroom for the
+# operator's real multi-repo pattern, far below the unbounded growth
+# the review measured.
+DEFAULT_DEFERRED_GLOBAL_CAP = 300
 DEFERRED_EXPIRY_AGE_SECONDS = 30 * 24 * 60 * 60
 _DEFERRED_SKIP_COUNTER_FILENAME = "deferred_skipped.json"
 CP5_FORMAT_VERSION = "cp5-pre-chain"
@@ -235,6 +249,41 @@ def _resolve_deferred_open_cap(explicit: int | None = None) -> int:
         except ValueError:
             pass
     return DEFAULT_DEFERRED_OPEN_CAP
+
+
+def _resolve_deferred_global_cap(explicit: int | None = None) -> int:
+    """Global ceiling across all projects. Same non-positive-falls-back
+    discipline as the per-project knob; env override
+    ``EPISTEME_DEFERRED_GLOBAL_CAP``. Never raises."""
+    if explicit is not None:
+        try:
+            val = int(explicit)
+        except (TypeError, ValueError):
+            return DEFAULT_DEFERRED_GLOBAL_CAP
+        return val if val > 0 else DEFAULT_DEFERRED_GLOBAL_CAP
+    raw = os.environ.get("EPISTEME_DEFERRED_GLOBAL_CAP", "").strip()
+    if raw:
+        try:
+            val = int(raw)
+            if val > 0:
+                return val
+        except ValueError:
+            pass
+    return DEFAULT_DEFERRED_GLOBAL_CAP
+
+
+def projects_at_cap(*, path: Path | None = None) -> list[tuple[str, int]]:
+    """(project, open_count) for every project whose OWN backlog is at
+    or over the per-project cap — i.e. the projects actually declining
+    writes right now. The banner needs this because 'writes paused' must
+    name who is paused: a global sum said 'paused' while this project
+    was admitting fine (Event 163 review)."""
+    cap = _resolve_deferred_open_cap()
+    return sorted(
+        (name, n)
+        for name, n in open_counts_by_project(path=path).items()
+        if cap and n >= cap
+    )
 
 
 def read_deferred_skip_counter(path: Path | None = None) -> dict:
@@ -380,28 +429,37 @@ def _deferred_cap_admit(
     global cap turns one repo's activity into silent finding-loss in
     every other repo, which is the same silent-guardrail-outage class
     E157 fixed. Storage stays global; backpressure follows the backlog
-    an operator actually drains. Entries with no project attribution
-    fall back to the global count."""
+    an operator actually drains.
+
+    An unattributable entry gets ``UNATTRIBUTED_KEY`` as its scope — NOT
+    a global fallback (Event 163 review, reproduced): falling back to
+    global made an unattributed write run relief over the whole ledger
+    and mass-expire another project's aged findings to make room, the
+    exact invariant ``_expire_stale_open`` states it upholds. It also
+    made unattributed writes the only ones still starvable.
+
+    A GLOBAL ceiling still applies on top, so total review load stays
+    bounded (hard rule 5)."""
+    scope = project_name or UNATTRIBUTED_KEY
     try:
         open_n = len(
-            open_deferred_discoveries(path=target, project_name=project_name)
-            if project_name
-            else open_deferred_discoveries(path=target)
+            open_deferred_discoveries(path=target, project_name=scope)
         )
+        global_n = len(open_deferred_discoveries(path=target))
     except Exception:
         return True
-    if open_n < cap_value:
+    global_cap = _resolve_deferred_global_cap()
+    if open_n < cap_value and global_n < global_cap:
         return True
     try:
-        if _expire_stale_open(target, now_dt, project_name=project_name):
+        if _expire_stale_open(target, now_dt, project_name=scope):
             open_n = len(
-                open_deferred_discoveries(path=target, project_name=project_name)
-                if project_name
-                else open_deferred_discoveries(path=target)
+                open_deferred_discoveries(path=target, project_name=scope)
             )
+            global_n = len(open_deferred_discoveries(path=target))
     except Exception:
         pass
-    return open_n < cap_value
+    return open_n < cap_value and global_n < global_cap
 
 
 # ---------------------------------------------------------------------------
@@ -739,26 +797,85 @@ def list_deferred_discoveries(
     return out
 
 
+def _normalize_project_key(name: str) -> str:
+    """Lowercase + whitespace-collapse — byte-identical to what
+    ``_context_signature._normalize_string`` writes into
+    ``project_name``. Both sides of every comparison MUST pass through
+    here: the writer normalized and the readers did not, so a repo named
+    ``MyProject`` (or any path containing a space, which the operator
+    has) stored ``myproject``, matched nothing, and reported its own
+    findings as belonging to other projects."""
+    return " ".join(str(name).split()).strip().lower()
+
+
+def canonical_project_key(path: Path) -> str:
+    """Stable project key for a working directory (Event 163 review).
+
+    Walks UP to the repo/project root before taking a basename, because
+    ``Path.cwd().name`` is wrong in the two places agents actually run:
+    a subdirectory (key ``hooks``) and a linked git worktree (key
+    ``agent-<hex>`` — one phantom project per agent task, each with its
+    own cap). Mirrors the ``_canonical_project_root`` helper the other
+    hooks already carry; duplicated per the hooks-stay-self-contained
+    convention. Falls back to the given path's own basename when no
+    root marker is found, and never raises."""
+    try:
+        start = path.resolve() if path.exists() else path
+    except OSError:
+        start = path
+
+    def _walk(marker) -> Path | None:
+        probe = start
+        for _ in range(_ROOT_WALK_MAX_DEPTH):
+            try:
+                if marker(probe):
+                    return probe
+            except OSError:
+                return None
+            if probe.parent == probe:
+                return None
+            probe = probe.parent
+        return None
+
+    # `.git` as a DIRECTORY is the only authoritative repo root. It is
+    # checked in its own full pass FIRST because a linked worktree is a
+    # complete checkout — it carries its own `.episteme/`, so a single
+    # interleaved walk stops at the worktree and mints a phantom project
+    # per agent task (measured: `agent-<hex>`, `event152-accepted`).
+    # A worktree's `.git` is a FILE, so this pass walks past it to the
+    # real root.
+    root = _walk(lambda p: (p / ".git").is_dir())
+    if root is None:
+        root = _walk(lambda p: (p / ".episteme").is_dir())
+    if root is not None:
+        return _normalize_project_key(root.name) or UNATTRIBUTED_KEY
+    return _normalize_project_key(path.name) or UNATTRIBUTED_KEY
+
+
 def entry_project(payload: dict) -> str | None:
     """Which project a discovery belongs to (Event 163).
 
     The ledger is GLOBAL — one chain across every repo the operator
-    works in. Attribution reads ``context_signature.project_name``,
-    falling back to the basename of ``source_op.cwd`` for entries
-    written before the signature carried it. Returns None when neither
-    signal exists; callers must COUNT those, never silently drop them."""
+    works in. Attribution reads ``context_signature.project_name``
+    (already normalized by the signature writer), falling back to
+    ``source_op.cwd`` canonicalized to its project ROOT — not its raw
+    basename, which produced phantom projects for subdirectories
+    (``.../artifacts/full_text/text_tablefree``) and worktrees. Returns
+    None when neither signal exists; callers must COUNT those under
+    ``UNATTRIBUTED_KEY``, never silently drop them and never let them
+    fall back to a global scope."""
     if not isinstance(payload, dict):
         return None
     sig = payload.get("context_signature")
     if isinstance(sig, dict):
         name = sig.get("project_name")
         if isinstance(name, str) and name.strip():
-            return name.strip()
+            return _normalize_project_key(name)
     src = payload.get("source_op")
     if isinstance(src, dict):
         cwd = src.get("cwd")
         if isinstance(cwd, str) and cwd.strip():
-            return Path(cwd.strip()).name or None
+            return canonical_project_key(Path(cwd.strip()))
     return None
 
 
@@ -777,10 +894,11 @@ def open_deferred_discoveries(
     session.
 
     ``project_name`` scopes the result to one project (Event 163 —
-    mirrors the ``list_deferred_discoveries`` idiom). Unscoped is the
-    whole ledger, which is what the E158 cap consults: the cap bounds
-    TOTAL operator review load, so scoping it would silently multiply
-    the ceiling by project count.
+    mirrors the ``list_deferred_discoveries`` idiom); pass
+    ``UNATTRIBUTED_KEY`` for entries carrying no project signal.
+    Unscoped is the whole ledger, which is what the GLOBAL ceiling
+    consults. The per-project cap consults the scoped count — see
+    ``_deferred_cap_admit`` for why that split exists.
     """
     target = path if path is not None else _deferred_discoveries_path()
     discoveries: list[dict] = []
@@ -803,9 +921,13 @@ def open_deferred_discoveries(
         if str(d.get("entry_hash") or "") not in verdicted
     ]
     if project_name is not None:
+        # An entry with no project signal answers to UNATTRIBUTED_KEY —
+        # it must be reachable by SOME scope, or the cap consult that
+        # passes that key would see an empty set and admit forever.
         out = [
             d for d in out
-            if entry_project(d.get("payload") or {}) == project_name
+            if (entry_project(d.get("payload") or {}) or UNATTRIBUTED_KEY)
+            == project_name
         ]
     return out
 

--- a/core/hooks/_framework.py
+++ b/core/hooks/_framework.py
@@ -132,6 +132,8 @@ DISCOVERY_EXPIRY_TYPE = "deferred_discovery_expiry"
 # because architectural-debt entries deserve a longer review window
 # than op samples. Budgets are code — changing either constant IS the
 # decision.
+UNATTRIBUTED_KEY = "<unattributed>"
+
 DEFAULT_DEFERRED_OPEN_CAP = 100
 DEFERRED_EXPIRY_AGE_SECONDS = 30 * 24 * 60 * 60
 _DEFERRED_SKIP_COUNTER_FILENAME = "deferred_skipped.json"
@@ -319,6 +321,7 @@ def _expire_stale_open(
     now_dt: datetime,
     *,
     age_seconds: int = DEFERRED_EXPIRY_AGE_SECONDS,
+    project_name: str | None = None,
 ) -> int:
     """At-cap relief valve (Event 158): append a terminal
     ``deferred_discovery_expiry`` record for every OPEN discovery older
@@ -332,7 +335,15 @@ def _expire_stale_open(
     count expired; errors propagate to the caller's guard."""
     cutoff = now_dt - timedelta(seconds=age_seconds)
     expired = 0
-    for env in open_deferred_discoveries(path=target):
+    # Relief follows the same scope as the cap that summoned it: one
+    # project's aged findings must never be expired to make room for
+    # another project's write (Event 163).
+    scoped = (
+        open_deferred_discoveries(path=target, project_name=project_name)
+        if project_name
+        else open_deferred_discoveries(path=target)
+    )
+    for env in scoped:
         payload = env.get("payload") if isinstance(env, dict) else None
         payload = payload if isinstance(payload, dict) else {}
         stamp = _parse_iso_ts(str(payload.get("logged_at") or ""))
@@ -352,21 +363,42 @@ def _expire_stale_open(
 
 
 def _deferred_cap_admit(
-    target: Path, cap_value: int, now_dt: datetime
+    target: Path,
+    cap_value: int,
+    now_dt: datetime,
+    project_name: str | None = None,
 ) -> bool:
     """Cap consult for the discovery write path. At cap, run the relief
     valve then recount; True when there is room. A count error fails
     toward admit — backpressure must never break Blueprint D's
-    bookkeeping (its writer already degrades gracefully)."""
+    bookkeeping (its writer already degrades gracefully).
+
+    The cap is PER PROJECT (Event 163). It was global at E158, when the
+    ledger was assumed to be one repo's; the drain proved otherwise —
+    with 118 open findings from another repo, this project could not
+    record a single new one despite an empty backlog of its own. A
+    global cap turns one repo's activity into silent finding-loss in
+    every other repo, which is the same silent-guardrail-outage class
+    E157 fixed. Storage stays global; backpressure follows the backlog
+    an operator actually drains. Entries with no project attribution
+    fall back to the global count."""
     try:
-        open_n = len(open_deferred_discoveries(path=target))
+        open_n = len(
+            open_deferred_discoveries(path=target, project_name=project_name)
+            if project_name
+            else open_deferred_discoveries(path=target)
+        )
     except Exception:
         return True
     if open_n < cap_value:
         return True
     try:
-        if _expire_stale_open(target, now_dt):
-            open_n = len(open_deferred_discoveries(path=target))
+        if _expire_stale_open(target, now_dt, project_name=project_name):
+            open_n = len(
+                open_deferred_discoveries(path=target, project_name=project_name)
+                if project_name
+                else open_deferred_discoveries(path=target)
+            )
     except Exception:
         pass
     return open_n < cap_value
@@ -612,7 +644,9 @@ def write_deferred_discovery(
     # (same tolerate-discarding contract as suppressed_duplicate).
     now_dt = now or datetime.now(timezone.utc)
     cap_value = _resolve_deferred_open_cap(cap)
-    if not _deferred_cap_admit(target, cap_value, now_dt):
+    if not _deferred_cap_admit(
+        target, cap_value, now_dt, entry_project(payload)
+    ):
         _bump_deferred_skip_counter(
             "cap_exceeded", now_dt, path=skip_counter_path
         )
@@ -705,7 +739,32 @@ def list_deferred_discoveries(
     return out
 
 
-def open_deferred_discoveries(*, path: Path | None = None) -> list[dict]:
+def entry_project(payload: dict) -> str | None:
+    """Which project a discovery belongs to (Event 163).
+
+    The ledger is GLOBAL — one chain across every repo the operator
+    works in. Attribution reads ``context_signature.project_name``,
+    falling back to the basename of ``source_op.cwd`` for entries
+    written before the signature carried it. Returns None when neither
+    signal exists; callers must COUNT those, never silently drop them."""
+    if not isinstance(payload, dict):
+        return None
+    sig = payload.get("context_signature")
+    if isinstance(sig, dict):
+        name = sig.get("project_name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    src = payload.get("source_op")
+    if isinstance(src, dict):
+        cwd = src.get("cwd")
+        if isinstance(cwd, str) and cwd.strip():
+            return Path(cwd.strip()).name or None
+    return None
+
+
+def open_deferred_discoveries(
+    *, path: Path | None = None, project_name: str | None = None
+) -> list[dict]:
     """Discoveries still awaiting an operator verdict.
 
     OPEN iff payload status is in ``OPEN_STATUSES`` (legacy records
@@ -716,6 +775,12 @@ def open_deferred_discoveries(*, path: Path | None = None) -> list[dict]:
     Single chain pass; the SessionStart banner and ``episteme guide
     --deferred`` read this so a verdicted finding stops re-firing every
     session.
+
+    ``project_name`` scopes the result to one project (Event 163 —
+    mirrors the ``list_deferred_discoveries`` idiom). Unscoped is the
+    whole ledger, which is what the E158 cap consults: the cap bounds
+    TOTAL operator review load, so scoping it would silently multiply
+    the ceiling by project count.
     """
     target = path if path is not None else _deferred_discoveries_path()
     discoveries: list[dict] = []
@@ -733,10 +798,28 @@ def open_deferred_discoveries(*, path: Path | None = None) -> list[dict]:
             status = payload.get("status")
             if status is None or status in OPEN_STATUSES:
                 discoveries.append(rec)
-    return [
+    out = [
         d for d in discoveries
         if str(d.get("entry_hash") or "") not in verdicted
     ]
+    if project_name is not None:
+        out = [
+            d for d in out
+            if entry_project(d.get("payload") or {}) == project_name
+        ]
+    return out
+
+
+def open_counts_by_project(*, path: Path | None = None) -> dict[str, int]:
+    """Open discoveries per project, with unattributable entries under
+    ``UNATTRIBUTED_KEY``. The counts always sum to the unscoped open
+    total — a scoped view may hide entries from a project's banner, but
+    the tally never loses one (Event 163 disconfirmation)."""
+    counts: dict[str, int] = {}
+    for env in open_deferred_discoveries(path=path):
+        name = entry_project(env.get("payload") or {}) or UNATTRIBUTED_KEY
+        counts[name] = counts.get(name, 0) + 1
+    return counts
 
 
 def _discovery_ref_sets(target: Path) -> tuple[list[dict], set[str], set[str]]:

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -144,7 +144,11 @@ def _framework_digest_line() -> str | None:
         # debt is named separately rather than inflating this banner (a
         # 178-entry count of which 131 belonged to other repos read as
         # episteme's own backlog for weeks).
-        _project = Path.cwd().resolve().name or "unknown_project"
+        # Canonical key, not Path.cwd().name: agents run in subdirs and
+        # in linked worktrees, where the raw basename invents a phantom
+        # project (`hooks`, `agent-<hex>`) and this repo's own findings
+        # read as somebody else's (Event 163 review, measured).
+        _project = _framework.canonical_project_key(Path.cwd())
         deferred = _framework.open_deferred_discoveries(project_name=_project)
         _counts = _framework.open_counts_by_project()
         elsewhere = sum(v for k, v in _counts.items() if k != _project)
@@ -193,19 +197,26 @@ def _framework_digest_line() -> str | None:
         pass
     try:
         cap = _framework._resolve_deferred_open_cap()
-        # The cap is GLOBAL (it bounds total operator review load), so it
-        # must be compared against the whole ledger — not this project's
-        # scoped count, which would hide a live write-decline behind a
-        # quiet local backlog (Event 163).
-        global_open = sum(_counts.values())
-        if cap and global_open >= cap:
+        # "Writes paused" must be TRUE where it is printed. The cap is
+        # per project, so comparing a global sum announced a pause while
+        # this project was admitting fine — the unclosable-alarm failure
+        # E158 claimed to have fixed (Event 163 review, reproduced).
+        # Name the projects actually declining, and only say THIS one is
+        # paused when it is.
+        at_cap = _framework.projects_at_cap()
+        mine = _counts.get(_project, 0)
+        if cap and mine >= cap:
             skipped = _framework.read_deferred_skip_counter().get(
                 "skipped_count", 0
             )
             line += (
-                f" — ledger AT CAP ({cap} across all projects): writes paused, "
+                f" — this project AT CAP ({cap}): writes paused, "
                 f"{skipped} record(s) skipped since last drain"
             )
+        elif at_cap:
+            # Somebody else is paused — say who, without claiming we are.
+            names = ", ".join(f"{n} ({c}/{cap})" for n, c in at_cap)
+            line += f" — at cap elsewhere: {names}"
     except Exception:
         pass
     return line

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -139,7 +139,15 @@ def _framework_digest_line() -> str | None:
         # unverdicted), not raw pending — 233 permanently-pending
         # entries made this banner an unclosable alarm because no
         # resolve path existed. Verdicted findings stop re-firing.
-        deferred = _framework.open_deferred_discoveries()
+        # Event 163 — the ledger is GLOBAL across every repo the operator
+        # works in. Count THIS project's open findings; other projects'
+        # debt is named separately rather than inflating this banner (a
+        # 178-entry count of which 131 belonged to other repos read as
+        # episteme's own backlog for weeks).
+        _project = Path.cwd().resolve().name or "unknown_project"
+        deferred = _framework.open_deferred_discoveries(project_name=_project)
+        _counts = _framework.open_counts_by_project()
+        elsewhere = sum(v for k, v in _counts.items() if k != _project)
     except Exception:
         return None
     total = len(all_protocols)
@@ -162,6 +170,10 @@ def _framework_digest_line() -> str | None:
         f"last session ({total} total), {pending_deferred} deferred "
         f"{deferred_noun} pending"
     )
+    # Other repos' findings are named, never folded into this project's
+    # count — the ledger is shared, the backlog is not (Event 163).
+    if elsewhere:
+        line += f" (+{elsewhere} in other projects)"
     # Event 158 — at/over the open cap the discovery writer declines
     # (relief valve permitting); surface the degradation instead of
     # letting the ledger go silently lossy. Machine-expired findings are
@@ -181,12 +193,17 @@ def _framework_digest_line() -> str | None:
         pass
     try:
         cap = _framework._resolve_deferred_open_cap()
-        if cap and pending_deferred >= cap:
+        # The cap is GLOBAL (it bounds total operator review load), so it
+        # must be compared against the whole ledger — not this project's
+        # scoped count, which would hide a live write-decline behind a
+        # quiet local backlog (Event 163).
+        global_open = sum(_counts.values())
+        if cap and global_open >= cap:
             skipped = _framework.read_deferred_skip_counter().get(
                 "skipped_count", 0
             )
             line += (
-                f" — queue AT CAP ({cap}): writes paused, "
+                f" — ledger AT CAP ({cap} across all projects): writes paused, "
                 f"{skipped} record(s) skipped since last drain"
             )
     except Exception:

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -5169,7 +5169,7 @@ def _deferred_dispatch(args) -> int:
             if getattr(args, "deferred_all_projects", False):
                 envelopes = _framework.open_deferred_discoveries()
             else:
-                project = Path.cwd().resolve().name or "unknown_project"
+                project = _framework.canonical_project_key(Path.cwd())
                 envelopes = _framework.open_deferred_discoveries(
                     project_name=project
                 )
@@ -5192,9 +5192,15 @@ def _deferred_dispatch(args) -> int:
         print(f"[ok] verdict '{payload.get('verdict')}' chained for "
               f"{str(payload.get('ref') or '')[:12]} "
               f"(record {str(env.get('entry_hash') or '')[:12]})")
-        remaining = len(_framework.open_deferred_discoveries())
+        # Scoped like `deferred list` — an unscoped remainder mid-drain
+        # reports other repos' debt as this one's, the confusion this
+        # event exists to remove (Event 163 review).
+        project = _framework.canonical_project_key(Path.cwd())
+        remaining = len(
+            _framework.open_deferred_discoveries(project_name=project)
+        )
         noun = "discovery" if remaining == 1 else "discoveries"
-        print(f"{remaining} open deferred {noun} remain")
+        print(f"{remaining} open deferred {noun} remain in this project")
         return 0
 
     return 1
@@ -5228,7 +5234,7 @@ def _deferred_print_list(args, envelopes: list) -> int:
         # Name other projects' findings rather than hiding them (E163).
         try:
             import _framework  # type: ignore  # pyright: ignore[reportMissingImports]
-            project = Path.cwd().resolve().name or "unknown_project"
+            project = _framework.canonical_project_key(Path.cwd())
             counts = _framework.open_counts_by_project()
             other = sum(v for k, v in counts.items() if k != project)
             if other:
@@ -5238,8 +5244,13 @@ def _deferred_print_list(args, envelopes: list) -> int:
                 )
                 print(f"{other} open in other projects ({names}) — "
                       f"episteme deferred list --all-projects")
-        except Exception:
-            pass
+        except Exception as exc:
+            # Never swallow: a silent failure here prints "0 open in
+            # this project" while the rest of the ledger is invisible
+            # (Event 163 review).
+            print(f"[warn] could not read other projects' counts "
+                  f"({exc.__class__.__name__}); this view may be partial",
+                  file=sys.stderr)
     if not expired_view:
         # Surface machine-expired findings so cap relief is never an
         # invisible loss (Event 158 review finding).

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -5164,7 +5164,15 @@ def _deferred_dispatch(args) -> int:
             # verdictable: an operator verdict supersedes the expiry.
             envelopes = _framework.expired_unverdicted_discoveries()
         else:
-            envelopes = _framework.open_deferred_discoveries()
+            # Event 163 — the ledger is global; scope to this project
+            # unless --all is asked for, and always name the remainder.
+            if getattr(args, "deferred_all_projects", False):
+                envelopes = _framework.open_deferred_discoveries()
+            else:
+                project = Path.cwd().resolve().name or "unknown_project"
+                envelopes = _framework.open_deferred_discoveries(
+                    project_name=project
+                )
         # Piping into head is the expected drain workflow; a closed
         # stdout must not stack-trace (observed via a commit-hook
         # pipeline on 2026-07-03).
@@ -5209,11 +5217,29 @@ def _deferred_print_list(args, envelopes: list) -> int:
         print(f"{str(env.get('entry_hash') or '')[:12]}  "
               f"{str(env.get('ts') or '')[:10]}  {desc}")
     expired_view = getattr(args, "deferred_expired", False)
+    all_view = getattr(args, "deferred_all_projects", False)
     state = "expired-unreviewed" if expired_view else "open"
+    scope = "" if (expired_view or all_view) else " in this project"
     noun = "discovery" if len(envelopes) == 1 else "discoveries"
-    print(f"\n{len(envelopes)} {state} deferred {noun}. Resolve with: "
+    print(f"\n{len(envelopes)} {state} deferred {noun}{scope}. Resolve with: "
           f"episteme deferred resolve <ref> --verdict "
           f"resolved OR noise OR duplicate OR accepted --why '...'")
+    if not expired_view and not all_view:
+        # Name other projects' findings rather than hiding them (E163).
+        try:
+            import _framework  # type: ignore  # pyright: ignore[reportMissingImports]
+            project = Path.cwd().resolve().name or "unknown_project"
+            counts = _framework.open_counts_by_project()
+            other = sum(v for k, v in counts.items() if k != project)
+            if other:
+                names = ", ".join(
+                    f"{k}: {v}" for k, v in sorted(counts.items())
+                    if k != project
+                )
+                print(f"{other} open in other projects ({names}) — "
+                      f"episteme deferred list --all-projects")
+        except Exception:
+            pass
     if not expired_view:
         # Surface machine-expired findings so cap relief is never an
         # invisible loss (Event 158 review finding).
@@ -6322,6 +6348,10 @@ def build_parser() -> argparse.ArgumentParser:
     deferred_list.add_argument(
         "--json", dest="deferred_json", action="store_true",
         help="Machine-readable output",
+    )
+    deferred_list.add_argument(
+        "--all-projects", dest="deferred_all_projects", action="store_true",
+        help="Show open discoveries from every project in the global ledger (default: this project only)",
     )
     deferred_list.add_argument(
         "--expired", dest="deferred_expired", action="store_true",

--- a/tests/test_chain_and_framework.py
+++ b/tests/test_chain_and_framework.py
@@ -1016,9 +1016,15 @@ class DeferredCapRelief(unittest.TestCase):
     def test_blueprint_d_writer_does_not_count_declined_entries(self):
         from core.hooks import _blueprint_d  # pyright: ignore[reportAttributeAccessIssue]
         with EphemeralHome():
+            # Occupy the cap slot in the SAME scope the Blueprint-D write
+            # will land in — post-E163 the cap is per project, so an
+            # unattributed seed is a different backlog entirely.
             _framework.write_deferred_discovery(
                 {"flaw_classification": "doc-code-drift",
                  "description": "fresh occupant of the only cap slot",
+                 "context_signature": {
+                     "project_name": _framework.canonical_project_key(Path("."))
+                 },
                  "logged_at": datetime.now(timezone.utc).isoformat()}
             )
             surface = {
@@ -1318,3 +1324,124 @@ class DeferredProjectScoping(unittest.TestCase):
                     project_name="other-project")),
                 1,
             )
+
+
+class DeferredScopingReviewFixes(unittest.TestCase):
+    """Event 163 independent-review findings, each reproduced before
+    being fixed — pinned here so they cannot regress."""
+
+    def test_worktree_and_subdir_resolve_to_the_repo_key(self):
+        # BLOCKING 1: Path.cwd().name invented a phantom project per
+        # subdir and per agent worktree ('hooks', 'agent-<hex>').
+        with tempfile.TemporaryDirectory() as td:
+            repo = Path(td) / "MyRepo"
+            (repo / ".git").mkdir(parents=True)
+            (repo / "core" / "hooks").mkdir(parents=True)
+            # Real shape: agent worktrees live INSIDE the repo at
+            # .claude/worktrees/agent-<hex>, and their .git is a FILE.
+            wt = repo / ".claude" / "worktrees" / "agent-deadbeef"
+            wt.mkdir(parents=True)
+            (wt / ".git").write_text("gitdir: elsewhere")
+            self.assertEqual(_framework.canonical_project_key(repo), "myrepo")
+            self.assertEqual(
+                _framework.canonical_project_key(repo / "core" / "hooks"),
+                "myrepo",
+            )
+            self.assertEqual(
+                _framework.canonical_project_key(wt), "myrepo",
+                "an agent worktree must not become its own phantom project",
+            )
+
+    def test_project_key_normalization_matches_the_signature_writer(self):
+        # NIT 10: the signature writer lowercases + collapses whitespace;
+        # the readers did not, so 'MyProject' stored 'myproject' and
+        # matched nothing. The operator has a path with a space today.
+        self.assertEqual(_framework._normalize_project_key("MyProject"), "myproject")
+        self.assertEqual(_framework._normalize_project_key("  mgh   lmic "), "mgh lmic")
+
+    def test_unattributed_write_never_expires_another_projects_findings(self):
+        # BLOCKING 3: with project None the cap+relief fell back to
+        # GLOBAL scope, so one unattributed write mass-expired another
+        # project's aged findings to make room.
+        with EphemeralHome():
+            old = (datetime.now(timezone.utc) - timedelta(days=31)).isoformat()
+            for i in range(3):
+                _framework.write_deferred_discovery({
+                    "flaw_classification": "other",
+                    "description": f"other-project aged finding {i}",
+                    "context_signature": {"project_name": "other-project"},
+                    "logged_at": old,
+                })
+            before = len(_framework.open_deferred_discoveries(
+                project_name="other-project"))
+            self.assertEqual(before, 3)
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "other",
+                 "description": "an entry with no project signal at all",
+                 "logged_at": datetime.now(timezone.utc).isoformat()},
+                cap=1,
+            )
+            self.assertEqual(
+                len(_framework.open_deferred_discoveries(
+                    project_name="other-project")),
+                3,
+                "an unattributed write expired another project's findings",
+            )
+
+    def test_unattributed_entries_are_not_starved_by_other_projects(self):
+        with EphemeralHome():
+            for i in range(3):
+                _framework.write_deferred_discovery({
+                    "flaw_classification": "other",
+                    "description": f"other-project finding {i}",
+                    "context_signature": {"project_name": "other-project"},
+                    "logged_at": datetime.now(timezone.utc).isoformat(),
+                })
+            res = _framework.write_deferred_discovery(
+                {"flaw_classification": "other",
+                 "description": "unattributed entry must still be admitted",
+                 "logged_at": datetime.now(timezone.utc).isoformat()},
+                cap=2,
+            )
+            self.assertIn("entry_hash", res)
+
+    def test_global_ceiling_still_bounds_total_review_load(self):
+        # SHOULD-FIX 4: per-project caps silently made the ceiling
+        # unbounded. Budgets are code — the global bound is explicit.
+        with EphemeralHome():
+            for p in range(3):
+                for i in range(2):
+                    _framework.write_deferred_discovery({
+                        "flaw_classification": "other",
+                        "description": f"p{p} finding {i}",
+                        "context_signature": {"project_name": f"proj-{p}"},
+                        "logged_at": datetime.now(timezone.utc).isoformat(),
+                    })
+            with patch.dict(os.environ, {"EPISTEME_DEFERRED_GLOBAL_CAP": "6"}):
+                res = _framework.write_deferred_discovery(
+                    {"flaw_classification": "other",
+                     "description": "fresh project blocked by GLOBAL ceiling",
+                     "context_signature": {"project_name": "proj-new"},
+                     "logged_at": datetime.now(timezone.utc).isoformat()},
+                    cap=100,
+                )
+            self.assertTrue(res.get("declined_at_cap"))
+
+    def test_projects_at_cap_names_only_the_paused_ones(self):
+        with EphemeralHome():
+            for i in range(2):
+                _framework.write_deferred_discovery({
+                    "flaw_classification": "other",
+                    "description": f"busy-project finding {i}",
+                    "context_signature": {"project_name": "busy-project"},
+                    "logged_at": datetime.now(timezone.utc).isoformat(),
+                })
+            _framework.write_deferred_discovery({
+                "flaw_classification": "other",
+                "description": "quiet-project lone finding",
+                "context_signature": {"project_name": "quiet-project"},
+                "logged_at": datetime.now(timezone.utc).isoformat(),
+            })
+            with patch.dict(os.environ, {"EPISTEME_DEFERRED_OPEN_CAP": "2"}):
+                at_cap = _framework.projects_at_cap()
+            self.assertEqual(at_cap, [("busy-project", 2)])

--- a/tests/test_chain_and_framework.py
+++ b/tests/test_chain_and_framework.py
@@ -1204,3 +1204,117 @@ class Phase12ChainIntegrity(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class DeferredProjectScoping(unittest.TestCase):
+    """Event 163 — the ledger is GLOBAL across every repo the operator
+    works in, but open_deferred_discoveries had no project filter (its
+    siblings list_deferred_discoveries/list_protocols both do), so every
+    session's banner counted every project's debt. Scope the VIEW; the
+    E158 cap stays global (it bounds total operator review load)."""
+
+    def _seed(self, project: str, desc: str, *, via_cwd: bool = False):
+        payload = {
+            "flaw_classification": "other",
+            "description": desc,
+            "logged_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if via_cwd:
+            payload["source_op"] = {"cwd": f"/Users/x/{project}"}
+        else:
+            payload["context_signature"] = {"project_name": project}
+        return _framework.write_deferred_discovery(payload)
+
+    def test_scoped_open_returns_only_that_project(self):
+        with EphemeralHome():
+            self._seed("episteme", "episteme finding one")
+            self._seed("sanomap-metabolome-hub", "sanomap finding one")
+            self._seed("sanomap-metabolome-hub", "sanomap finding two")
+            self.assertEqual(len(_framework.open_deferred_discoveries()), 3)
+            scoped = _framework.open_deferred_discoveries(project_name="episteme")
+            self.assertEqual(len(scoped), 1)
+            self.assertEqual(
+                scoped[0]["payload"]["description"], "episteme finding one"
+            )
+
+    def test_cwd_basename_fallback_attributes_legacy_entries(self):
+        with EphemeralHome():
+            self._seed("episteme", "legacy via cwd", via_cwd=True)
+            scoped = _framework.open_deferred_discoveries(project_name="episteme")
+            self.assertEqual(len(scoped), 1)
+
+    def test_unattributed_entries_are_counted_never_dropped(self):
+        # A filter that hides findings is worse than a banner that
+        # overcounts — unattributable entries must surface in the tally.
+        with EphemeralHome():
+            self._seed("episteme", "attributed finding")
+            _framework.write_deferred_discovery({
+                "flaw_classification": "other",
+                "description": "no project signal at all",
+                "logged_at": datetime.now(timezone.utc).isoformat(),
+            })
+            counts = _framework.open_counts_by_project()
+            self.assertEqual(counts.get("episteme"), 1)
+            self.assertEqual(counts.get(_framework.UNATTRIBUTED_KEY), 1)
+            self.assertEqual(sum(counts.values()),
+                             len(_framework.open_deferred_discoveries()))
+
+    def test_cap_is_per_project_no_cross_project_starvation(self):
+        # E158 made the cap global on the assumption the ledger was one
+        # repo's. The E163 drain disproved it empirically: with 118 open
+        # findings from another repo, THIS repo could not record a single
+        # new finding despite an empty backlog of its own — one repo's
+        # activity silently causing finding-loss in every other repo, the
+        # same silent-outage class E157 fixed. Storage stays global;
+        # backpressure follows the backlog an operator actually drains.
+        with EphemeralHome():
+            self._seed("other-project", "occupies other-project's only slot")
+            res = _framework.write_deferred_discovery(
+                {"flaw_classification": "other",
+                 "description": "episteme entry must NOT be starved",
+                 "context_signature": {"project_name": "episteme"},
+                 "logged_at": datetime.now(timezone.utc).isoformat()},
+                cap=1,
+            )
+            self.assertIn("entry_hash", res)
+            self.assertEqual(
+                len(_framework.open_deferred_discoveries(project_name="episteme")),
+                1,
+            )
+
+    def test_cap_still_bounds_within_one_project(self):
+        with EphemeralHome():
+            self._seed("episteme", "occupies episteme's only slot")
+            res = _framework.write_deferred_discovery(
+                {"flaw_classification": "other",
+                 "description": "second episteme entry exceeds its own cap",
+                 "context_signature": {"project_name": "episteme"},
+                 "logged_at": datetime.now(timezone.utc).isoformat()},
+                cap=1,
+            )
+            self.assertTrue(res.get("declined_at_cap"))
+
+    def test_relief_never_expires_another_projects_findings(self):
+        with EphemeralHome():
+            old = (datetime.now(timezone.utc) - timedelta(days=31)).isoformat()
+            _framework.write_deferred_discovery({
+                "flaw_classification": "other",
+                "description": "another repo's ancient finding",
+                "context_signature": {"project_name": "other-project"},
+                "logged_at": old,
+            })
+            self._seed("episteme", "episteme fresh finding")
+            _framework.write_deferred_discovery(
+                {"flaw_classification": "other",
+                 "description": "episteme second finding triggers its own cap",
+                 "context_signature": {"project_name": "episteme"},
+                 "logged_at": datetime.now(timezone.utc).isoformat()},
+                cap=1,
+            )
+            # The other project's aged finding must survive: relief is
+            # scoped to the backlog that summoned it.
+            self.assertEqual(
+                len(_framework.open_deferred_discoveries(
+                    project_name="other-project")),
+                1,
+            )

--- a/tests/test_deferred_resolution.py
+++ b/tests/test_deferred_resolution.py
@@ -352,10 +352,22 @@ class CliDrain(unittest.TestCase):
         return rc, out.getvalue(), err.getvalue()
 
     def test_list_shows_open_with_ref(self):
-        rc, out, _ = self._main(["deferred", "list"])
+        # Event 163 — `deferred list` scopes to the current project by
+        # default (the ledger is global across every repo the operator
+        # works in); --all-projects restores the whole-ledger view that
+        # this fixture's entry belongs to.
+        rc, out, _ = self._main(["deferred", "list", "--all-projects"])
         self.assertEqual(rc, 0)
         self.assertIn(self.entry["entry_hash"][:12], out)
         self.assertIn("1 open deferred discovery", out)
+
+    def test_list_scopes_to_current_project_by_default(self):
+        rc, out, _ = self._main(["deferred", "list"])
+        self.assertEqual(rc, 0)
+        # The fixture entry carries no project matching this cwd, so the
+        # scoped view is empty — but it must be NAMED, never hidden.
+        self.assertIn("open in other projects", out)
+        self.assertIn("--all-projects", out)
 
     def test_resolve_then_list_empty(self):
         rc, out, err = self._main([

--- a/tests/test_session_context_deferred_cap.py
+++ b/tests/test_session_context_deferred_cap.py
@@ -46,7 +46,7 @@ class DeferredCapLineTests(unittest.TestCase):
                 _framework, "_resolve_deferred_open_cap", return_value=cap
             )
         )
-        project = Path.cwd().resolve().name or "unknown_project"
+        project = _framework.canonical_project_key(Path.cwd())
         counts = {project: open_n}
         if elsewhere:
             counts["some-other-repo"] = elsewhere
@@ -57,6 +57,11 @@ class DeferredCapLineTests(unittest.TestCase):
              ), \
              mock.patch.object(
                  _framework, "open_counts_by_project", return_value=counts,
+             ), \
+             mock.patch.object(
+                 _framework, "projects_at_cap",
+                 return_value=[(k, v) for k, v in counts.items()
+                               if k != project and cap and v >= cap],
              ), \
              mock.patch.object(
                  _framework, "expired_unverdicted_count",
@@ -76,14 +81,26 @@ class DeferredCapLineTests(unittest.TestCase):
         self.assertIn("3 deferred discoveries pending", line)
         self.assertIn("+118 in other projects", line)
 
-    def test_cap_notice_fires_on_global_total_not_scoped_count(self):
-        # This project is quiet (2 open) but the global ledger is at cap
-        # and writes ARE being declined — the notice must still fire.
+    def test_quiet_project_is_not_told_its_writes_are_paused(self):
+        # REPLACES a test that pinned the bug as correct. The cap is per
+        # project: with 2 open here and 120 elsewhere, THIS project is
+        # admitting writes fine, so claiming "writes paused" is false —
+        # the unclosable-alarm failure E158 claimed to fix (Event 163
+        # review reproduced it against the live ledger).
         line = self._line(open_n=2, elsewhere=120, cap=100, skipped=9)
         assert line is not None
         self.assertIn("2 deferred discoveries pending", line)
-        self.assertIn("AT CAP (100 across all projects)", line)
-        self.assertIn("9 record(s) skipped", line)
+        self.assertNotIn("writes paused", line)
+        # But the projects that ARE paused get named, not hidden.
+        self.assertIn("at cap elsewhere", line)
+        self.assertIn("some-other-repo", line)
+
+    def test_this_project_at_cap_says_so_plainly(self):
+        line = self._line(open_n=100, elsewhere=0, cap=100, skipped=4)
+        assert line is not None
+        self.assertIn("this project AT CAP (100)", line)
+        self.assertIn("writes paused", line)
+        self.assertIn("4 record(s) skipped", line)
 
     def test_below_cap_line_unchanged(self):
         line = self._line(open_n=28)
@@ -97,7 +114,7 @@ class DeferredCapLineTests(unittest.TestCase):
         line = self._line(open_n=100, cap=100, skipped=7)
         assert line is not None
         self.assertIn("100 deferred discoveries pending", line)
-        self.assertIn("AT CAP (100 across all projects)", line)
+        self.assertIn("this project AT CAP (100)", line)
         self.assertIn("writes paused", line)
         self.assertIn("7 record(s) skipped", line)
 
@@ -105,7 +122,7 @@ class DeferredCapLineTests(unittest.TestCase):
         line = self._line(open_n=178, cap=100, skipped=42)
         assert line is not None
         self.assertIn("178 deferred discoveries pending", line)
-        self.assertIn("AT CAP (100 across all projects)", line)
+        self.assertIn("this project AT CAP (100)", line)
         self.assertIn("42 record(s) skipped", line)
 
     def test_expired_count_surfaces(self):

--- a/tests/test_session_context_deferred_cap.py
+++ b/tests/test_session_context_deferred_cap.py
@@ -32,7 +32,10 @@ def _open_stub(n: int) -> list[dict]:
 
 class DeferredCapLineTests(unittest.TestCase):
     def _line(self, *, open_n, cap=100, skipped=0, expired=0,
-              cap_error=False):
+              cap_error=False, elsewhere=0):
+        # Event 163 — the banner scopes the deferred count to THIS
+        # project and names other projects' findings separately, while
+        # the cap is compared against the whole (global) ledger.
         cap_mock = (
             mock.patch.object(
                 _framework, "_resolve_deferred_open_cap",
@@ -43,10 +46,17 @@ class DeferredCapLineTests(unittest.TestCase):
                 _framework, "_resolve_deferred_open_cap", return_value=cap
             )
         )
+        project = Path.cwd().resolve().name or "unknown_project"
+        counts = {project: open_n}
+        if elsewhere:
+            counts["some-other-repo"] = elsewhere
         with mock.patch.object(_framework, "list_protocols", return_value=[]), \
              mock.patch.object(
                  _framework, "open_deferred_discoveries",
                  return_value=_open_stub(open_n),
+             ), \
+             mock.patch.object(
+                 _framework, "open_counts_by_project", return_value=counts,
              ), \
              mock.patch.object(
                  _framework, "expired_unverdicted_count",
@@ -60,6 +70,21 @@ class DeferredCapLineTests(unittest.TestCase):
              mock.patch.object(sc, "_read_last_session_ts", return_value=None):
             return sc._framework_digest_line()
 
+    def test_other_projects_named_not_folded_in(self):
+        line = self._line(open_n=3, elsewhere=118)
+        assert line is not None
+        self.assertIn("3 deferred discoveries pending", line)
+        self.assertIn("+118 in other projects", line)
+
+    def test_cap_notice_fires_on_global_total_not_scoped_count(self):
+        # This project is quiet (2 open) but the global ledger is at cap
+        # and writes ARE being declined — the notice must still fire.
+        line = self._line(open_n=2, elsewhere=120, cap=100, skipped=9)
+        assert line is not None
+        self.assertIn("2 deferred discoveries pending", line)
+        self.assertIn("AT CAP (100 across all projects)", line)
+        self.assertIn("9 record(s) skipped", line)
+
     def test_below_cap_line_unchanged(self):
         line = self._line(open_n=28)
         self.assertEqual(
@@ -72,7 +97,7 @@ class DeferredCapLineTests(unittest.TestCase):
         line = self._line(open_n=100, cap=100, skipped=7)
         assert line is not None
         self.assertIn("100 deferred discoveries pending", line)
-        self.assertIn("queue AT CAP (100)", line)
+        self.assertIn("AT CAP (100 across all projects)", line)
         self.assertIn("writes paused", line)
         self.assertIn("7 record(s) skipped", line)
 
@@ -80,7 +105,7 @@ class DeferredCapLineTests(unittest.TestCase):
         line = self._line(open_n=178, cap=100, skipped=42)
         assert line is not None
         self.assertIn("178 deferred discoveries pending", line)
-        self.assertIn("AT CAP (100)", line)
+        self.assertIn("AT CAP (100 across all projects)", line)
         self.assertIn("42 record(s) skipped", line)
 
     def test_expired_count_surfaces(self):


### PR DESCRIPTION
## The discovery that reframed the task

The operator asked to resolve all deferred findings. A read-only evidence sweep clustered all 178 open+expired entries and found: **the ledger is GLOBAL across every repo the operator works in.** Only 47 entries were episteme's — 121 belonged to a biomedical pipeline repo, 9 to a website, 1 to a class lab. episteme had been reading other projects' debt as its own backlog for weeks.

## Drain — 50 verdicts, each with evidence

- **4 resolved**, spot-checked against master. One of them *is* a real fix made during this drain: `gh pr merge --auto` could merge red because branch protection had **zero required checks** — now `master` requires the three CI contexts with `strict: true` (verified via `gh api`).
- **2 noise, 44 accepted** — operator-gated externals, named design boundaries, conditional watch-triggers, each with its cost of ignorance named per the E152 contract.
- **The 121 cross-project findings were deliberately NOT closed.** Their substance needs each repo's owner; closing them from here is the fabrication the E148 precedent forbids. They stay open in their own project's scope.

## Structural fix

`open_deferred_discoveries()` had no project filter while its siblings `list_deferred_discoveries`/`list_protocols` both did — that asymmetry was the whole defect. Now: project-scoped views for the banner and `deferred list` (`--all-projects` restores global), with unattributable entries always *counted*, never dropped.

**The cap is now per project.** With 118 findings from another repo, episteme could not record a single new finding despite an empty backlog — one repo's activity causing silent finding-loss in every other, the same silent-outage class E157 fixed. Proven fixed: the two E161 discoveries the global cap had declined now file cleanly.

## Independent review found 3 blocking bugs — all fixed (second commit)

Reproduced against the live ledger and real worktrees:
1. `Path.cwd().name` minted a phantom project per subdir and per agent worktree (`agent-<hex>`, each with its own cap). Now a shared `canonical_project_key()` walks to the repo root, checking `.git`-as-directory first — a worktree is a full checkout carrying its own `.episteme/`, which defeated a naive walk. All five real paths (both worktrees, a subdir, `web/`, root) now resolve to `episteme`; the phantom `text_tablefree` folded back into sanomap.
2. The banner announced "writes paused" from a global sum while admission is per project — **every episteme session was told writes were paused while they were being admitted.** It now says so only when true, and otherwise names who is actually paused. The test that pinned the bug as correct was replaced with its inverse.
3. An unattributed write fell back to global scope and mass-expired *another project's* aged findings — the exact invariant the relief valve states.

Plus: an explicit `DEFAULT_DEFERRED_GLOBAL_CAP = 300` (per-project caps had silently made the budget unbounded — hard rule 5 says a budget raise belongs in the diff), key normalization on both sides, two inverted comments corrected, scoped `resolve` remainder, and no more silently-swallowed read failures.

**One drain verdict was wrong and is corrected in the ledger, not quietly dropped:** the reviewer proved `default_autonomy_class` / `fence_check_strictness` are derived but read by nothing (0 consumers). I had verified derivation, not consumption. A correction entry is chained recording the false closure and the evidence (rule 11).

## Verification
Suite **1730 + 93 subtests, 0 failed**. Live-verified against the real ledger, both live worktrees, and the actual SessionStart banner.