### PR TITLE
fix(sync): Event 166 — refuse to deploy from a non-primary checkout (live incident)

### DIFF
--- a/src/episteme/adapters/claude.py
+++ b/src/episteme/adapters/claude.py
@@ -597,6 +597,12 @@ def sync(governance_mode: str = "balanced") -> None:
             {
                 "governance_pack": (governance_mode or "balanced").strip().lower(),
                 "synced_at": datetime.now(timezone.utc).isoformat(),
+                # Event 166 — which checkout deployed. The next sync
+                # compares against this to refuse a clobber from a
+                # second clone/worktree (a scratchpad clone once
+                # rewrote the operator's global memory to point at its
+                # own example files).
+                "repo_root": str(_cli.REPO_ROOT),
                 "deployed_skills": deployed_skills,
                 "deployed_agents": deployed_agents,
             },

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import uuid
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -1647,6 +1648,84 @@ def _stamp_volatile_facts(
                 continue
             changed.append(path)
     return changed
+
+
+def sync_origin_problem(repo_root: Path, claude_root: Path) -> str | None:
+    """Why this checkout must not deploy — or None when it may.
+
+    Event 166, from a live incident: a sync run from a scratchpad CLONE
+    rewrote the operator's real ``~/.claude/CLAUDE.md`` to @-reference
+    that clone's EXAMPLE memory files, silently replacing the encoded
+    operator profile with defaults for every future session. The kernel
+    already carried the rule ("[K] never run episteme sync from a
+    worktree") but it was prose wired to no gate — inert by the kernel's
+    own D11 standard.
+
+    Three refusals, cheapest first. Each names a checkout that is
+    structurally NOT the operator's primary one:
+
+    1. a linked git worktree (``.git`` is a FILE, not a directory),
+    2. a checkout under a temp root (``/tmp``, ``/private/tmp``, ...),
+    3. a repo root differing from the one the last sync recorded.
+
+    (3) is the general case; (1) and (2) catch a FIRST-EVER sync from a
+    throwaway checkout, which has no prior root to differ from. The
+    escape hatch is explicit (``--force``): moving the primary checkout
+    is legitimate and must stay possible.
+    """
+    git_path = repo_root / ".git"
+    if git_path.is_file():
+        return (
+            f"this checkout is a linked git worktree ({repo_root}). Sync "
+            f"resolves memory from the CURRENT checkout, so deploying from "
+            f"a worktree overwrites the operator's real ~/.claude with the "
+            f"worktree's copy."
+        )
+    tmp_roots = (Path("/tmp"), Path("/private/tmp"), Path(tempfile.gettempdir()))
+    for tmp_root in tmp_roots:
+        try:
+            repo_root.relative_to(tmp_root.resolve())
+        except (ValueError, OSError):
+            continue
+        return (
+            f"this checkout lives under a temp root ({repo_root}). A "
+            f"throwaway clone must never become the source of the "
+            f"operator's global memory."
+        )
+    try:
+        from .adapters import claude as _claude_meta
+        prior = _claude_meta.read_sync_meta(claude_root).get("repo_root")
+    except Exception:
+        prior = None
+    if isinstance(prior, str) and prior.strip():
+        prior_path = Path(prior).resolve()
+        if prior_path != repo_root.resolve() and prior_path.exists():
+            return (
+                f"this checkout ({repo_root}) is not the one that last "
+                f"deployed ({prior_path}). Syncing from a second checkout "
+                f"replaces the operator's global memory with this copy's."
+            )
+    return None
+
+
+def _enforce_sync_origin(claude_root: Path, force: bool) -> int | None:
+    """Print + refuse when the origin is wrong. Returns an exit code to
+    propagate, or None to proceed. ``--force`` downgrades to a warning
+    so a deliberate primary-checkout move stays possible."""
+    problem = sync_origin_problem(REPO_ROOT, claude_root)
+    if problem is None:
+        return None
+    if force:
+        print(f"[warn] sync origin: {problem}\n"
+              f"       Proceeding because --force was passed.", file=sys.stderr)
+        return None
+    print(
+        f"[episteme sync] refused — {problem}\n"
+        f"  Deploy from the primary checkout instead, or pass --force if "
+        f"you intend this checkout to become the primary one.",
+        file=sys.stderr,
+    )
+    return 2
 
 
 def _sync_user_runtime(governance_mode: str = "balanced") -> None:
@@ -5813,6 +5892,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Dry-run: show what would be written/updated without making changes. Exits 1 if changes needed.",
     )
+    sync.add_argument(
+        "--force",
+        action="store_true",
+        help="Deploy even when this checkout is not the one that last synced (worktree / clone / moved primary). Use when you intend THIS checkout to become the primary one.",
+    )
     sub.add_parser("update", help="Pull the latest episteme from git")
     sub.add_parser("list", help="Show installed agents, skills, plugins, and active hooks")
     sub.add_parser("validate", help="Check manifest integrity — every declared skill must have a SKILL.md")
@@ -6836,6 +6920,14 @@ def main(argv: Iterable[str] | None = None) -> int:
     if args.command == "sync":
         if getattr(args, "check", False):
             return _sync_check(getattr(args, "governance_pack", "balanced"))
+        # Event 166 — refuse to deploy from a checkout that is not the
+        # operator's primary one; a clobbered ~/.claude/CLAUDE.md is
+        # silent and affects every future session.
+        _refusal = _enforce_sync_origin(
+            HOME / ".claude", getattr(args, "force", False)
+        )
+        if _refusal is not None:
+            return _refusal
         print("🛸 Transitioning Soul to all available vessels...")
         _sync_user_runtime(getattr(args, "governance_pack", "balanced"))
         print("✅ Transition complete. Your agents are now aware.")

