### PR TITLE
feat(adapters): Event 167 — implement the Codex adapter (declared, never wired)

### DIFF
--- a/src/episteme/adapters/codex.py
+++ b/src/episteme/adapters/codex.py
@@ -1,0 +1,113 @@
+"""Codex CLI adapter. Mounts the operator context into ~/.codex as a
+managed region inside AGENTS.md, and adds managed skills alongside the
+operator's own.
+
+Event 167 — the adapter was DECLARED in ``core/adapters/codex.json``
+(detect paths, ``sync.skills_dir``, ``project_contract: AGENTS.md``, and
+the explicit note that episteme must not overwrite
+``~/.codex/skills/.system``) but never implemented: ``episteme sync``
+wrote to Claude, Hermes, OMO and OMX, so a Codex session carried none of
+the operator's governance state.
+
+## Why a managed REGION, not a managed file
+
+``~/.codex/AGENTS.md`` is the operator's own primary contract — 428 lines
+of hand-authored directives at the time this shipped, starting with an
+autonomy directive that predates episteme. Codex reads it the way Claude
+Code reads ``CLAUDE.md``. Overwriting it would destroy operator content
+that exists nowhere else, which is precisely the failure Event 166
+recovered from hours earlier in the same session (a sync from a
+throwaway checkout rewrote the operator's global memory to point at
+example files).
+
+So this adapter uses ``_write_managed_file``: episteme owns only the
+text between its markers, and every byte outside them survives every
+sync. The managed block is appended on first sync and updated in place
+thereafter.
+
+## Posture conflict is surfaced, not resolved
+
+The operator's existing directive tells Codex to execute autonomously
+without asking. episteme's posture gates irreversible operations. Those
+are in genuine tension, and an adapter is the wrong place to silently
+pick a winner — so the managed block states the precedence question
+plainly and leaves the resolution to the operator's own text.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .. import cli as _cli
+
+
+# Distinct from the default marker so a future Codex-specific migration
+# can find exactly this block without touching other managed files.
+CODEX_MARKER = "episteme:codex"
+
+# The adapter spec forbids touching this: it is Codex's own bundled
+# skill namespace, not ours to manage.
+PROTECTED_SKILL_DIRS = {".system"}
+
+
+def _compose_codex_context() -> str:
+    """The managed block written into ~/.codex/AGENTS.md.
+
+    Path-references the operator's real memory files rather than
+    inlining them: the files are the source of truth, they change on
+    every `episteme sync`, and a copy here would silently rot.
+    """
+    memory = _cli.REPO_ROOT / "core" / "memory" / "global"
+    digest = _cli._resolve_memory_file("runtime_digest")
+    feedback = _cli._resolve_memory_file("agent_feedback")
+    python_policy = _cli._resolve_memory_file("python_runtime_policy")
+    return (
+        "# episteme — operator governance contract\n\n"
+        "Managed by `episteme sync`. Edit the source of truth in\n"
+        f"`{memory}`, not this block — changes here are overwritten.\n\n"
+        "## Always-on\n\n"
+        f"- `{digest}` — the single control surface: precedence contract,\n"
+        "  hard rules, decision posture, session flow.\n"
+        f"- `{feedback}` — behavioral rules learned across sessions\n"
+        "  (includes: never add AI-attribution trailers to commits or PRs).\n"
+        f"- `{python_policy}` — Python runtime policy for this machine.\n\n"
+        "## Read on demand\n\n"
+        f"- `{memory / 'cognitive_profile.md'}` — mental models + Decision Protocol\n"
+        f"- `{memory / 'workflow_policy.md'}` — the five stages, signal-over-noise rules\n"
+        f"- `{memory / 'operator_profile.md'}` — per-axis operator profile\n"
+        f"- `{memory / 'overview.md'}` — project topology\n\n"
+        "## Precedence with the rest of this file\n\n"
+        "This block is additive. Where a directive elsewhere in AGENTS.md\n"
+        "conflicts with the governance posture above — most likely around\n"
+        "autonomy versus gating irreversible operations — the operator's\n"
+        "own text in this file wins, and the conflict should be raised\n"
+        "rather than silently resolved in either direction.\n"
+    )
+
+
+def sync() -> bool:
+    """Mount operator context + managed skills into ~/.codex if present.
+
+    Returns True when Codex was found and synced, False when it is not
+    installed. Never removes or rewrites operator-authored content.
+    """
+    codex_root = _cli.HOME / ".codex"
+    if not codex_root.exists():
+        return False
+
+    skills_dst = codex_root / "skills"
+    for skill_dir in _cli._managed_skills():
+        if skill_dir.name in PROTECTED_SKILL_DIRS:
+            continue
+        _cli._copy_tree(skill_dir, skills_dst / skill_dir.name)
+
+    # AGENTS.md is Codex's project contract AND the operator's own file.
+    # Managed-region write: everything outside the markers is preserved.
+    _cli._write_managed_file(
+        codex_root / "AGENTS.md",
+        _compose_codex_context(),
+        marker=CODEX_MARKER,
+    )
+    return True
+
+
+__all__ = ["sync", "CODEX_MARKER", "PROTECTED_SKILL_DIRS"]

--- a/src/episteme/cli.py
+++ b/src/episteme/cli.py
@@ -1730,6 +1730,7 @@ def _enforce_sync_origin(claude_root: Path, force: bool) -> int | None:
 
 def _sync_user_runtime(governance_mode: str = "balanced") -> None:
     from .adapters import claude as _claude
+    from .adapters import codex as _codex
     from .adapters import hermes as _hermes
     from .adapters import omo as _omo
     from .adapters import omx as _omx
@@ -1751,6 +1752,9 @@ def _sync_user_runtime(governance_mode: str = "balanced") -> None:
 
     _claude.sync(governance_mode)
     hermes_synced = _hermes.sync()
+    # Event 167 — Codex was declared in core/adapters/codex.json but had
+    # no implementation, so `episteme sync` never reached it.
+    codex_synced = _codex.sync()
     omo_synced = _omo.sync(governance_mode)
     omx_synced = _omx.sync(governance_mode)
 
@@ -1761,6 +1765,8 @@ def _sync_user_runtime(governance_mode: str = "balanced") -> None:
         print(f"  - Stamped version facts in {len(_stamped)} doc(s)")
     if hermes_synced:
         print(f"  - Hermes: {HOME / '.hermes'}")
+    if codex_synced:
+        print(f"  - Codex: {HOME / '.codex'} (managed region in AGENTS.md)")
     if omo_synced:
         print(f"  - OMO: {HOME / '.omo'}")
     if omx_synced:

--- a/tests/test_sync_selfheal.py
+++ b/tests/test_sync_selfheal.py
@@ -356,3 +356,132 @@ class SyncOriginGuardTests(unittest.TestCase):
             self.assertIsNone(
                 ecli._enforce_sync_origin(th.claude_root, True)
             )
+
+
+class CodexAdapterTests(unittest.TestCase):
+    """Event 167 — the Codex adapter was DECLARED in
+    core/adapters/codex.json but never implemented, so `episteme sync`
+    never reached ~/.codex. AGENTS.md there is the operator's own
+    contract (428 lines of hand-authored directives when this shipped),
+    so the adapter must ADD a managed region and preserve every byte
+    outside it — the E166 clobber class, hours old at the time."""
+
+    def _codex_home(self, stack):
+        td = stack.enter_context(tempfile.TemporaryDirectory())
+        home = Path(td)
+        (home / ".codex").mkdir()
+        return home
+
+    def test_not_installed_is_a_no_op(self):
+        import contextlib
+        from episteme.adapters import codex as cadex  # pyright: ignore[reportMissingImports]
+        with contextlib.ExitStack() as stack:
+            td = stack.enter_context(tempfile.TemporaryDirectory())
+            orig, ecli.HOME = ecli.HOME, Path(td)  # no ~/.codex
+            try:
+                self.assertFalse(cadex.sync())
+            finally:
+                ecli.HOME = orig
+
+    def test_preserves_operator_authored_agents_md(self):
+        import contextlib
+        from episteme.adapters import codex as cadex  # pyright: ignore[reportMissingImports]
+        with contextlib.ExitStack() as stack:
+            home = self._codex_home(stack)
+            agents = home / ".codex" / "AGENTS.md"
+            operator_text = (
+                "<!-- AUTONOMY DIRECTIVE — DO NOT REMOVE -->\n"
+                "YOU ARE AN AUTONOMOUS CODING AGENT.\n\n"
+                "## My own section\n\nhand-authored, exists nowhere else\n"
+            )
+            agents.write_text(operator_text, encoding="utf-8")
+            orig, ecli.HOME = ecli.HOME, home
+            try:
+                self.assertTrue(cadex.sync())
+                after = agents.read_text(encoding="utf-8")
+            finally:
+                ecli.HOME = orig
+            # Every operator line survives, verbatim.
+            for line in operator_text.strip().splitlines():
+                self.assertIn(line, after)
+            self.assertIn("episteme — operator governance contract", after)
+
+    def test_resync_is_idempotent_and_still_preserves(self):
+        import contextlib
+        from episteme.adapters import codex as cadex  # pyright: ignore[reportMissingImports]
+        with contextlib.ExitStack() as stack:
+            home = self._codex_home(stack)
+            agents = home / ".codex" / "AGENTS.md"
+            agents.write_text("## operator\nkeep me\n", encoding="utf-8")
+            orig, ecli.HOME = ecli.HOME, home
+            try:
+                runs = []
+                for _ in range(3):
+                    cadex.sync()
+                    runs.append(agents.read_text(encoding="utf-8"))
+            finally:
+                ecli.HOME = orig
+            # The shared _compose_managed_file primitive normalizes one
+            # blank line between the appended block and pre-existing
+            # content on the SECOND write, then converges. That is
+            # pre-existing behavior of the primitive (shared with the
+            # Claude and Hermes adapters), not something this adapter
+            # introduces — pinned here as the real contract rather than
+            # asserted away. Filed as a deferred discovery.
+            self.assertEqual(runs[1], runs[2], "must converge after the first resync")
+            # The properties that actually matter hold on EVERY run.
+            for r in runs:
+                self.assertIn("keep me", r)
+                self.assertEqual(r.count("episteme — operator governance contract"), 1)
+
+    def test_creates_agents_md_when_absent(self):
+        import contextlib
+        from episteme.adapters import codex as cadex  # pyright: ignore[reportMissingImports]
+        with contextlib.ExitStack() as stack:
+            home = self._codex_home(stack)
+            orig, ecli.HOME = ecli.HOME, home
+            try:
+                self.assertTrue(cadex.sync())
+            finally:
+                ecli.HOME = orig
+            self.assertTrue((home / ".codex" / "AGENTS.md").is_file())
+
+    def test_managed_skills_added_without_touching_operator_skills(self):
+        import contextlib
+        from episteme.adapters import codex as cadex  # pyright: ignore[reportMissingImports]
+        with contextlib.ExitStack() as stack:
+            home = self._codex_home(stack)
+            skills = home / ".codex" / "skills"
+            (skills / "ask-claude").mkdir(parents=True)
+            (skills / "ask-claude" / "SKILL.md").write_text("operator's own", encoding="utf-8")
+            system = skills / ".system"
+            system.mkdir()
+            (system / "bundled.md").write_text("codex bundled", encoding="utf-8")
+            orig, ecli.HOME = ecli.HOME, home
+            try:
+                cadex.sync()
+            finally:
+                ecli.HOME = orig
+            # Operator + Codex-bundled content untouched...
+            self.assertEqual(
+                (skills / "ask-claude" / "SKILL.md").read_text(encoding="utf-8"),
+                "operator's own",
+            )
+            self.assertEqual(
+                (system / "bundled.md").read_text(encoding="utf-8"), "codex bundled"
+            )
+            # ...and managed skills landed alongside.
+            managed = {d.name for d in ecli._managed_skills()}
+            deployed = {p.name for p in skills.iterdir() if p.is_dir()}
+            self.assertTrue(managed.issubset(deployed))
+
+    def test_declared_adapter_spec_matches_implementation(self):
+        # The JSON registry is the contract; drift between it and the
+        # code is what let this adapter sit unimplemented for months.
+        from episteme.adapters import codex as cadex  # pyright: ignore[reportMissingImports]
+        spec = json.loads(
+            (ecli.REPO_ROOT / "core" / "adapters" / "codex.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(spec["sync"]["skills_dir"], "~/.codex/skills")
+        self.assertEqual(spec["project_contract"], "AGENTS.md")
+        self.assertIn(".system", cadex.PROTECTED_SKILL_DIRS)


### PR DESCRIPTION
## The gap

`core/adapters/codex.json` has declared a Codex adapter for months — detect paths, `sync.skills_dir`, `project_contract: AGENTS.md`, and an explicit note not to touch `~/.codex/skills/.system`. **There was no implementation.** `src/episteme/adapters/` held claude, hermes, omo and omx, so `episteme sync` never reached Codex and `~/.codex/AGENTS.md` carried zero episteme content. The registry said one thing; the code did another.

## Managed region, not managed file

`~/.codex/AGENTS.md` is the operator's own contract — 428 lines of hand-authored directives on this machine, opening with an autonomy directive that predates episteme. Overwriting it destroys content that exists nowhere else, which is precisely the failure **Event 166 recovered from earlier the same day**. So this uses `_write_managed_file`: episteme owns only the text between its markers; everything outside survives every sync. Managed skills are *added* alongside the operator's own, and `.system` is skipped per the spec.

The block path-references the memory files instead of inlining them (so it can't rot), and it names the genuine posture conflict — an autonomy directive that says "never ask" versus a governance layer that gates irreversible operations — explicitly deferring to the operator's own text rather than letting an adapter silently pick a winner.

## Tests

Operator content preserved verbatim; `.system` and operator skills untouched; absent-Codex is a no-op; AGENTS.md created when missing; spec/implementation parity so the registry can't drift from the code again; and the **real** convergence behavior — the shared `_compose_managed_file` primitive normalizes one blank line on the second write and then converges. That's pre-existing behavior shared with the Claude and Hermes adapters, so it's pinned as the actual contract rather than asserted away, and filed as a deferred discovery.

Suite **1743 + 93 subtests, 0 failed**.