### PR TITLE
chore(docs): stamp 1.10.0-rc.1 version facts

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -125,7 +125,7 @@ Puedes regrabar tú mismo la demo estrella: `scripts/demo_posture.sh` (la receta
 
 ## Bajo el capó
 
-Estado: **<!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version -->** · La práctica son cinco etapas — Frame → Decompose → Execute → Verify → Handoff — y cada una existe para contrarrestar una forma concreta en que la mente falla bajo la fluidez: question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence. La historia completa está en [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md); los cuatro Cognitive Blueprints (Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade) están especificados en [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
+Estado: **<!-- episteme-fact:version -->1.10.0-rc.1<!-- /episteme-fact:version -->** · La práctica son cinco etapas — Frame → Decompose → Execute → Verify → Handoff — y cada una existe para contrarrestar una forma concreta en que la mente falla bajo la fluidez: question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence. La historia completa está en [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md); los cuatro Cognitive Blueprints (Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade) están especificados en [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 
 ```mermaid
 graph TD

--- a/README.ko.md
+++ b/README.ko.md
@@ -125,7 +125,7 @@ episteme doctor    # verify wiring
 
 ## 내부 구조
 
-상태: **<!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version -->** · 실천은 다섯 단계입니다 — Frame → Decompose → Execute → Verify → Handoff — 그리고 각 단계는 유창함 아래에서 사고가 무너지는 특정한 방식에 맞서기 위해 존재합니다: question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence. 전체 이야기는 [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md)에 있고, 네 개의 Cognitive Blueprint(Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade)는 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)에 명세돼 있습니다.
+상태: **<!-- episteme-fact:version -->1.10.0-rc.1<!-- /episteme-fact:version -->** · 실천은 다섯 단계입니다 — Frame → Decompose → Execute → Verify → Handoff — 그리고 각 단계는 유창함 아래에서 사고가 무너지는 특정한 방식에 맞서기 위해 존재합니다: question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence. 전체 이야기는 [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md)에 있고, 네 개의 Cognitive Blueprint(Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade)는 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)에 명세돼 있습니다.
 
 ```mermaid
 graph TD

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Re-record the hero demo yourself: `scripts/demo_posture.sh` (recipe in the scrip
 
 ## Under the hood
 
-Status: **<!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version -->** · The practice is five stages — Frame → Decompose → Execute → Verify → Handoff — and each one exists to counter a specific way minds go wrong under fluency: question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence. The full story is in [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md); the four Cognitive Blueprints (Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade) are specced in [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
+Status: **<!-- episteme-fact:version -->1.10.0-rc.1<!-- /episteme-fact:version -->** · The practice is five stages — Frame → Decompose → Execute → Verify → Handoff — and each one exists to counter a specific way minds go wrong under fluency: question substitution, WYSIATI, anchoring, narrative fallacy, planning fallacy, overconfidence. The full story is in [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md); the four Cognitive Blueprints (Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade) are specced in [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md).
 
 ```mermaid
 graph TD

--- a/README.zh.md
+++ b/README.zh.md
@@ -125,7 +125,7 @@ episteme doctor    # verify wiring
 
 ## 底层原理
 
-状态：**<!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version -->** · 这套实践一共五步 —— Frame → Decompose → Execute → Verify → Handoff —— 而每一步的存在，都是为了对付人在"顺畅"状态下出错的一种特定方式：question substitution、WYSIATI、anchoring、narrative fallacy、planning fallacy、overconfidence。完整的来龙去脉在 [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md)；四个 Cognitive Blueprints（Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade）的规格在 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)。
+状态：**<!-- episteme-fact:version -->1.10.0-rc.1<!-- /episteme-fact:version -->** · 这套实践一共五步 —— Frame → Decompose → Execute → Verify → Handoff —— 而每一步的存在，都是为了对付人在"顺畅"状态下出错的一种特定方式：question substitution、WYSIATI、anchoring、narrative fallacy、planning fallacy、overconfidence。完整的来龙去脉在 [`docs/THE_WAY_TO_THINK.md`](./docs/THE_WAY_TO_THINK.md)；四个 Cognitive Blueprints（Axiomatic Judgment · Fence Reconstruction · Consequence Chain · Architectural Cascade）的规格在 [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)。
 
 ```mermaid
 graph TD

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 <!-- episteme-lifecycle: status=living; reviewed_as_of=E147 -->
-# Architecture — The Sovereign Kernel (<!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version -->)
+# Architecture — The Sovereign Kernel (<!-- episteme-fact:version -->1.10.0-rc.1<!-- /episteme-fact:version -->)
 
 > Mermaid flowchart. Renders natively on GitHub, Obsidian, and any CommonMark viewer with Mermaid support. **Five** subgraphs trace the full lifecycle from agent intention through the three-pillar kernel — Cognitive Blueprints, Append-Only Hash Chain, Framework Synthesis & Active Guidance — into praxis, the learning loop, and the post-v1.0-RC behavior-conformance extensions (Event 130 — Contract Gate; Event 131 — FAILURE_MODES mode 12 + CALIBRATION_TELEMETRY).
 >
-> **State.** This diagram depicts the **v1.0 RC shipped state** (spec: [`./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md), status *approved (reframed, third pass)* 2026-04-21) plus the v1.2-RC behavior-conformance extensions in Subgraph ⑤. All ten RC checkpoints shipped with paused-review-before-commit discipline. Current head: <!-- episteme-fact:version -->1.10.0-rc<!-- /episteme-fact:version --> (via release-please; test counts are owned by CI, not this prose). v1.3.0-rc2 stages from this Event's `feat:` commits; release-please regenerates the staging PR automatically — no manual version edit.
+> **State.** This diagram depicts the **v1.0 RC shipped state** (spec: [`./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md`](./DESIGN_V1_0_SEMANTIC_GOVERNANCE.md), status *approved (reframed, third pass)* 2026-04-21) plus the v1.2-RC behavior-conformance extensions in Subgraph ⑤. All ten RC checkpoints shipped with paused-review-before-commit discipline. Current head: <!-- episteme-fact:version -->1.10.0-rc.1<!-- /episteme-fact:version --> (via release-please; test counts are owned by CI, not this prose). v1.3.0-rc2 stages from this Event's `feat:` commits; release-please regenerates the staging PR automatically — no manual version edit.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ hand-edit between the markers; run the command and commit the result.
 <!-- episteme-docs-index:start -->
 - [`ADAPTER_PORTABILITY.md`](./ADAPTER_PORTABILITY.md) · report · Adapter Portability Audit
 - [`ANTHROPIC_MANAGED_AGENTS_BRIDGE.md`](./ANTHROPIC_MANAGED_AGENTS_BRIDGE.md) · living · Anthropic Managed Agents Bridge
-- [`ARCHITECTURE.md`](./ARCHITECTURE.md) · living · Architecture — The Sovereign Kernel (1.10.0-rc)
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) · living · Architecture — The Sovereign Kernel (1.10.0-rc.1)
 - [`COMMANDS.md`](./COMMANDS.md) · living · episteme — command reference
 - [`COMPLIANCE_CROSSWALK.md`](./COMPLIANCE_CROSSWALK.md) · living · Compliance Crosswalk — `signed-surface@1.0` → Regulatory Clauses
 - [`CONTRACT_GATE.md`](./CONTRACT_GATE.md) · living · Contract Gate — deterministic contract-test complement to the Reasoning Surface


### PR DESCRIPTION
Mechanical output of `episteme sync` after the 1.10.0-rc.1 release: the volatile-fact stamper refreshes release-coupled version strings in tracked docs (README ×4, ARCHITECTURE, generated docs index) so no surface carries a stale version. No prose changes.