--- a/tests/test_sync_selfheal.py
+++ b/tests/test_sync_selfheal.py
@@ -275,3 +275,84 @@ class DeployPruneTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SyncOriginGuardTests(unittest.TestCase):
+    """Event 166, from a live incident — a sync run from a scratchpad
+    CLONE rewrote the operator's real ~/.claude/CLAUDE.md to @-reference
+    that clone's EXAMPLE memory files, silently swapping the encoded
+    operator profile for defaults in every future session. The kernel
+    already had the rule ('never sync from a worktree') as prose wired
+    to no gate."""
+
+    def test_primary_checkout_is_allowed(self):
+        with _TmpHome() as th:
+            self.assertIsNone(
+                cadapter.sync_origin_problem(ecli.REPO_ROOT, th.claude_root)
+                if hasattr(cadapter, "sync_origin_problem")
+                else ecli.sync_origin_problem(ecli.REPO_ROOT, th.claude_root)
+            )
+
+    def test_linked_worktree_refused(self):
+        with _TmpHome() as th, tempfile.TemporaryDirectory() as td:
+            wt = Path(td) / "wt"
+            wt.mkdir()
+            # A linked worktree carries .git as a FILE, not a directory.
+            (wt / ".git").write_text("gitdir: /elsewhere/.git/worktrees/wt")
+            problem = ecli.sync_origin_problem(wt, th.claude_root)
+            assert problem is not None
+            self.assertIn("worktree", problem)
+
+    def test_temp_checkout_refused(self):
+        with _TmpHome() as th, tempfile.TemporaryDirectory() as td:
+            clone = Path(td).resolve() / "repo2"
+            (clone / ".git").mkdir(parents=True)
+            problem = ecli.sync_origin_problem(clone, th.claude_root)
+            assert problem is not None
+            self.assertIn("temp root", problem)
+
+    def test_second_checkout_refused_when_sidecar_names_another(self):
+        with _TmpHome() as th, tempfile.TemporaryDirectory() as td:
+            other = Path(td) / "other-checkout"
+            (other / ".git").mkdir(parents=True)
+            meta = cadapter.read_sync_meta(th.claude_root)
+            meta["repo_root"] = str(other)
+            (th.claude_root / cadapter.SYNC_META_FILENAME).write_text(
+                json.dumps(meta), encoding="utf-8"
+            )
+            problem = ecli.sync_origin_problem(ecli.REPO_ROOT, th.claude_root)
+            assert problem is not None
+            self.assertIn("last deployed", problem)
+
+    def test_sidecar_records_repo_root(self):
+        with _TmpHome() as th:
+            meta = cadapter.read_sync_meta(th.claude_root)
+            self.assertEqual(meta.get("repo_root"), str(ecli.REPO_ROOT))
+
+    def test_missing_prior_root_does_not_refuse(self):
+        # First-ever sync has nothing to compare against.
+        with _TmpHome() as th:
+            meta = cadapter.read_sync_meta(th.claude_root)
+            meta.pop("repo_root", None)
+            (th.claude_root / cadapter.SYNC_META_FILENAME).write_text(
+                json.dumps(meta), encoding="utf-8"
+            )
+            self.assertIsNone(
+                ecli.sync_origin_problem(ecli.REPO_ROOT, th.claude_root)
+            )
+
+    def test_force_downgrades_refusal_to_warning(self):
+        with _TmpHome() as th, tempfile.TemporaryDirectory() as td:
+            other = Path(td) / "other-checkout"
+            (other / ".git").mkdir(parents=True)
+            meta = cadapter.read_sync_meta(th.claude_root)
+            meta["repo_root"] = str(other)
+            (th.claude_root / cadapter.SYNC_META_FILENAME).write_text(
+                json.dumps(meta), encoding="utf-8"
+            )
+            self.assertEqual(
+                ecli._enforce_sync_origin(th.claude_root, False), 2
+            )
+            self.assertIsNone(
+                ecli._enforce_sync_origin(th.claude_root, True)
+            )


### PR DESCRIPTION
## What happened

Mid-session, a sync run from a **scratchpad clone** rewrote the operator's real `~/.claude/CLAUDE.md` so its `@import`s pointed at that clone's `*.example.md` files. Every future session would have loaded generic defaults instead of the encoded operator profile — silently, because the file still looked perfectly well-formed. It was caught only because the clobbered file happened to surface in context.

Restored by syncing from the primary checkout. This PR makes it unrepeatable.

## Why it was possible

The kernel already carried the rule — *"[K] never run `episteme sync` from a worktree"* — as **prose wired to no gate**. Inert by the kernel's own D11 standard, and the blast radius is every future session on the machine.

## The guard

Three refusals, cheapest first, each identifying a checkout that structurally is not the operator's primary one:

1. a **linked git worktree** (`.git` is a FILE, not a directory),
2. a checkout under a **temp root** (`/tmp`, `/private/tmp`, `TMPDIR`),
3. a **repo root differing** from the one the last sync recorded.

(3) is the general case; (1) and (2) catch a first-ever sync from a throwaway checkout, which has no prior root to differ from. The sync sidecar now records `repo_root` alongside the E150 governance pack and E159 deploy manifest.

`--force` is the explicit escape — relocating the primary checkout is legitimate, and it downgrades the refusal to a visible warning rather than hiding it.

## Verification

Suite **1737 + 93 subtests, 0 failed**, including 7 new tests: primary allowed, worktree refused, temp refused, second-checkout refused, sidecar records the root, first-ever sync doesn't refuse, and `--force` downgrades to a warning.