### PR TITLE
fix(governance): Event 170 — operational-doc rot detector, toxic-clone hook purge, PROGRESS closure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,7 +342,7 @@ Before this config, `prerelease: true` + `prerelease-type: rc` ran under the **d
 ## Commit and handoff conventions
 
 - Commit messages: imperative mood, scoped (`kernel: …`, `docs: …`, `adapters: …`). Checkpoint commits use the Conventional-Commits-valid prefix `chore(chkpt):`.
-- Maintainer workflow — **handoff semantics (compaction discipline, Event 145):** a handoff (1) **REPLACES** the private `NEXT_STEPS.md` (current state · decisions-waiting · next actions · backlog · standing rules) and (2) **appends exactly one line** to the private `EVENTS.md` history index (`| E<N> | date | one-line what | PR/commit/tag refs |`). Appending a "Prior resume" block to `NEXT_STEPS.md` is a protocol violation — the append stack was the accretion disease compaction removed. `PROGRESS.md` is retired to a tombstone that points at `EVENTS.md` + the archive; do not append events to it (its verbatim history lives under `~/episteme-private/docs/archive/`). Each handoff carries a Reasoning Surface block and ends with a one-sentence "So-What Now?".
+- Maintainer workflow — **handoff semantics (compaction discipline, Event 145):** a handoff (1) **REPLACES** the private `NEXT_STEPS.md` (current state · decisions-waiting · next actions · backlog · standing rules) and (2) **appends exactly one line** to the private `EVENTS.md` history index (`| E<N> | date | one-line what | PR/commit/tag refs |`). Appending a "Prior resume" block to `NEXT_STEPS.md` is a protocol violation — the append stack was the accretion disease compaction removed. `PROGRESS.md` is fully retired (tombstone removed E170); its verbatim history lives under `~/episteme-private/docs/archive/`. Do not recreate it. Each handoff carries a Reasoning Surface block and ends with a one-sentence "So-What Now?".
 - External contributor workflow: include the Reasoning Surface block + "So-What Now?" inline in the PR description; the maintainer integrates these into the operational record on merge. Contributors do not need to update operational docs themselves.
 - Branch naming: `event-NN-shortname` for maintainer-ordered Events (numbering tracked in the maintainer's operational record); `feat/<name>`, `fix/<name>`, `research/<name>`, `ops/<name>`, `docs/<name>` for non-Event work.
 
@@ -361,7 +361,7 @@ Before creating or moving any doc under `docs/`, classify it. The repo splits `d
 
 **PRIVATE tier (symlink to `~/episteme-private/docs/<name>`, gitignore the symlink):**
 
-- Operational state — *"where I am, what I'm doing, what I'm fighting"*: `NEXT_STEPS.md` (REPLACE-on-handoff; carries the active-plan pointer since PLAN.md was retired at Event 168 — it never got tracked), `EVENTS.md` (append-one-line history index), `PROGRESS.md` (retired tombstone), `*_TRIAGE.md`, `*_CALIBRATION.md`.
+- Operational state — *"where I am, what I'm doing, what I'm fighting"*: `NEXT_STEPS.md` (REPLACE-on-handoff; carries the active-plan pointer since PLAN.md was retired at Event 168 — it never got tracked), `EVENTS.md` (append-one-line history index), `*_TRIAGE.md`, `*_CALIBRATION.md`. (`PROGRESS.md`'s tombstone was fully removed at Event 170 — its guard condition had already dissolved in the E147/E153 policy rewrites.)
 - Operating contract / positioning narrative — *"how I work / how I market"*: `PLAYBOOK.md` (merged operating contract), `POSTURE.md`, `NARRATIVE.md`.
 - Historical decision logs (`DECISION_STORY.md`-class once filled with content).
 - Anything that documents the operator's *how I work* or *how I market*.

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -860,6 +860,14 @@ def main() -> int:
     if doc_staleness_line:
         lines.append(doc_staleness_line)
 
+    # Event 170 · the PLAN.md-class detector — private-doc SYMLINKS are
+    # exempt from lifecycle lint (no markers, no git), which is exactly
+    # how PLAN.md rotted 13 days unnoticed until the OPERATOR caught it.
+    # Silent when the operational set moves together.
+    rot_line = _operational_rot_line()
+    if rot_line:
+        lines.append(rot_line)
+
     # Phase A · v1.0.1 — noise-watch advisory derived from the operator
     # profile's cognitive.noise_signature axis. Silent when the knob is
     # absent. Ordering: AFTER the framework digest so the cognitive

--- a/core/hooks/session_context.py
+++ b/core/hooks/session_context.py
@@ -392,6 +392,68 @@ _DOC_STALENESS_EVENT_LAG = 15
 _DOC_STALENESS_DATE_DAYS = 45
 
 
+_OPERATIONAL_ROT_GRACE_DAYS = 7
+
+
+def _operational_rot_line() -> str | None:
+    """Event 170 — the PLAN.md-class detector.
+
+    The doc-lifecycle staleness machinery deliberately scans only
+    TRACKED ``docs/*.md`` with lifecycle markers, which exempts exactly
+    the operational docs that need freshness most: the private-doc
+    SYMLINKS (no markers, no git history). That blind spot is how
+    ``PLAN.md`` sat untouched for 13 days across ten handoffs until the
+    OPERATOR caught it by hand — every handoff moved ``NEXT_STEPS`` and
+    ``EVENTS`` while a doc still referenced as authoritative rotted
+    silently.
+
+    Rule: every ``docs/*.md`` symlink with an existing target is an
+    operational doc; the newest mtime among them is "last handoff
+    time"; any sibling lagging it by more than
+    ``_OPERATIONAL_ROT_GRACE_DAYS`` is named. One line, silent when
+    clean. The remedy is the operator's (track it or retire it) — the
+    banner's job is to make sure a human never has to be the detector
+    again."""
+    try:
+        docs_dir = Path("docs")
+        if not docs_dir.is_dir():
+            return None
+        targets: list[tuple[str, float]] = []
+        for link in sorted(docs_dir.glob("*.md")):
+            if not link.is_symlink():
+                continue
+            try:
+                if not link.exists():
+                    # A dangling operational symlink is rot of a harder
+                    # kind — name it immediately.
+                    return (
+                        f"operational doc rot: {link} is a DANGLING symlink "
+                        f"— retire it or restore its target"
+                    )
+                targets.append((link.name, link.stat().st_mtime))
+            except OSError:
+                continue
+        if len(targets) < 2:
+            return None
+        newest = max(m for _, m in targets)
+        grace = _OPERATIONAL_ROT_GRACE_DAYS * 86400
+        rotting = [
+            (name, int((newest - m) / 86400))
+            for name, m in targets
+            if (newest - m) > grace
+        ]
+        if not rotting:
+            return None
+        worst = ", ".join(f"{n} ({d}d behind)" for n, d in sorted(
+            rotting, key=lambda x: -x[1]))
+        return (
+            f"operational doc rot: {worst} — untouched while handoffs "
+            f"moved on; track it or retire it (PLAN.md died of this, E168)"
+        )
+    except Exception:
+        return None
+
+
 def _doc_staleness_line() -> str | None:
     """Event 147 · doc-lifecycle staleness banner.
 

--- a/src/episteme/adapters/claude.py
+++ b/src/episteme/adapters/claude.py
@@ -297,13 +297,50 @@ def _collect_managed_hook_commands(settings: dict) -> set[str]:
     return commands
 
 
+def _managed_hook_basenames() -> set[str]:
+    """Script filenames of every managed hook across all packs."""
+    names: set[str] = set()
+    for m in ("minimal", "balanced", "strict"):
+        for cmd in _collect_managed_hook_commands(build_settings(m)):
+            for tok in cmd.split():
+                if tok.endswith(".py"):
+                    names.add(Path(tok).name)
+    return names
+
+
+def _is_toxic_clone_hook(cmd: str, managed_basenames: set[str]) -> bool:
+    """Event 170, from a live incident: the E166 rogue sync from a
+    scratchpad clone also MERGED its clone-path hook registrations into
+    settings.json, and the positive-system 'keep external hooks' rule
+    preserved them — 19 scripts then ran DOUBLE on every governed op
+    (double telemetry, double gates, doubled advisories).
+
+    The separating rule: a command whose script BASENAME matches a
+    managed hook but whose path lies OUTSIDE the primary checkout is a
+    clone's residue, not operator content — the operator's own hooks
+    have their own names. Managed-named scripts under REPO_ROOT stay;
+    non-managed names stay unconditionally."""
+    for tok in cmd.split():
+        if not tok.endswith(".py"):
+            continue
+        p = Path(tok)
+        if p.name in managed_basenames and not str(p).startswith(
+            str(_cli.REPO_ROOT)
+        ):
+            return True
+    return False
+
+
 def prune_managed_hook_entries(settings: dict, governance_mode: str) -> dict:
-    """Keep external hooks, but remove managed hooks not in the selected pack."""
+    """Keep external hooks, but remove managed hooks not in the selected
+    pack — and remove managed-NAMED hooks registered from outside the
+    primary checkout (toxic clone residue; see _is_toxic_clone_hook)."""
     mode = (governance_mode or "balanced").strip().lower()
     expected = _collect_managed_hook_commands(build_settings(mode))
     managed_any: set[str] = set()
     for m in ("minimal", "balanced", "strict"):
         managed_any.update(_collect_managed_hook_commands(build_settings(m)))
+    managed_basenames = _managed_hook_basenames()
 
     hooks = settings.get("hooks")
     if not isinstance(hooks, dict):
@@ -331,8 +368,13 @@ def prune_managed_hook_entries(settings: dict, governance_mode: str) -> dict:
                 if not isinstance(h, dict):
                     kept_hooks.append(h)
                     continue
-                cmd = normalize_hook_command(str(h.get("command", "")))
+                raw_cmd = str(h.get("command", ""))
+                cmd = normalize_hook_command(raw_cmd)
                 if cmd and cmd in managed_any and cmd not in expected:
+                    continue
+                if raw_cmd and _is_toxic_clone_hook(
+                    raw_cmd, managed_basenames
+                ):
                     continue
                 kept_hooks.append(h)
 

--- a/tests/test_session_context_operational_rot.py
+++ b/tests/test_session_context_operational_rot.py
@@ -1,0 +1,104 @@
+"""Event 170 — the PLAN.md-class detector.
+
+Private-doc symlinks are exempt from lifecycle lint (no markers, no git
+history) — the blind spot that let docs/PLAN.md rot 13 days across ten
+handoffs until the OPERATOR caught it by hand. `_operational_rot_line`
+watches the symlinked operational set as a cohort: when one member lags
+the newest by more than the grace window, it gets named at SessionStart.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+from core.hooks import session_context as sc  # pyright: ignore[reportAttributeAccessIssue]
+
+
+@contextmanager
+def _chdir(path: Path):
+    prev = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev)
+
+
+def _mk_link(root: Path, name: str, *, age_days: float, now: float) -> None:
+    real = root / "private" / f"{name}.real"
+    real.parent.mkdir(exist_ok=True)
+    real.write_text("content", encoding="utf-8")
+    stamp = now - age_days * 86400
+    os.utime(real, (stamp, stamp))
+    (root / "docs" / name).symlink_to(real)
+
+
+class OperationalRotTests(unittest.TestCase):
+    def _root(self, stack):
+        td = stack.enter_context(tempfile.TemporaryDirectory())
+        root = Path(td)
+        (root / "docs").mkdir()
+        return root
+
+    def test_silent_when_cohort_moves_together(self):
+        import contextlib, time
+        now = time.time()
+        with contextlib.ExitStack() as stack:
+            root = self._root(stack)
+            _mk_link(root, "NEXT_STEPS.md", age_days=0.1, now=now)
+            _mk_link(root, "EVENTS.md", age_days=2, now=now)  # within grace
+            with _chdir(root):
+                self.assertIsNone(sc._operational_rot_line())
+
+    def test_names_the_rotting_doc_with_lag(self):
+        import contextlib, time
+        now = time.time()
+        with contextlib.ExitStack() as stack:
+            root = self._root(stack)
+            _mk_link(root, "NEXT_STEPS.md", age_days=0.1, now=now)
+            _mk_link(root, "SOME_PLAN.md", age_days=13, now=now)  # the PLAN case
+            with _chdir(root):
+                line = sc._operational_rot_line()
+            assert line is not None
+            self.assertIn("operational doc rot", line)
+            self.assertIn("SOME_PLAN.md", line)
+            self.assertIn("12d behind", line)
+            self.assertIn("track it or retire it", line)
+
+    def test_dangling_symlink_named_immediately(self):
+        import contextlib
+        with contextlib.ExitStack() as stack:
+            root = self._root(stack)
+            (root / "docs" / "GONE.md").symlink_to(root / "private" / "missing.md")
+            with _chdir(root):
+                line = sc._operational_rot_line()
+            assert line is not None
+            self.assertIn("DANGLING", line)
+            self.assertIn("GONE.md", line)
+
+    def test_silent_with_fewer_than_two_members(self):
+        import contextlib, time
+        with contextlib.ExitStack() as stack:
+            root = self._root(stack)
+            _mk_link(root, "NEXT_STEPS.md", age_days=30, now=time.time())
+            with _chdir(root):
+                self.assertIsNone(sc._operational_rot_line())
+
+    def test_regular_files_are_not_cohort_members(self):
+        import contextlib, time
+        now = time.time()
+        with contextlib.ExitStack() as stack:
+            root = self._root(stack)
+            _mk_link(root, "NEXT_STEPS.md", age_days=0.1, now=now)
+            old = root / "docs" / "TRACKED.md"
+            old.write_text("tracked docs have lifecycle lint", encoding="utf-8")
+            os.utime(old, (now - 40 * 86400, now - 40 * 86400))
+            with _chdir(root):
+                self.assertIsNone(sc._operational_rot_line())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sync_selfheal.py
+++ b/tests/test_sync_selfheal.py
@@ -485,3 +485,44 @@ class CodexAdapterTests(unittest.TestCase):
         self.assertEqual(spec["sync"]["skills_dir"], "~/.codex/skills")
         self.assertEqual(spec["project_contract"], "AGENTS.md")
         self.assertIn(".system", cadex.PROTECTED_SKILL_DIRS)
+
+
+class ToxicCloneHookPruneTests(unittest.TestCase):
+    """Event 170 — live incident residue: the E166 rogue sync ALSO
+    merged its clone-path hook registrations into settings.json, and
+    prune_managed_hook_entries preserved them as 'external hooks'
+    (positive-system keep). 19 scripts ran DOUBLE on every governed op.
+    The rule that separates residue from genuinely-foreign hooks: a
+    command whose script BASENAME matches a managed hook but whose path
+    is outside the primary checkout is clone residue; a non-managed
+    script name is operator content and stays."""
+
+    def _settings_with(self, extra_cmd):
+        base = cadapter.build_settings("balanced")
+        base["hooks"].setdefault("PreToolUse", []).append(
+            {"matcher": "Bash", "hooks": [{"type": "command", "command": extra_cmd}]}
+        )
+        return base
+
+    def test_managed_basename_under_foreign_root_is_pruned(self):
+        toxic = "/usr/bin/python3 /tmp/somewhere/repo2/core/hooks/workflow_guard.py"
+        s = cadapter.prune_managed_hook_entries(
+            self._settings_with(toxic), "balanced"
+        )
+        flat = json.dumps(s)
+        self.assertNotIn("/tmp/somewhere/repo2", flat)
+
+    def test_operator_authored_foreign_hook_survives(self):
+        mine = "/usr/bin/python3 /Users/x/my-own-hooks/notify_slack.py"
+        s = cadapter.prune_managed_hook_entries(
+            self._settings_with(mine), "balanced"
+        )
+        self.assertIn("notify_slack.py", json.dumps(s))
+
+    def test_primary_root_managed_hooks_untouched(self):
+        s = cadapter.prune_managed_hook_entries(
+            cadapter.build_settings("balanced"), "balanced"
+        )
+        flat = json.dumps(s)
+        self.assertIn("workflow_guard.py", flat)
+        self.assertIn(str(ecli.REPO_ROOT), flat)


### PR DESCRIPTION
Continuation of the operator's directive to find more of the **PLAN.md class** (exists, referenced, never maintained). The sweep found live damage, not just rot:

## Toxic-clone double registration (live incident residue)
The E166 rogue sync also **merged its scratchpad-clone hook paths into `settings.json`**, and the pruner's positive-system "keep external hooks" rule preserved them as operator content. **19 hook scripts ran double on every governed op** since — doubled telemetry, doubled gates, and the doubled advisory pairs visible all afternoon (caught because E168's string change made the two copies emit *different* text). Fix: a managed-*named* script under a path outside the primary checkout is clone residue and gets pruned; genuinely-foreign hooks (their own names) survive untouched — pinned by tests. Live settings purged (22 clean entries), clone deleted, pre-purge settings archived.

## PROGRESS tombstone closed
Its own text says it exists only because "workflow_policy still names PROGRESS.md" (edit HELD for the operator) — but the E147/E153 rewrites **already satisfied that condition**, and the tombstone outlived its own justification unnoticed. A perfect PLAN-class specimen: archived verbatim, removed, all mentions repaired (PLAYBOOK's five dangling PLAN refs too, archived first — no git history).

## The detector (loop-closer)
Doc-lifecycle lint deliberately exempts private-doc **symlinks** — exactly where PLAN.md rotted 13 days until a human noticed. `_operational_rot_line` watches the symlinked operational docs as a cohort at SessionStart: any member lagging the newest by >7 days is named ("track it or retire it — PLAN.md died of this, E168"); dangling symlinks named immediately; silent when the set moves together.

Suite **1755 + 91, 0 failed**.